### PR TITLE
Benchmark: enable transform_path

### DIFF
--- a/benchmark/benchmark/base.py
+++ b/benchmark/benchmark/base.py
@@ -154,13 +154,13 @@ class BenchmarkBase:
     def class_params(self) -> Dict[str, Any]:
         return self._class_params
 
-    def train_df(
-        self, spark: SparkSession
+    def input_dataframe(
+        self, spark: SparkSession, *paths: str
     ) -> Tuple[DataFrame, Union[str, List[str]], str]:
         """Return a Spark DataFrame for benchmarking, along with the input and label column names."""
         assert self._args is not None
 
-        df = spark.read.parquet(*self._args.train_path)
+        df = spark.read.parquet(*paths)
 
         # Label column label is "label" which is hardcoded by gen_data.py
         label_col = "label"
@@ -206,10 +206,21 @@ class BenchmarkBase:
             self._args.spark_confs, shutdown=(not self._args.no_shutdown)
         ) as spark:
             for _ in range(self._args.num_runs):
-                df, features_col, label_col = self.train_df(spark)
+                train_df, features_col, label_col = self.input_dataframe(
+                    spark, *self._args.train_path
+                )
+
+                transform_df: Optional[DataFrame] = None
+                if len(self._args.transform_path) > 0:
+                    transform_df, _, _ = self.input_dataframe(
+                        spark, *self._args.transform_path
+                    )
+
                 results, benchmark_time = with_benchmark(
                     "benchmark time: ",
-                    lambda: self.run_once(spark, df, features_col, label_col),
+                    lambda: self.run_once(
+                        spark, train_df, features_col, transform_df, label_col
+                    ),
                 )
                 results["benchmark_time"] = benchmark_time
                 run_results.append(results)
@@ -238,6 +249,7 @@ class BenchmarkBase:
         spark: SparkSession,
         df: DataFrame,
         features_col: Union[str, List[str]],
+        transform_df: Optional[DataFrame],
         label_col: Optional[str],
     ) -> Dict[str, Any]:
         """Run a single iteration of benchmarks for the class under test, returning a summary of

--- a/benchmark/benchmark/base.py
+++ b/benchmark/benchmark/base.py
@@ -176,7 +176,7 @@ class BenchmarkBase:
             if any(["array" in t[1] for t in df.dtypes]):
                 # Array Type
                 selected_cols.append(
-                    array_to_vector(col(features_col)).alias("features")
+                    array_to_vector(col(features_col)).alias("features")  # type: ignore
                 )
                 features_col = "features"  # type: ignore
             elif not any(["vector" in t[1] for t in df.dtypes]):
@@ -247,7 +247,7 @@ class BenchmarkBase:
     def run_once(
         self,
         spark: SparkSession,
-        df: DataFrame,
+        train_df: DataFrame,
         features_col: Union[str, List[str]],
         transform_df: Optional[DataFrame],
         label_col: Optional[str],

--- a/benchmark/benchmark/bench_kmeans.py
+++ b/benchmark/benchmark/bench_kmeans.py
@@ -117,6 +117,7 @@ class BenchmarkKMeans(BenchmarkBase):
         spark: SparkSession,
         df: DataFrame,
         features_col: Union[str, List[str]],
+        transform_df: Optional[DataFrame],
         label_name: Optional[str],
     ) -> Dict[str, Any]:
         num_gpus = self.args.num_gpus

--- a/benchmark/benchmark/bench_linear_regression.py
+++ b/benchmark/benchmark/bench_linear_regression.py
@@ -40,7 +40,6 @@ class BenchmarkLinearRegression(BenchmarkBase):
         transform_df: Optional[DataFrame],
         label_name: Optional[str],
     ) -> Dict[str, Any]:
-
         assert label_name is not None
 
         params = self.class_params

--- a/benchmark/benchmark/bench_pca.py
+++ b/benchmark/benchmark/bench_pca.py
@@ -114,6 +114,7 @@ class BenchmarkPCA(BenchmarkBase):
         spark: SparkSession,
         df: DataFrame,
         features_col: Union[str, List[str]],
+        transform_df: Optional[DataFrame],
         label_name: Optional[str],
     ) -> Dict[str, Any]:
         n_components = self.args.k

--- a/benchmark/benchmark/bench_random_forest.py
+++ b/benchmark/benchmark/bench_random_forest.py
@@ -60,8 +60,9 @@ class BenchmarkRandomForestClassifier(BenchmarkBase):
     def run_once(
         self,
         spark: SparkSession,
-        df: DataFrame,
+        train_df: DataFrame,
         features_col: Union[str, List[str]],
+        transform_df: Optional[DataFrame],
         label_col: Optional[str],
     ) -> Dict[str, Any]:
         assert label_col is not None
@@ -85,10 +86,12 @@ class BenchmarkRandomForestClassifier(BenchmarkBase):
         rfc.setLabelCol(label_col)
 
         model, training_time = with_benchmark(
-            f"{benchmark_string} training:", lambda: rfc.fit(df)
+            f"{benchmark_string} training:", lambda: rfc.fit(train_df)
         )
 
-        df_with_preds = model.transform(df)
+        eval_df = train_df if transform_df is None else transform_df
+
+        df_with_preds = model.transform(eval_df)
 
         # model does not yet have col getters setters and uses default value for prediction col
         prediction_col = model.getOrDefault(model.predictionCol)
@@ -158,8 +161,9 @@ class BenchmarkRandomForestRegressor(BenchmarkBase):
     def run_once(
         self,
         spark: SparkSession,
-        df: DataFrame,
+        train_df: DataFrame,
         features_col: Union[str, List[str]],
+        transform_df: Optional[DataFrame],
         label_col: Optional[str],
     ) -> Dict[str, Any]:
         assert label_col is not None
@@ -184,10 +188,12 @@ class BenchmarkRandomForestRegressor(BenchmarkBase):
         rf.setLabelCol(label_col)
 
         model, training_time = with_benchmark(
-            f"{benchmark_string} training:", lambda: rf.fit(df)
+            f"{benchmark_string} training:", lambda: rf.fit(train_df)
         )
 
-        df_with_preds = model.transform(df)
+        eval_df = train_df if transform_df is None else transform_df
+
+        df_with_preds = model.transform(eval_df)
 
         # model does not yet have col getters setters and uses default value for prediction col
         prediction_col = model.getOrDefault(model.predictionCol)

--- a/src/spark_rapids_ml/knn.py
+++ b/src/spark_rapids_ml/knn.py
@@ -406,10 +406,10 @@ class NearestNeighborsModel(
         cumlParams = NearestNeighbors._get_cuml_params_default()
         self.set_params(**cumlParams)
 
-    def _out_schema(self, input_schema: StructType) -> Union[StructType, str]:
+    def _out_schema(self, input_schema: StructType) -> Union[StructType, str]:  # type: ignore
         pass
 
-    def _get_cuml_transform_func(
+    def _get_cuml_transform_func(  # type: ignore
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],


### PR DESCRIPTION
If we directly use train dataframe as the evaluation dataframe, the RMSE or accuracy may suffer the overfitting issue. This PR enables transform_path parameter which the user can specify, if it is not set, the train dataframe will be as the eval dataframe.