### PR TITLE
[auto-merge] branch-23.02 to branch-23.04 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-22.12
+    - branch-23.02
     types: [closed]
 
 jobs:
@@ -29,13 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: branch-22.12 # force to fetch from latest upstream instead of PR ref
+          ref: branch-23.02 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids-ml
-          HEAD: branch-22.12
-          BASE: branch-23.02
+          HEAD: branch-23.02
+          BASE: branch-23.04
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR
+


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-23.02` to create a PR keeping `branch-23.04` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.