### PR TITLE
Fall back to use cudf 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and cmake dependecies
 4. [cuDF](https://github.com/rapidsai/cudf):
     - install cuDF shared library via conda:
       ```bash
-      conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=22.06 python=3.8 -y
+      conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=22.04 python=3.8 -y
       ```
 5. [RAFT(22.06)](https://github.com/rapidsai/raft):
     - raft provides only header files, so no build instructions for it.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and cmake dependecies
 4. [cuDF](https://github.com/rapidsai/cudf):
     - install cuDF shared library via conda:
       ```bash
-      conda install -c rapidsai-nightly -c nvidia -c conda-forge cudf=22.04 python=3.8 -y
+      conda install -c rapidsai -c nvidia -c conda-forge cudf=22.04 python=3.8 -y
       ```
 5. [RAFT(22.06)](https://github.com/rapidsai/raft):
     - raft provides only header files, so no build instructions for it.

--- a/native/src/CMakeLists.txt
+++ b/native/src/CMakeLists.txt
@@ -59,9 +59,9 @@ include(${CPM_DOWNLOAD_LOCATION})
 # pull cuDF sources, to use jni_utils.hpp
 # cmake options should be added here for CI build.
 CPMAddPackage(NAME cudf
-        VERSION         "22.06.00"
+        VERSION         "22.04.00"
         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
-        GIT_TAG         branch-22.06
+        GIT_TAG         branch-22.04
 )
 
 add_library(rapidsml_jni SHARED rapidsml_jni.cpp


### PR DESCRIPTION
Due to issue: https://github.com/NVIDIA/spark-rapids-ml/issues/73.

This change has been tested with the [example app](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.06/examples/ML%2BDL-Examples/Spark-cuML/pca) in a docker container with no cudf library attached.

Signed-off-by: Allen Xu <allxu@nvidia.com>