### PR TITLE
RF: fix NCCL bug

### DIFF
--- a/src/spark_rapids_ml/tree.py
+++ b/src/spark_rapids_ml/tree.py
@@ -272,8 +272,8 @@ class _RandomForestEstimator(
             fields.append(StructField("num_classes", IntegerType(), False))
         return StructType(fields)
 
-    def _enable_nccl(self) -> bool:
-        return False
+    def _require_nccl_ucx(self) -> Tuple[bool, bool]:
+        return False, False
 
 
 class _RandomForestModel(


### PR DESCRIPTION
I tried running RandomForestClassifier on the spark standalone cluster with 2 workers, each of which has 1 GPU. But I got the below NCCL error.

``` console
_py4j.protocol.Py4JJavaError: An error occurred while calling z:org.apache.spark.api.python.PythonRDD.collectAndServe.
: org.apache.spark.SparkException: Job aborted due to stage failure: Could not recover from a failed barrier ResultStage. Most recent failure reason: Stage failed because barrier task ResultTask(1, 1) finished unsuccessfully.
org.apache.spark.api.python.PythonException: Traceback (most recent call last):
File "/tmp/spark-93495d91-6f13-4b97-b04e-36c9b713cc7a/userFiles-c6003233-1a32-4d54-b627-8e913b171274/sparkcuml.zip/spark_rapids_ml/core.py", line 419, in _train_udf
File "./sparkcuml.zip/spark_rapids_ml/common/cuml_context.py", line 104, in _enter_
self._nccl_comm.init(self._nranks, self._nccl_unique_id, self._rank)
File "nccl.pyx", line 151, in raft_dask.common.nccl.nccl.init
RuntimeError: NCCL_ERROR: b'remote process exited or there was a network error'_
```

It turned out #143 has changed the API. 