### PR TITLE
Add doc for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ version. But in GPU version, user doesn't need to do the extra preprocess step t
 
 ### Prerequisites:
 1. essential build tools: 
-    - [cmake(>=3.20)](https://cmake.org/download/), 
+    - [cmake(>=3.23.1)](https://cmake.org/download/),
     - [ninja(>=1.10)](https://github.com/ninja-build/ninja/releases),
     - [gcc(>=9.3)](https://gcc.gnu.org/releases.html)
-2. [CUDA Toolkit(>=11.0)](https://developer.nvidia.com/cuda-toolkit)
+2. [CUDA Toolkit(>=11.5)](https://developer.nvidia.com/cuda-toolkit)
 3. conda: use [miniconda](https://docs.conda.io/en/latest/miniconda.html) to maintain header files
 and cmake dependecies
 4. [cuDF](https://github.com/rapidsai/cudf):
@@ -62,11 +62,23 @@ and cmake dependecies
     ```
 Note: For those using other types of GPUs which do not have CUDA forward compatibility (for example, GeForce), CUDA 11.5 or later is required.
 ### Build target jar
-User can build it directly in the _project root path_ with:
+Spark-rapids-ml uses [spark-rapids](https://github.com/NVIDIA/spark-rapids) plugin as a dependency.
+To build the _SNAPSHOT_ jar, user needs to build and install the denpendency jar _rapids-4-spark_ first
+because there's no snapshot jar for spark-rapids plugin in public maven repositories.
+See [build instructions](https://github.com/NVIDIA/spark-rapids/blob/branch-22.06/CONTRIBUTING.md#building-a-distribution-for-multiple-versions-of-spark) to get the dependency jar installed.
+
+Make sure the _rapids-4-spark_ is installed in your local maven Then User can build it directly in
+the _project root path_ with:
 ```
 mvn clean package
 ```
 Then `rapids-4-spark-ml_2.12-22.12.0-SNAPSHOT.jar` will be generated under `target` folder.
+
+Users can also use the _release_ version spark-rapids plugin as the dependency if it's already been
+release in public maven repositories, see [rapids-4-spark maven repository](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark)
+for release versions. In this case, users doesn't need to manually build and install spark-rapids
+plugin jar by themselves. Remember to replace the [dependency](https://github.com/NVIDIA/spark-rapids-ml/blob/branch-22.12/pom.xml#L94-L96)
+in pom file.
 
 _Note_: This module contains both native and Java/Scala code. The native library build instructions
 has been added to the pom.xml file so that maven build command will help build native library all
@@ -74,7 +86,7 @@ the way. Make sure the prerequisites are all met, or the build will fail with er
 accordingly such as "cmake not found" or "ninja not found" etc.
 
 ## How to use
-When building the jar, spark-rapids plugin jar will be downloaded to your local maven
+After the building processes, spark-rapids plugin jar will be installed to your local maven
 repository, usually in your `~/.m2/repository`.
 
 Add the artifact jar to the Spark, for example:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and cmake dependecies
       ```
 6. export RAFT_PATH:
     ```bash
-    export RAFT_PATH=PATH_TO_YOUR_RAFT_FOLDER
+    export RAFT_PATH=ABSOLUTE_PATH_TO_YOUR_RAFT_FOLDER
     ```
 Note: For those using other types of GPUs which do not have CUDA forward compatibility (for example, GeForce), CUDA 11.5 or later is required.
 ### Build target jar

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To build the _SNAPSHOT_ jar, user needs to build and install the denpendency jar
 because there's no snapshot jar for spark-rapids plugin in public maven repositories.
 See [build instructions](https://github.com/NVIDIA/spark-rapids/blob/branch-22.12/CONTRIBUTING.md#building-a-distribution-for-multiple-versions-of-spark) to get the dependency jar installed.
 
-Make sure the _rapids-4-spark_ is installed in your local maven Then User can build it directly in
+Make sure the _rapids-4-spark_ is installed in your local maven then user can build it directly in
 the _project root path_ with:
 ```
 mvn clean package

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Note: For those using other types of GPUs which do not have CUDA forward compati
 Spark-rapids-ml uses [spark-rapids](https://github.com/NVIDIA/spark-rapids) plugin as a dependency.
 To build the _SNAPSHOT_ jar, user needs to build and install the denpendency jar _rapids-4-spark_ first
 because there's no snapshot jar for spark-rapids plugin in public maven repositories.
-See [build instructions](https://github.com/NVIDIA/spark-rapids/blob/branch-22.06/CONTRIBUTING.md#building-a-distribution-for-multiple-versions-of-spark) to get the dependency jar installed.
+See [build instructions](https://github.com/NVIDIA/spark-rapids/blob/branch-22.12/CONTRIBUTING.md#building-a-distribution-for-multiple-versions-of-spark) to get the dependency jar installed.
 
 Make sure the _rapids-4-spark_ is installed in your local maven Then User can build it directly in
 the _project root path_ with:
@@ -78,12 +78,6 @@ Users can also use the _release_ version spark-rapids plugin as the dependency i
 release in public maven repositories, see [rapids-4-spark maven repository](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark)
 for release versions. In this case, users doesn't need to manually build and install spark-rapids
 plugin jar by themselves. Remember to replace the [dependency](https://github.com/NVIDIA/spark-rapids-ml/blob/branch-22.12/pom.xml#L94-L96)
-in pom file.
-
-Users can also use the _release_ version spark-rapids plugin as the dependency if it's already been
-release in public maven repositories, see [rapids-4-spark maven repository](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark)
-for release versions. In this case, users doesn't need to manually build and install spark-rapids
-plugin jar by themselves. Remember to replace the [dependency](https://github.com/NVIDIA/spark-rapids-ml/blob/branch-22.06/pom.xml#L93-L97)
 in pom file.
 
 _Note_: This module contains both native and Java/Scala code. The native library build instructions
@@ -120,4 +114,4 @@ more details about example code. We provide both
 [Notebook](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/examples/ML+DL-Examples/Spark-cuML/pca/notebooks/Spark_PCA_End_to_End.ipynb)
 and [jar](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/examples/ML+DL-Examples/Spark-cuML/pca/scala/src/com/nvidia/spark/examples/pca/Main.scala)
  versions there. Instructions to run these examples are described in the
- [README](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/examples/ML+DL-Examples/Spark-cuML/pca/README.md).
+[README](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/examples/ML+DL-Examples/Spark-cuML/pca/README.md).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Then `rapids-4-spark-ml_2.12-22.12.0-SNAPSHOT.jar` will be generated under `targ
 
 Users can also use the _release_ version spark-rapids plugin as the dependency if it's already been
 released in public maven repositories, see [rapids-4-spark maven repository](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark)
-for release versions. In this case, users doesn't need to manually build and install spark-rapids
+for release versions. In this case, users don't need to manually build and install spark-rapids
 plugin jar by themselves. Remember to replace the [dependency](https://github.com/NVIDIA/spark-rapids-ml/blob/branch-22.12/pom.xml#L94-L96)
 in pom file.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ mvn clean package
 Then `rapids-4-spark-ml_2.12-22.12.0-SNAPSHOT.jar` will be generated under `target` folder.
 
 Users can also use the _release_ version spark-rapids plugin as the dependency if it's already been
-release in public maven repositories, see [rapids-4-spark maven repository](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark)
+released in public maven repositories, see [rapids-4-spark maven repository](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark)
 for release versions. In this case, users doesn't need to manually build and install spark-rapids
 plugin jar by themselves. Remember to replace the [dependency](https://github.com/NVIDIA/spark-rapids-ml/blob/branch-22.12/pom.xml#L94-L96)
 in pom file.


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>

When building the SNAPSHOT jar which is depending on the spark-rapids SNAPSHOT jar that is not released to public maven repositories, the build process will fail. In this case add doc to instruct users to build and install the dependency jar manually.

On the other hand, user can also use the release version directly by modifying the pom file.

Also update the CUDA dependency version.
Also to close: #95 