### PR TITLE
Remove setGpuId API

### DIFF
--- a/src/test/scala/com/nvidia/spark/ml/feature/PCASuite.scala
+++ b/src/test/scala/com/nvidia/spark/ml/feature/PCASuite.scala
@@ -65,7 +65,6 @@ class PCASuite extends RapidsMLTest with DefaultReadWriteTest {
         .setInputCol("array_features")
         .setOutputCol("pca_features")
         .setK(3)
-        .setGpuId(0)
 
     val pcaModel = pca.fit(df)
     val transformed = pcaModel.transform(df)


### PR DESCRIPTION
To close: https://github.com/NVIDIA/spark-rapids-ml/issues/42

Now user doesn't need to call `setGpuId(0)` to avoid GPU resource scheduling failure in local mode.
Signed-off-by: Allen Xu <allxu@nvidia.com>