### PR TITLE
Support cpu-arch artifact for rapids-4-spark_2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ repository, usually in your `~/.m2/repository`.
 Add the artifact jar to the Spark, for example:
 ```bash
 ML_JAR="target/rapids-4-spark-ml_2.12-22.12.0-SNAPSHOT.jar"
-PLUGIN_JAR="~/.m2/repository/com/nvidia/rapids-4-spark_2.12/22.12.0-SNAPSHOT/rapids-4-spark_2.12-22.12.0-SNAPSHOT.jar"
+PLUGIN_JAR="~/.m2/repository/com/nvidia/rapids-4-spark-amd64_2.12/22.12.0-SNAPSHOT/rapids-4-spark-amd64_2.12-22.12.0-SNAPSHOT.jar"
 
 $SPARK_HOME/bin/spark-shell --master $SPARK_MASTER \
  --driver-memory 20G \

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <!-- https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark -->
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark_2.12</artifactId>
+            <artifactId>rapids-4-spark-amd64_2.12</artifactId>
             <version>22.12.0-SNAPSHOT</version>
         </dependency>
 


### PR DESCRIPTION
From 22.12.0 on, spark-rapids jar will suffix cup-arch to the artifact name, e.g.

rapids-4-spark-amd64_2.12 for x86 CPU architecture,

rapids-4-spark-arm64_2.12 for arm CPU architecture

Signed-off-by: Tim Liu <timl@nvidia.com>