### PR TITLE
fix benchmarks for py3.8

### DIFF
--- a/benchmark/benchmark/bench_kmeans.py
+++ b/benchmark/benchmark/bench_kmeans.py
@@ -33,7 +33,7 @@ class BenchmarkKMeans(BenchmarkBase):
         from pyspark.ml.clustering import KMeans
 
         params = inspect_default_params_from_func(
-            KMeans,
+            KMeans.__init__,
             [
                 "distanceMeasure",
                 "featuresCol",

--- a/benchmark/benchmark/bench_linear_regression.py
+++ b/benchmark/benchmark/bench_linear_regression.py
@@ -28,7 +28,8 @@ class BenchmarkLinearRegression(BenchmarkBase):
         from pyspark.ml.regression import LinearRegression
 
         params = inspect_default_params_from_func(
-            LinearRegression, ["featuresCol", "labelCol", "predictionCol", "weightCol"]
+            LinearRegression.__init__,
+            ["featuresCol", "labelCol", "predictionCol", "weightCol"],
         )
         return params
 

--- a/benchmark/benchmark/bench_pca.py
+++ b/benchmark/benchmark/bench_pca.py
@@ -33,7 +33,7 @@ class BenchmarkPCA(BenchmarkBase):
         from pyspark.ml.feature import PCA
 
         params = inspect_default_params_from_func(
-            PCA,
+            PCA.__init__,
             [
                 "featuresCol",
                 "labelCol",

--- a/benchmark/benchmark/bench_random_forest.py
+++ b/benchmark/benchmark/bench_random_forest.py
@@ -32,7 +32,7 @@ class BenchmarkRandomForestClassifier(BenchmarkBase):
 
         # pyspark paramters
         params = inspect_default_params_from_func(
-            RandomForestClassifier,
+            RandomForestClassifier.__init__,
             [
                 "featuresCol",
                 "labelCol",


### PR DESCRIPTION
Fixes discrepancies in behavior of `inspect.signature()` between py3.8 and py3.9 by forcing the code to inspect the `__init__` function.