### PR TITLE
fix docker ci

### DIFF
--- a/benchmark/gen_data.py
+++ b/benchmark/gen_data.py
@@ -189,7 +189,8 @@ class DefaultDataGen(DataGenBase):
 
 class BlobsDataGen(DataGenBase):
     """Generate random dataset using sklearn.datasets.make_blobs,
-    which creates blobs for benchmarking unsupervised clustering algorithms (e.g. KMeans)"""
+    which creates blobs for benchmarking unsupervised clustering algorithms (e.g. KMeans)
+    """
 
     def __init__(self, argv: List[Any]) -> None:
         super().__init__()
@@ -234,7 +235,8 @@ class BlobsDataGen(DataGenBase):
 
 class LowRankMatrixDataGen(DataGenBase):
     """Generate random dataset using sklearn.datasets.make_low_rank_matrix,
-    which creates large low rank matrices for benchmarking dimensionality reduction algos like pca"""
+    which creates large low rank matrices for benchmarking dimensionality reduction algos like pca
+    """
 
     def __init__(self, argv: List[Any]) -> None:
         super().__init__()

--- a/ci/lint_python.py
+++ b/ci/lint_python.py
@@ -126,12 +126,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.format:
         print("Formatting...")
-        if not all(run_formatter(path) for path in SRC_PATHS):
+        format_results = [run_formatter(path) for path in SRC_PATHS]
+        if not all(format_results):
             sys.exit(-1)
 
     if args.type_check:
         print("Type checking...")
-        if not all(run_mypy(path) for path in SRC_PATHS):
+        type_results = [run_mypy(path) for path in SRC_PATHS]
+        if not all(type_results):
             sys.exit(-1)
 
     if args.pylint:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,8 @@
 -r requirements.txt
-black
+black>=23.1.0
 build
-mypy
+isort>=5.12.0
+mypy>=1.0.0
 numpydoc
 pydata-sphinx-theme
 pylint

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -63,7 +63,7 @@ if [[ "${MODE}" == "linear_regression" ]] || [[ "${MODE}" == "all" ]]; then
         --num_gpus 1 \
         --num_cpus 0 \
         --train_path "/tmp/regression/5k_3k_float64.parquet" \
-        --transform_path "./tmp/regression/transform" \
+        --transform_path "/tmp/regression/5k_3k_float64.parquet" \
         --report_path "report_linear_regression.csv" \
         --spark_confs "spark.master=local[12]" \
         --spark_confs "spark.driver.memory=128g" \
@@ -134,7 +134,7 @@ if [[ "${MODE}" == "random_forest_classifier" ]] || [[ "${MODE}" == "all" ]]; th
         --num_gpus 1 \
         --num_cpus 0 \
         --train_path "/tmp/classification/5k_3k_float64.parquet" \
-        --transform_path "./tmp/classification/transform" \
+        --transform_path "/tmp/classification/5k_3k_float64.parquet" \
         --report_path "report_rf_classifier.csv" \
         --spark_confs "spark.master=local[12]" \
         --spark_confs "spark.driver.memory=128g" \
@@ -159,7 +159,7 @@ if [[ "${MODE}" == "random_forest_regressor" ]] || [[ "${MODE}" == "all" ]]; the
         --num_gpus 1 \
         --num_cpus 0 \
         --train_path "/tmp/regression/5k_3k_float64.parquet" \
-        --transform_path "./tmp/regression/transform" \
+        --transform_path "/tmp/regression/5k_3k_float64.parquet" \
         --report_path "report_rf_regressor.csv" \
         --spark_confs "spark.master=local[12]" \
         --spark_confs "spark.driver.memory=128g" \

--- a/src/spark_rapids_ml/feature.py
+++ b/src/spark_rapids_ml/feature.py
@@ -359,7 +359,6 @@ class PCAModel(PCAClass, _CumlModel, _PCACumlParams):
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
     ]:
-
         cuml_alg_params = self.cuml_params.copy()
 
         transformed_mean = np.matmul(

--- a/src/spark_rapids_ml/knn.py
+++ b/src/spark_rapids_ml/knn.py
@@ -298,14 +298,12 @@ class NearestNeighbors(
     def _get_cuml_fit_func(
         self, dataset: DataFrame
     ) -> Callable[[CumlInputType, Dict[str, Any]], Dict[str, Any],]:
-
         label_isdata = self.label_isdata
 
         def _cuml_fit(
             dfs: CumlInputType,
             params: Dict[str, Any],
         ) -> Dict[str, Any]:
-
             from pyspark import BarrierTaskContext
 
             context = BarrierTaskContext.get()

--- a/src/spark_rapids_ml/tree.py
+++ b/src/spark_rapids_ml/tree.py
@@ -191,7 +191,6 @@ class _RandomForestEstimator(
             dfs: CumlInputType,
             params: Dict[str, Any],
         ) -> Dict[str, Any]:
-
             from pyspark import BarrierTaskContext
 
             context = BarrierTaskContext.get()

--- a/tests/test_linear_model.py
+++ b/tests/test_linear_model.py
@@ -45,6 +45,7 @@ LinearRegressionModelType = TypeVar(
     Type[SparkLinearRegressionModel],
 )
 
+
 # @lru_cache(4) TODO fixme: TypeError: Unhashable Type” Numpy.Ndarray
 def train_with_cuml_linear_regression(
     X: np.ndarray,

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -235,7 +235,6 @@ def test_pca(
     data_type: np.dtype,
     max_record_batch: int,
 ) -> None:
-
     X, _ = make_blobs(n_samples=data_shape[0], n_features=data_shape[1], random_state=0)
 
     from cuml import PCA as cuPCA


### PR DESCRIPTION
- specific version ranges in `requirements_dev.txt` for `black`, `isort`, and `mypy` to get more consistent behavior.
- fixed formatting errors for these latest formatter versions.
- modified `ci/lint_python.py` to run formatting (or type-checking) on all specified directories before failing.
- using same dataset paths for `--train_path` and `--transform_path` for now in `run_benchmark.sh` to fix "path does not exist" error.  (Pending PR from @wbo4958 should specify separate dataset paths).