### PR TITLE
RF classifier model: add num classes

### DIFF
--- a/src/spark_rapids_ml/classification.py
+++ b/src/spark_rapids_ml/classification.py
@@ -74,6 +74,21 @@ class RandomForestClassificationModel(
     _RandomForestCumlParams,
     _RandomForestClassifierParams,
 ):
+    def __init__(
+        self,
+        n_cols: int,
+        dtype: str,
+        treelite_model: str,
+        num_classes: int,
+    ):
+        super().__init__(
+            dtype=dtype,
+            n_cols=n_cols,
+            treelite_model=treelite_model,
+            num_classes=num_classes,
+        )
+        self._num_classes = num_classes
+
     def _is_classification(self) -> bool:
         return True
 
@@ -85,4 +100,4 @@ class RandomForestClassificationModel(
     @property
     def numClasses(self) -> int:
         """Number of classes (values which the label can take)."""
-        raise NotImplementedError
+        return self._num_classes

--- a/src/spark_rapids_ml/regression.py
+++ b/src/spark_rapids_ml/regression.py
@@ -513,5 +513,13 @@ class RandomForestRegressionModel(
     _RandomForestCumlParams,
     _RandomForestRegressorParams,
 ):
+    def __init__(
+        self,
+        n_cols: int,
+        dtype: str,
+        treelite_model: str,
+    ):
+        super().__init__(dtype=dtype, n_cols=n_cols, treelite_model=treelite_model)
+
     def _is_classification(self) -> bool:
         return False

--- a/tests/test_random_forest.py
+++ b/tests/test_random_forest.py
@@ -134,15 +134,13 @@ rf_est_model_classes = [
 @pytest.mark.parametrize("est_model_classes", rf_est_model_classes, ids=idfn)
 @pytest.mark.parametrize("feature_type", pyspark_supported_feature_types)
 @pytest.mark.parametrize("data_type", cuml_supported_data_types)
-@pytest.mark.parametrize("data_shape", [(10, 8)], ids=idfn)
-@pytest.mark.parametrize("n_classes", [2, 4])
+@pytest.mark.parametrize("data_shape", [(100, 8)], ids=idfn)
 def test_random_forest_basic(
     tmp_path: str,
     est_model_classes: Tuple[RandomForest, RandomForestModel, int],
     feature_type: str,
     data_type: np.dtype,
     data_shape: Tuple[int, int],
-    n_classes: int,
 ) -> None:
     RFEstimator, RFEstimatorModel, n_classes = est_model_classes
 
@@ -190,6 +188,10 @@ def test_random_forest_basic(
             assert lhs.dtype == rhs.dtype
             assert lhs.n_cols == rhs.n_cols
             assert lhs.n_cols == data_shape[1]
+
+            if RFEstimator == RandomForestClassifier:
+                assert lhs.numClasses == rhs.numClasses
+                assert lhs.numClasses == n_classes
 
         # train a model
         model = est.fit(df)


### PR DESCRIPTION
This PR implements numClasses method for RandomForestClassification. num_classes in the model is useful when doing evaluation (binary evaluation or multi evaluation)