### PR TITLE
Update dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,13 +93,13 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark_2.12</artifactId>
-            <version>21.12.0-SNAPSHOT</version>
+            <version>22.02.0-SNAPSHOT</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/ai.rapids/cudf -->
         <dependency>
             <groupId>ai.rapids</groupId>
             <artifactId>cudf</artifactId>
-            <version>21.12.0-SNAPSHOT</version>
+            <version>22.02.0-SNAPSHOT</version>
         </dependency>
 
 


### PR DESCRIPTION
Update cuDF and spark-rapids version to 22.02-SNAPSHOT. This is required because there will be error like:

```
java.lang.NoClassDefFoundError: org/apache/spark/sql/catalyst/expressions/TimeSub
```
when version mismatch.

Signed-off-by: Allen Xu <allxu@nvidia.com>