### PR TITLE
Change signoff check image to slim-buster

### DIFF
--- a/.github/workflows/signoff-check/Dockerfile
+++ b/.github/workflows/signoff-check/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:alpine
+FROM python:3.8-slim-buster
 
 WORKDIR /
 COPY signoff-check .


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

alpine image is failing to build required env after recent updates