### PR TITLE
Fix the format issue of test_random_forest.py

### DIFF
--- a/tests/test_random_forest.py
+++ b/tests/test_random_forest.py
@@ -442,7 +442,6 @@ def test_random_forest_classifier_spark_compat(
             with pytest.raises((NotImplementedError, AttributeError)):
                 assert np.allclose(model.treeWeights, [1.0, 1.0, 1.0])
 
-
         test0 = spark.createDataFrame([(Vectors.dense(-1.0, 0.0),)], ["features"])
         example = test0.head()
         if example:


### PR DESCRIPTION
When running ./run_test.sh, it threw below error info,

``` console
Formatting...
All done! ✨ 🍰 ✨
11 files would be left unchanged.
would reformat tests/test_random_forest.py

Oh no! 💥 💔 💥
1 file would be reformatted, 9 files would be left unchanged.
Please run the following command on your machine to address the format errors:
 isort --profile=black tests
 black tests
```

This PR just fix it.