### PR TITLE
Exclude org.apache.commons:commons-text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,12 @@
             <classifier>tests</classifier>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
To avoid CVE issue

Signed-off-by: Gary Shen <gashen@nvidia.com>