### PR TITLE
Disable auto-merge from 23.02 to 23.04 in advance

### DIFF
--- a/.github/workflows/auto-merge.yml-bak
+++ b/.github/workflows/auto-merge.yml-bak
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# NOTE: DISABLE AUTO-MERGE FROM 23.02 to 23.04
 # A workflow to keep BASE branch up-to-date from HEAD branch
 name: auto-merge HEAD to BASE
 


### PR DESCRIPTION
update extension of workflow file to disable auto-merge from 23.02

ML repo will have a branch-new branch-23.04 which will not follow existing code base