### PR TITLE
fix benchmark args

### DIFF
--- a/benchmark/benchmark/utils.py
+++ b/benchmark/benchmark/utils.py
@@ -63,6 +63,7 @@ def inspect_default_params_from_func(
         # Remove parameters without a default value and those in the unsupported_set
         if (
             parameter.default is not parameter.empty
+            and parameter.default is not None
             and parameter.name not in unsupported_set
         ):
             filtered_params_dict[parameter.name] = parameter.default

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -150,7 +150,7 @@ if [[ "${MODE}" == "random_forest_regressor" ]] || [[ "${MODE}" == "all" ]]; the
             --num_cols 3000 \
             --dtype "float64" \
             --feature_type "array" \
-            --output_dir "/tmp/classification/5k_3k_float64.parquet" \
+            --output_dir "/tmp/regression/5k_3k_float64.parquet" \
             --spark_conf "spark.master=local[*]" \
             --spark_confs "spark.driver.memory=128g"
     fi
@@ -158,8 +158,8 @@ if [[ "${MODE}" == "random_forest_regressor" ]] || [[ "${MODE}" == "all" ]]; the
     python ./benchmark/benchmark_runner.py random_forest_regressor \
         --num_gpus 1 \
         --num_cpus 0 \
-        --train_path "/tmp/classification/5k_3k_float64.parquet" \
-        --transform_path "./tmp/classification/transform" \
+        --train_path "/tmp/regression/5k_3k_float64.parquet" \
+        --transform_path "./tmp/regression/transform" \
         --report_path "report_rf_regressor.csv" \
         --spark_confs "spark.master=local[12]" \
         --spark_confs "spark.driver.memory=128g" \


### PR DESCRIPTION
This reverts some of the changes introduced in #124 to fix:
- Spark 3.2.1 (which doesn't have type annotations for TypeConverters)
- CPU testing w/o GPU dependencies