### PR TITLE
Unify api using raft

### DIFF
--- a/native/src/rapidsml_jni.cu
+++ b/native/src/rapidsml_jni.cu
@@ -65,16 +65,14 @@ void signFlip(
 
 cublasOperation_t convertToCublasOpEnum(int int_type)
 {
-  if (int_type == 0) {
-    return CUBLAS_OP_N;
-  } else if (int_type == 1) {
-    return CUBLAS_OP_T;
-  } else if (int_type == 2) {
-    return CUBLAS_OP_C;
-  } else if (int_type == 3) {
-    return CUBLAS_OP_CONJG;
-  } else {
-    throw "Invalid type enum: " + std::to_string(int_type);
+  switch(int_type) {
+    case 0: return CUBLAS_OP_N;
+    case 1: return CUBLAS_OP_T;
+    case 2: return CUBLAS_OP_C;
+    case 3: return CUBLAS_OP_CONJG;
+    default:
+      throw "Invalid type enum: " + std::to_string(int_type);
+      break;
   }
 }
 } // anonymous namespace

--- a/src/main/java/com/nvidia/spark/ml/linalg/JniRAPIDSML.java
+++ b/src/main/java/com/nvidia/spark/ml/linalg/JniRAPIDSML.java
@@ -63,7 +63,9 @@ public final class JniRAPIDSML {
 
   public native void dspr(int n, double[] x, double[] A);
 
-  public native void dgemm(int m, int n, double[] A, double[] C, int deviceID);
+//  public native void dgemm(int m, int n, double[] A, double[] C, int deviceID);
+  public native void dgemm(int transa, int transb, int m, int n, int k, double alpha, double[] A, int lda, double[] B,
+                           int ldb, double beta, double[] C, int ldc, int deviceID);
   public native void dgemm_b(int m, int n, int k, double[] A, double[] B, double[] C, int deviceID);
 
   public native void calSVD(int m, double[] A, double[] U, double[] S, int deviceID);

--- a/src/main/java/com/nvidia/spark/ml/linalg/JniRAPIDSML.java
+++ b/src/main/java/com/nvidia/spark/ml/linalg/JniRAPIDSML.java
@@ -63,7 +63,6 @@ public final class JniRAPIDSML {
 
   public native void dspr(int n, double[] x, double[] A);
 
-//  public native void dgemm(int m, int n, double[] A, double[] C, int deviceID);
   public native void dgemm(int transa, int transb, int m, int n, int k, double alpha, double[] A, int lda, double[] B,
                            int ldb, double beta, double[] C, int ldc, int deviceID);
   public native void dgemm_b(int m, int n, int k, double[] A, double[] B, double[] C, int deviceID);

--- a/src/main/scala/org/apache/spark/ml/linalg/RAPIDSML.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/RAPIDSML.scala
@@ -51,16 +51,36 @@ private[spark] object RAPIDSML extends Serializable {
   }
 
   /**
-   * C := B.transpose * B
+   * Wrapper of Cublas gemm function. More details: https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemm
    *
-   * @param B the matrix B that will be left multiplied by its transpose. Size of m x n.
-   * @param C the resulting matrix C. Size of n x n.
+   * @param transa int type representing the operation op(A) that is non- or (conj.) transpose.
+   * @param transb int type representing the operation op(B) that is non- or (conj.) transpose.
+   * @param m number of rows of matrix op(A) and C.
+   * @param n number of columns of matrix op(B) and C.
+   * @param k number of columns of op(A) and rows of op(B).
+   * @param alpha scalar used for multiplication.
+   * @param A array of dimensions lda x k with lda>=max(1,m) if transa == CUBLAS_OP_N and lda x m with lda>=max(1,k) otherwise.
+   * @param lda leading dimension of two-dimensional array used to store the matrix A.
+   * @param B array of dimension ldb x n with ldb>=max(1,k) if transb == CUBLAS_OP_N and ldb x k with ldb>=max(1,n) otherwise.
+   * @param ldb leading dimension of two-dimensional array used to store matrix B.
+   * @param beta scalar used for multiplication. If beta==0, C does not have to be a valid input.
+   * @param C array of dimensions ldc x n with ldc>=max(1,m).
+   * @param ldc leading dimension of a two-dimensional array used to store the matrix C.
+   * @param deviceID the device that will run the computation
    */
   def gemm(transa: Int, transb: Int, m: Int, n: Int, k: Int, alpha: Double, A: DenseMatrix, lda: Int,
            B: DenseMatrix, ldb: Int,beta: Double,C: DenseMatrix, ldc: Int, deviceID: Int): Unit = {
     jniRAPIDSML.dgemm(transa, transb, m, n, k, alpha, A.values, lda, B.values, ldb, beta, C.values, ldc, deviceID)
   }
 
+  /**
+   *
+   * @param m size of sqiare matrix A
+   * @param A raw matrix to be decomposed, size of m * m
+   * @param U left matrix after decomposition
+   * @param S middle vector after decomposition
+   * @param deviceID the device that will run the computation
+   */
   def calSVD(m: Int, A: DenseMatrix, U: DenseMatrix, S: DenseMatrix, deviceID: Int): Unit = {
     require(m == A.numRows, s"The rows of A don't match required dimension")
     require(m == A.numCols, s"The cols of A don't match required dimension")

--- a/src/main/scala/org/apache/spark/ml/linalg/distributed/RapidsRowMatrix.scala
+++ b/src/main/scala/org/apache/spark/ml/linalg/distributed/RapidsRowMatrix.scala
@@ -192,7 +192,8 @@ class RapidsRowMatrix(
 
         val nvtxRangeGemm = new NvtxRange("cublas gemm", NvtxColor.GREEN)
         try {
-          RAPIDSML.gemm(B, C, gpu)
+          RAPIDSML.gemm(RAPIDSML.CublasOperationT.CUBLAS_OP_N.id, RAPIDSML.CublasOperationT.CUBLAS_OP_T.id, B.numCols, B.numCols,
+            B.numRows, 1.0, B, B.numCols, B, B.numCols, 0.0, C, B.numCols, gpu)
         } finally  {
           nvtxRangeGemm.close()
         }


### PR DESCRIPTION
- update cublas calls to raft wrappers
- add docs

fix https://github.com/NVIDIA/spark-rapids-ml/issues/9
Note, the [dgemm_1b](https://github.com/NVIDIA/spark-rapids-ml/blob/branch-21.10/native/src/rapidsml_jni.cu#L224) will be remove after transform(inference) is optimized.

Signed-off-by: Allen Xu <allxu@nvidia.com>