### PR TITLE
Build cudf library locally during the building process

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -15,13 +15,23 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.20)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.02/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 
+include(rapids-cmake)
+include(rapids-cpm)
 include(rapids-cuda)
+include(rapids-export)
+include(rapids-find)
+
+# Use GPU_ARCHS if it is defined
+if(DEFINED GPU_ARCHS)
+  set(CMAKE_CUDA_ARCHITECTURES "${GPU_ARCHS}")
+endif()
 
 rapids_cuda_init_architectures(SPARK_RAPIDS_ML)
+
 project(SPARK_RAPIDS_ML LANGUAGES CXX CUDA C)
 
 # Build options.

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.20)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.02/RAPIDS.cmake
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 

--- a/native/src/CMakeLists.txt
+++ b/native/src/CMakeLists.txt
@@ -47,10 +47,10 @@ endif(DEFINED ENV{RAFT_PATH})
 set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 
 rapids_cpm_init()
-rapids_cpm_find(cudf 22.02.00
+rapids_cpm_find(cudf 21.12.00
         CPM_ARGS
         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
-        GIT_TAG         branch-22.02
+        GIT_TAG         branch-21.12
         GIT_SHALLOW     TRUE
         SOURCE_SUBDIR   cpp
         OPTIONS         "BUILD_TESTS OFF"

--- a/native/src/CMakeLists.txt
+++ b/native/src/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 
 # Install cuDF nightly via Conda, only for local development, will remove in CI.
-find_package(cudf)
+# find_package(cudf)
 
 set (CMAKE_CUDA_FLAGS "--extended-lambda")
 
@@ -40,29 +40,29 @@ else(DEFINED ENV{RAFT_PATH})
   set(RAFT_INCLUDE_DIR ${RAFT_GIT_DIR}/src/raft/cpp/include CACHE STRING "RAFT include variable")
 endif(DEFINED ENV{RAFT_PATH})
 
+############################################################################################
+# - cudf -----------------------------------------------------------------------------------
 
+# Ensure CUDA runtime is dynamic despite statically linking Arrow in libcudf
+set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 
-#################################################################################################
-# - CPM -----------------------------------------------------------------------------------------
-
-set(CPM_DOWNLOAD_VERSION 0.27.2)
-set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
-
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
-    message(STATUS "Downloading CPM.cmake")
-    file(DOWNLOAD https://github.com/TheLartians/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake ${CPM_DOWNLOAD_LOCATION})
-endif()
-
-include(${CPM_DOWNLOAD_LOCATION})
-#################################################################################################
-
-# pull cuDF sources, to use jni_utils.hpp
-# cmake options should be added here for CI build.
-CPMAddPackage(NAME cudf
-        VERSION         "21.12.00"
+rapids_cpm_init()
+rapids_cpm_find(cudf 22.02.00
+        CPM_ARGS
         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
-        GIT_TAG         branch-21.12
-)
+        GIT_TAG         branch-22.02
+        GIT_SHALLOW     TRUE
+        SOURCE_SUBDIR   cpp
+        OPTIONS         "BUILD_TESTS OFF"
+                        "BUILD_BENCHMARKS OFF"
+                        "CUDF_USE_ARROW_STATIC ON"
+                        "JITIFY_USE_CACHE ON"
+                        "CUDA_STATIC_RUNTIME OFF"
+                        "DISABLE_DEPRECATION_WARNING ON"
+                        "AUTO_DETECT_CUDA_ARCHITECTURES OFF"
+    )
+
+############################################################################################
 
 add_library(rapidsml_jni SHARED rapidsml_jni.cpp
                                 rapidsml_jni.cu

--- a/native/src/CMakeLists.txt
+++ b/native/src/CMakeLists.txt
@@ -14,10 +14,6 @@
 # limitations under the License.
 #=============================================================================
 
-
-# Install cuDF nightly via Conda, only for local development, will remove in CI.
-# find_package(cudf)
-
 set (CMAKE_CUDA_FLAGS "--extended-lambda")
 
 if(DEFINED ENV{RAFT_PATH})

--- a/native/src/CMakeLists.txt
+++ b/native/src/CMakeLists.txt
@@ -56,6 +56,7 @@ rapids_cpm_find(cudf 21.12.00
         OPTIONS         "BUILD_TESTS OFF"
                         "BUILD_BENCHMARKS OFF"
                         "CUDF_USE_ARROW_STATIC ON"
+                        "CUDF_ENABLE_ARROW_S3 OFF"
                         "JITIFY_USE_CACHE ON"
                         "CUDA_STATIC_RUNTIME OFF"
                         "DISABLE_DEPRECATION_WARNING ON"

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <test.include.tags></test.include.tags>
         <cuda.version>cuda11</cuda.version>
         <GPU_ARCHS>ALL</GPU_ARCHS>
-        <CUDF_ENABLE_ARROW_S3>OFF</CUDF_ENABLE_ARROW_S3>
         <CPP_PARALLEL_LEVEL>4</CPP_PARALLEL_LEVEL>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,9 @@
         <test.exclude.tags></test.exclude.tags>
         <test.include.tags></test.include.tags>
         <cuda.version>cuda11</cuda.version>
-
+        <GPU_ARCHS>ALL</GPU_ARCHS>
+        <CUDF_ENABLE_ARROW_S3>OFF</CUDF_ENABLE_ARROW_S3>
+        <CPP_PARALLEL_LEVEL>4</CPP_PARALLEL_LEVEL>
     </properties>
 
     <repositories>
@@ -362,10 +364,15 @@
                         <configuration>
                             <target>
                                 <exec executable="cmake" failonerror="true">
-                                    <arg line="-S ${basedir}/native/ -B ${project.build.directory}/native -GNinja"/>
+                                    <arg value="-S${basedir}/native/"/>
+                                    <arg value="-B${project.build.directory}/native"/>
+                                    <arg value="-DGPU_ARCHS=${GPU_ARCHS}"/>
+                                    <arg value="-DCUDF_ENABLE_ARROW_S3=${CUDF_ENABLE_ARROW_S3}"/>
+                                    <arg value="-GNinja"/>
                                 </exec>
                                 <exec executable="ninja" dir="${project.build.directory}/native" failonerror="true">
-                                    <arg line="-v -j 2"/>
+                                    <arg value="-v"/>
+                                    <arg value="-j${CPP_PARALLEL_LEVEL}"/>
                                 </exec>
                             </target>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,6 @@
                                     <arg value="-S${basedir}/native/"/>
                                     <arg value="-B${project.build.directory}/native"/>
                                     <arg value="-DGPU_ARCHS=${GPU_ARCHS}"/>
-                                    <arg value="-DCUDF_ENABLE_ARROW_S3=${CUDF_ENABLE_ARROW_S3}"/>
                                     <arg value="-GNinja"/>
                                 </exec>
                                 <exec executable="ninja" dir="${project.build.directory}/native" failonerror="true">


### PR DESCRIPTION
- update CMakeLists.txt to locally build cuDF to get rid of the dependency of arrow library. Previously we installed cuDF via conda but the libcudf there has dynamic link to libarrow which may cause lib not found problem in another runtime.

Signed-off-by: Allen Xu <allxu@nvidia.com>