### PR TITLE
fix raft version to 22.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ and cmake dependecies
       ```bash
       conda install -c rapidsai -c conda-forge cudf=22.04 python=3.8 -y
       ```
-5. [RAFT(23.02)](https://github.com/rapidsai/raft):
-    - raft provides only header files, so no build instructions for it.
+5. [RAFT(22.12)](https://github.com/rapidsai/raft):
+    - raft provides only header files, so no build instructions for it. Note we fix the version to
+      22.12 to avoid potential API compatibility issues in the future.
       ```bash
-      $ git clone -b branch-23.02 https://github.com/rapidsai/raft.git
+      $ git clone -b branch-22.12 https://github.com/rapidsai/raft.git
       ```
 6. export RAFT_PATH:
     ```bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,7 +90,7 @@ RUN wget --quiet \
 ARG CONDA_CUDF_VER=22.04
 RUN conda install -c rapidsai -c conda-forge cudf=$CONDA_CUDF_VER python=3.8 -y
 
-ARG RAFT_VER=23.02
+ARG RAFT_VER=22.12
 RUN git clone -b branch-$RAFT_VER https://github.com/rapidsai/raft.git
 ENV RAFT_PATH=/raft
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,6 +90,8 @@ RUN wget --quiet \
 ARG CONDA_CUDF_VER=22.04
 RUN conda install -c rapidsai -c conda-forge cudf=$CONDA_CUDF_VER python=3.8 -y
 
+# Note: the raft verion is fixed to 22.12, do not modify it when updating the spark-rapids-ml version.
+#       newer versions may fail the build process due to API incompatibility.
 ARG RAFT_VER=22.12
 RUN git clone -b branch-$RAFT_VER https://github.com/rapidsai/raft.git
 ENV RAFT_PATH=/raft


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>
Since https://github.com/rapidsai/raft/commit/79e1ce854329bd655f2b02c86e6ec39165eebfc6, raft changes their API again and this breaks our build pipeline. Since we don't plan to introduce any new functionalities to this repo, we fix the raft version to 22.12 to avoid such issue in the future.