### PR TITLE
eliminate most 'F' order warnings

### DIFF
--- a/src/spark_rapids_ml/clustering.py
+++ b/src/spark_rapids_ml/clustering.py
@@ -270,7 +270,7 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 concated = pd.concat(df_list)
             else:
                 # should be list of np.ndarrays here
-                concated = np.concatenate(df_list)
+                concated = np.array(np.concatenate(df_list), order='F')
 
             kmeans_object.fit(
                 concated,
@@ -283,13 +283,15 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 f"iterations: {kmeans_object.n_iter_}, inertia: {kmeans_object.inertia_}"
             )
 
-            return {
+            res = {
                 "cluster_centers_": [
                     kmeans_object.cluster_centers_.to_numpy().tolist()
                 ],
                 "n_cols": params["n"],
-                "dtype": kmeans_object.dtype.name,
+                "dtype": str(kmeans_object.dtype.name),
             }
+            del kmeans_object
+            return res
 
         return _cuml_fit
 

--- a/src/spark_rapids_ml/clustering.py
+++ b/src/spark_rapids_ml/clustering.py
@@ -275,8 +275,8 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 d_type = df_list[0].dtype
                 concated_out = np.empty(shape=(rows, cols), order="F", dtype=d_type)
                 concated = np.concatenate(df_list, out=concated_out)
-                #for df in df_list:
-                #    del df
+                for df in df_list:
+                    del df
 
             kmeans_object.fit(
                 concated,

--- a/src/spark_rapids_ml/clustering.py
+++ b/src/spark_rapids_ml/clustering.py
@@ -270,7 +270,14 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 concated = pd.concat(df_list)
             else:
                 # should be list of np.ndarrays here
-                concated = np.array(np.concatenate(df_list), order='F')
+                rows = sum([arr.shape[0] for arr in df_list])
+                cols = df_list[0].shape[1]
+                d_type = df_list[0].dtype
+                concated_out = np.empty(shape=(rows, cols), order='F', dtype=d_type)
+                concated = np.concatenate(df_list, out=concated_out)
+                for df in df_list:
+                    del df
+                
 
             kmeans_object.fit(
                 concated,
@@ -377,6 +384,7 @@ class KMeansModel(KMeansClass, _CumlModelSupervised, _KMeansCumlParams):
             kmeans: CumlT, df: Union[pd.DataFrame, np.ndarray]
         ) -> pd.Series:
             res = list(kmeans.predict(df, normalize_weights=False).to_numpy())
+            del df
             return pd.Series(res)
 
         return _construct_kmeans, _transform_internal

--- a/src/spark_rapids_ml/clustering.py
+++ b/src/spark_rapids_ml/clustering.py
@@ -273,11 +273,10 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 rows = sum([arr.shape[0] for arr in df_list])
                 cols = df_list[0].shape[1]
                 d_type = df_list[0].dtype
-                concated_out = np.empty(shape=(rows, cols), order='F', dtype=d_type)
+                concated_out = np.empty(shape=(rows, cols), order="F", dtype=d_type)
                 concated = np.concatenate(df_list, out=concated_out)
                 for df in df_list:
                     del df
-                
 
             kmeans_object.fit(
                 concated,

--- a/src/spark_rapids_ml/clustering.py
+++ b/src/spark_rapids_ml/clustering.py
@@ -289,15 +289,13 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 f"iterations: {kmeans_object.n_iter_}, inertia: {kmeans_object.inertia_}"
             )
 
-            res = {
+            return {
                 "cluster_centers_": [
                     kmeans_object.cluster_centers_.to_numpy().tolist()
                 ],
                 "n_cols": params["n"],
                 "dtype": str(kmeans_object.dtype.name),
             }
-            #del kmeans_object
-            return res
 
         return _cuml_fit
 
@@ -383,7 +381,6 @@ class KMeansModel(KMeansClass, _CumlModelSupervised, _KMeansCumlParams):
             kmeans: CumlT, df: Union[pd.DataFrame, np.ndarray]
         ) -> pd.Series:
             res = list(kmeans.predict(df, normalize_weights=False).to_numpy())
-            #del df
             return pd.Series(res)
 
         return _construct_kmeans, _transform_internal

--- a/src/spark_rapids_ml/clustering.py
+++ b/src/spark_rapids_ml/clustering.py
@@ -275,8 +275,8 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 d_type = df_list[0].dtype
                 concated_out = np.empty(shape=(rows, cols), order="F", dtype=d_type)
                 concated = np.concatenate(df_list, out=concated_out)
-                for df in df_list:
-                    del df
+                #for df in df_list:
+                #    del df
 
             kmeans_object.fit(
                 concated,
@@ -296,7 +296,7 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 "n_cols": params["n"],
                 "dtype": str(kmeans_object.dtype.name),
             }
-            del kmeans_object
+            #del kmeans_object
             return res
 
         return _cuml_fit
@@ -383,7 +383,7 @@ class KMeansModel(KMeansClass, _CumlModelSupervised, _KMeansCumlParams):
             kmeans: CumlT, df: Union[pd.DataFrame, np.ndarray]
         ) -> pd.Series:
             res = list(kmeans.predict(df, normalize_weights=False).to_numpy())
-            del df
+            #del df
             return pd.Series(res)
 
         return _construct_kmeans, _transform_internal

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -767,8 +767,9 @@ class _CumlModelSupervised(_CumlModel, HasPredictionCol):
                     data = np.array(list(pdf[select_cols[0]]))
                 else:
                     data = pdf[select_cols]
-
-                yield cuml_transform_func(cuml_object, data)
+                res = cuml_transform_func(cuml_object, data)
+                del data
+                yield res
 
         pred_name = self.getOrDefault(self.predictionCol)
         pred_col = predict_udf(struct(*select_cols))

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -436,8 +436,8 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                         if alias.row_number in pdf.columns
                         else None
                     )
-                    if not multi_col_names:
-                        del pdf
+                    #if not multi_col_names:
+                    #    del pdf
                     inputs.append((features, label, row_number))
 
                 params["handle"] = cc.handle
@@ -448,6 +448,8 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                 logger.info("Invoking cuml fit")
 
                 # call the cuml fit function
+                # *note*: cuml_fit_func may delete components of inputs to free
+                # memory.  do not rely on inputs after this call.
                 result = cuml_fit_func(inputs, params)
                 logger.info("Cuml fit complete")
 

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -429,7 +429,7 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                     if multi_col_names:
                         features = pdf[multi_col_names]
                     else:
-                        features = np.array(list(pdf[alias.data]))
+                        features = np.array(list(pdf[alias.data]), order='F')
                     label = pdf[alias.label] if alias.label in pdf.columns else None
                     row_number = (
                         pdf[alias.row_number]
@@ -695,7 +695,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                     yield cuml_transform_func(cuml_object, pdf[select_cols])
             else:
                 for pdf in pdf_iter:
-                    nparray = np.array(list(pdf[select_cols[0]]))
+                    nparray = np.array(list(pdf[select_cols[0]]), order='F')
                     yield cuml_transform_func(cuml_object, nparray)
 
         return dataset.mapInPandas(

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -436,6 +436,8 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                         if alias.row_number in pdf.columns
                         else None
                     )
+                    if not multi_col_names:
+                        del pdf
                     inputs.append((features, label, row_number))
 
                 params["handle"] = cc.handle

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -429,7 +429,7 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                     if multi_col_names:
                         features = pdf[multi_col_names]
                     else:
-                        features = np.array(list(pdf[alias.data]), order='F')
+                        features = np.array(list(pdf[alias.data]), order="F")
                     label = pdf[alias.label] if alias.label in pdf.columns else None
                     row_number = (
                         pdf[alias.row_number]
@@ -697,7 +697,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                     yield cuml_transform_func(cuml_object, pdf[select_cols])
             else:
                 for pdf in pdf_iter:
-                    nparray = np.array(list(pdf[select_cols[0]]), order='F')
+                    nparray = np.array(list(pdf[select_cols[0]]), order="F")
                     yield cuml_transform_func(cuml_object, nparray)
 
         return dataset.mapInPandas(

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -764,7 +764,7 @@ class _CumlModelSupervised(_CumlModel, HasPredictionCol):
             cuml_object = construct_cuml_object_func()
             for pdf in iterator:
                 if not input_is_multi_cols:
-                    data = np.array(list(pdf[select_cols[0]]))
+                    data = np.array(list(pdf[select_cols[0]]), order='F')
                 else:
                     data = pdf[select_cols]
                 res = cuml_transform_func(cuml_object, data)

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -436,7 +436,7 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                         if alias.row_number in pdf.columns
                         else None
                     )
-                    #if not multi_col_names:
+                    # if not multi_col_names:
                     #    del pdf
                     inputs.append((features, label, row_number))
 
@@ -764,7 +764,7 @@ class _CumlModelSupervised(_CumlModel, HasPredictionCol):
             cuml_object = construct_cuml_object_func()
             for pdf in iterator:
                 if not input_is_multi_cols:
-                    data = np.array(list(pdf[select_cols[0]]), order='F')
+                    data = np.array(list(pdf[select_cols[0]]), order="F")
                 else:
                     data = pdf[select_cols]
                 res = cuml_transform_func(cuml_object, data)

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -436,8 +436,6 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                         if alias.row_number in pdf.columns
                         else None
                     )
-                    # if not multi_col_names:
-                    #    del pdf
                     inputs.append((features, label, row_number))
 
                 params["handle"] = cc.handle

--- a/src/spark_rapids_ml/tree.py
+++ b/src/spark_rapids_ml/tree.py
@@ -229,7 +229,7 @@ class _RandomForestEstimator(
                 d_type = X_list[0].dtype
                 concated_out = np.empty(shape=(rows, cols), order="F", dtype=d_type)
                 X = np.concatenate(X_list, out=concated_out)
-                # y one is small, so we can be less efficient
+                # y array uses less memory, so we can be less efficient
                 y = np.array(np.concatenate(y_list), order="F")  # type: ignore
                 for X_ in X_list:
                     del X_
@@ -381,7 +381,7 @@ class _RandomForestModel(
         def _predict(rf: CumlT, pdf: Union[cudf.DataFrame, np.ndarray]) -> pd.Series:
             rf.update_labels = False
             ret = rf.predict(pdf)
-            del pdf
+            #del pdf
             return pd.Series(ret)
 
         return _construct_rf, _predict

--- a/src/spark_rapids_ml/tree.py
+++ b/src/spark_rapids_ml/tree.py
@@ -227,10 +227,10 @@ class _RandomForestEstimator(
                 rows = sum([arr.shape[0] for arr in X_list])
                 cols = X_list[0].shape[1]
                 d_type = X_list[0].dtype
-                concated_out = np.empty(shape=(rows, cols), order='F', dtype=d_type)
+                concated_out = np.empty(shape=(rows, cols), order="F", dtype=d_type)
                 X = np.concatenate(X_list, out=concated_out)
                 # y one is small, so we can be less efficient
-                y = np.array(np.concatenate(y_list), order='F')  # type: ignore
+                y = np.array(np.concatenate(y_list), order="F")  # type: ignore
                 for X_ in X_list:
                     del X_
                 for y_ in y_list:

--- a/src/spark_rapids_ml/tree.py
+++ b/src/spark_rapids_ml/tree.py
@@ -381,7 +381,6 @@ class _RandomForestModel(
         def _predict(rf: CumlT, pdf: Union[cudf.DataFrame, np.ndarray]) -> pd.Series:
             rf.update_labels = False
             ret = rf.predict(pdf)
-            #del pdf
             return pd.Series(ret)
 
         return _construct_rf, _predict

--- a/src/spark_rapids_ml/tree.py
+++ b/src/spark_rapids_ml/tree.py
@@ -224,8 +224,8 @@ class _RandomForestEstimator(
                 y = pd.concat(y_list)
             else:
                 # should be list of np.ndarrays here
-                X = np.concatenate(X_list)
-                y = np.concatenate(y_list)  # type: ignore
+                X = np.array(np.concatenate(X_list), order='F')
+                y = np.array(np.concatenate(y_list), order='F')  # type: ignore
 
             # Fit a random forest model on the dataset (X, y)
             rf.fit(X, y, convert_dtype=False)

--- a/src/spark_rapids_ml/utils.py
+++ b/src/spark_rapids_ml/utils.py
@@ -137,8 +137,7 @@ def _concat_and_free(np_array_list: List[np.ndarray]) -> np.ndarray:
     d_type = np_array_list[0].dtype
     concated = np.empty(shape=concat_shape, order="F", dtype=d_type)
     np.concatenate(np_array_list, out=concated)
-    for x_ in np_array_list:
-        del x_
+    del np_array_list[:]
     return concated
 
 


### PR DESCRIPTION
in a memory efficient way and improve memory usage behavior in benchmarks.   

Also proactively deletes some objects.   

Found these to help with memory related reliability issues when running benchmarks.

One 'F' order warning persists, but I think it may be due to 1-d arrays being both 'C' and 'F' ordered and the check in cuml mnmg code not handling this correctly.