### PR TITLE
Init CI environment and test script

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG CUDA_VERSION=11.5.2
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04
+
+# Install packages to build spark-rapids-ml
+RUN apt update -y \
+    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y openjdk-8-jdk \
+    && apt install -y git numactl software-properties-common wget zip \
+    && rm -rf /var/lib/apt/lists
+
+# Config JAVA_HOME
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+# Install conda
+ENV PATH="/root/miniconda3/bin:${PATH}"
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh \
+    && mkdir /root/.conda \
+    && bash Miniconda3-py38_4.10.3-Linux-x86_64.sh -b \
+    && rm -f Miniconda3-py38_4.10.3-Linux-x86_64.sh \
+    && conda init
+
+# install cuML
+ARG CUML_VER=22.12
+RUN conda install -c conda-forge mamba && \
+    mamba install -y -c rapidsai -c nvidia -c conda-forge cuml=$CUML_VER python=3.8 cuda-toolkit=11.5 \
+    && mamba clean --all -f -y

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -1,0 +1,257 @@
+#!/usr/local/env groovy
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * Jenkinsfile for building spark-rapids-ml on blossom
+ *
+ */
+import hudson.model.Result
+import hudson.model.Run
+import jenkins.model.CauseOfInterruption.UserInterruption
+
+@Library(['blossom-lib']) _
+@Library('blossom-github-lib@master')
+import ipp.blossom.*
+
+def githubHelper // blossom github helper
+def TEMP_IMAGE_BUILD = true
+def IMAGE_PREMERGE = "${common.ARTIFACTORY_NAME}/sw-spark-docker/rapids-cuml:ubuntu20.04-cuda11.5.2-blossom"
+def cpuImage = pod.getCPUYAML(IMAGE_PREMERGE)
+def PREMERGE_DOCKERFILE = 'ci/Dockerfile'
+def PREMERGE_TAG
+def skipped = false
+
+pipeline {
+    agent {
+        kubernetes {
+            label "premerge-init-${BUILD_TAG}"
+            cloud 'sc-ipp-blossom-prod'
+            yaml cpuImage
+        }
+    }
+
+    options {
+        ansiColor('xterm')
+        buildDiscarder(logRotator(numToKeepStr: '50'))
+        skipDefaultCheckout true
+        timeout(time: 8, unit: 'HOURS')
+    }
+
+    parameters {
+        string(name: 'REF', defaultValue: '',
+            description: 'Merged commit of specific PR')
+        string(name: 'GITHUB_DATA', defaultValue: '',
+            description: 'Json-formatted github data from upstream blossom-ci')
+    }
+
+    environment {
+        JENKINS_ROOT = 'jenkins'
+        GITHUB_TOKEN = credentials("github-token")
+        ART_CREDS = credentials("urm_creds")
+        ART_URL = "https://${common.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
+        ARTIFACTORY_NAME = "${common.ARTIFACTORY_NAME}"
+        PVC = credentials("pvc")
+        CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
+    }
+
+    stages {
+        stage("Init githubHelper") {
+            steps {
+                script {
+                    githubHelper = GithubHelper.getInstance("${GITHUB_TOKEN}", params.GITHUB_DATA)
+                    // desc contains the PR ID and can be accessed from different builds
+                    currentBuild.description = githubHelper.getBuildDescription()
+                    try {
+                        // quiet period here in case the first build of two close dup triggers has not set desc
+                        sleep(time: 30, unit: "SECONDS")
+                        // abort duplicate running builds of the same PR (based on build desc)
+                        abortDupBuilds()
+                    } catch (e) { // do not block following build if abort failure
+                        echo "failed to try abort duplicate builds: " + e.toString()
+                    }
+
+                    def title = githubHelper.getIssue().title
+                    if (title ==~ /.*\[skip ci\].*/) {
+                        githubHelper.updateCommitStatus("$BUILD_URL", "Skipped", GitHubCommitState.SUCCESS)
+                        currentBuild.result == "SUCCESS"
+                        skipped = true
+                        return
+                    }
+                }
+            }
+        } // end of Init githubHelper
+
+        stage('Build docker image') {
+            when {
+                beforeAgent true
+                expression {
+                    !skipped
+                }
+            }
+
+            agent {
+                kubernetes {
+                    label "premerge-docker-${BUILD_TAG}"
+                    cloud 'sc-ipp-blossom-prod'
+                    yaml pod.getDockerBuildYAML()
+                    workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
+                    customWorkspace "${CUSTOM_WORKSPACE}"
+                }
+            }
+
+            steps {
+                script {
+                    githubHelper.updateCommitStatus("$BUILD_URL", "Running - preparing", GitHubCommitState.PENDING)
+                    checkout(
+                        changelog: false,
+                        poll: true,
+                        scm: [
+                            $class           : 'GitSCM', branches: [[name: githubHelper.getMergedSHA()]],
+                            submoduleCfg     : [],
+                            userRemoteConfigs: [[
+                                                    credentialsId: 'github-token',
+                                                    url          : githubHelper.getCloneUrl(),
+                                                    refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']]
+                        ]
+                    )
+
+                    stash(name: "source_tree", includes: "**")
+
+                    container('docker-build') {
+                        // check if pre-merge dockerfile modified
+                        def dockerfileModified = sh(returnStdout: true,
+                            script: 'BASE=$(git --no-pager log --oneline -1 | awk \'{ print $NF }\'); ' +
+                                'git --no-pager diff --name-only HEAD $(git merge-base HEAD $BASE) ' +
+                                "-- ${PREMERGE_DOCKERFILE} || true")
+                        if (!dockerfileModified?.trim()) {
+                            TEMP_IMAGE_BUILD = false
+                        }
+
+                        if (TEMP_IMAGE_BUILD) {
+                            PREMERGE_TAG = "${BUILD_TAG}"
+                            IMAGE_PREMERGE = "${ARTIFACTORY_NAME}/sw-spark-docker-local/rapids-cuml:${PREMERGE_TAG}"
+                            docker.build(IMAGE_PREMERGE, "-f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE .")
+                            uploadDocker(IMAGE_PREMERGE)
+                        }
+                    }
+                }
+            }
+        } // end of Build docker image
+
+        stage('Premerge Test') {
+            when {
+                beforeAgent true
+                beforeOptions true
+                expression {
+                    !skipped
+                }
+            }
+            options {
+                // We have to use params to pass the resource label in options block,
+                // this is a limitation of declarative pipeline. And we need to lock resource before agent start
+                lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
+            }
+            agent {
+                kubernetes {
+                    label "premerge-ci-${BUILD_TAG}"
+                    cloud 'sc-ipp-blossom-prod'
+                    yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi')
+                    workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
+                    customWorkspace "${CUSTOM_WORKSPACE}"
+                }
+            }
+
+            steps {
+                script {
+                    githubHelper.updateCommitStatus("$BUILD_URL", "Running - tests", GitHubCommitState.PENDING)
+                    container('gpu') {
+                        timeout(time: 2, unit: 'HOURS') { // step only timeout for test run
+                            common.resolveIncompatibleDriverIssue(this)
+                            sh 'bash ci/test.sh pre-merge'
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                if (skipped) {
+                    return
+                }
+
+                if (currentBuild.currentResult == "SUCCESS") {
+                    githubHelper.updateCommitStatus("$BUILD_URL", "Success", GitHubCommitState.SUCCESS)
+                } else {
+                    // upload log only in case of build failure
+                    def guardWords = ["gitlab.*?\\.com", "urm.*?\\.com"]
+                    guardWords.add("nvidia-smi(?s)(.*?)(?=git)") // hide GPU info
+                    githubHelper.uploadLogs(this, env.JOB_NAME, env.BUILD_NUMBER, null, guardWords)
+
+                    githubHelper.updateCommitStatus("$BUILD_URL", "Fail", GitHubCommitState.FAILURE)
+                }
+
+                if (TEMP_IMAGE_BUILD) {
+                    container('cpu') {
+                        deleteDockerTempTag("${PREMERGE_TAG}") // clean premerge temp image
+                    }
+                }
+            }
+        }
+    }
+} // end of pipeline
+
+void uploadDocker(String IMAGE_NAME) {
+    def DOCKER_CMD = "docker --config $WORKSPACE/.docker"
+    retry(3) {
+        sleep(time: 10, unit: "SECONDS")
+        sh """
+            echo $ART_CREDS_PSW | $DOCKER_CMD login $ARTIFACTORY_NAME -u $ART_CREDS_USR --password-stdin
+            $DOCKER_CMD push $IMAGE_NAME
+            $DOCKER_CMD logout $ARTIFACTORY_NAME
+        """
+    }
+}
+
+void deleteDockerTempTag(String tag) {
+    if (!tag?.trim()) { // return if the tag is null or empty
+        return
+    }
+    sh "curl -u $ART_CREDS_USR:$ART_CREDS_PSW -XDELETE " +
+        "https://${ARTIFACTORY_NAME}/artifactory/sw-spark-docker-local/rapids-cuml/${tag} || true"
+}
+
+void abortDupBuilds() {
+    Run prevBuild = currentBuild.rawBuild.getPreviousBuildInProgress()
+    while (prevBuild != null) {
+        if (prevBuild.isInProgress()) {
+            def prevDesc = prevBuild.description?.trim()
+            if (prevDesc && prevDesc == currentBuild.description?.trim()) {
+                def prevExecutor = prevBuild.getExecutor()
+                if (prevExecutor != null) {
+                    echo "...Aborting duplicate Build #${prevBuild.number}"
+                    prevExecutor.interrupt(Result.ABORTED,
+                        new UserInterruption("Build #${currentBuild.number}"))
+                }
+            }
+        }
+        prevBuild = prevBuild.getPreviousBuildInProgress()
+    }
+}

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -30,7 +30,7 @@ import ipp.blossom.*
 
 def githubHelper // blossom github helper
 def TEMP_IMAGE_BUILD = true
-def IMAGE_PREMERGE = "${common.ARTIFACTORY_NAME}/sw-spark-docker/rapids-cuml:ubuntu20.04-cuda11.5.2-blossom"
+def IMAGE_PREMERGE = "${common.ARTIFACTORY_NAME}/sw-spark-docker/spark-rapids-ml:ubuntu20.04-cuda11.5.2-blossom"
 def cpuImage = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:rapids-databricks") // tooling image
 def PREMERGE_DOCKERFILE = 'ci/Dockerfile'
 def PREMERGE_TAG
@@ -144,7 +144,7 @@ pipeline {
 
                         if (TEMP_IMAGE_BUILD) {
                             PREMERGE_TAG = "${BUILD_TAG}"
-                            IMAGE_PREMERGE = "${ARTIFACTORY_NAME}/sw-spark-docker-local/rapids-cuml:${PREMERGE_TAG}"
+                            IMAGE_PREMERGE = "${ARTIFACTORY_NAME}/sw-spark-docker-local/spark-rapids-ml:${PREMERGE_TAG}"
                             docker.build(IMAGE_PREMERGE, "-f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE .")
                             uploadDocker(IMAGE_PREMERGE)
                         }
@@ -235,7 +235,7 @@ void deleteDockerTempTag(String tag) {
         return
     }
     sh "curl -u $ART_CREDS_USR:$ART_CREDS_PSW -XDELETE " +
-        "https://${ARTIFACTORY_NAME}/artifactory/sw-spark-docker-local/rapids-cuml/${tag} || true"
+        "https://${ARTIFACTORY_NAME}/artifactory/sw-spark-docker-local/spark-rapids-ml/${tag} || true"
 }
 
 void abortDupBuilds() {

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -31,7 +31,7 @@ import ipp.blossom.*
 def githubHelper // blossom github helper
 def TEMP_IMAGE_BUILD = true
 def IMAGE_PREMERGE = "${common.ARTIFACTORY_NAME}/sw-spark-docker/rapids-cuml:ubuntu20.04-cuda11.5.2-blossom"
-def cpuImage = pod.getCPUYAML(IMAGE_PREMERGE)
+def cpuImage = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:rapids-databricks") // tooling image
 def PREMERGE_DOCKERFILE = 'ci/Dockerfile'
 def PREMERGE_TAG
 def skipped = false

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -ex
+
+type="$1"
+case $type in
+  "pre-merge" | "")
+    ut_args=""
+    ;;
+  "nightly")
+    ut_args="--runslow"
+    ;;
+  *)
+    echo "Unknown test type: $type"; exit 1;;
+esac
+bench_args=""
+
+# environment
+nvidia-smi
+which python
+pip install --no-cache -r requirements_dev.txt && pip install --no-cache -e .
+
+# unit tests
+./run_test.sh $ut_args
+
+# benchmark
+./run_benchmark.sh $bench_args

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark_2.12</artifactId>
-            <version>23.02.0-SNAPSHOT</version>
+            <version>23.02.0</version>
         </dependency>
 
 


### PR DESCRIPTION
Initiate the CI setup and script,

A. Add CI-specific dockerfile, mostly was copied from [docker/Dockerfile.python](https://github.com/NVIDIA/spark-rapids-ml/blob/spark-cuml/docker/Dockerfile.python) w/ some changes,
1. use mamba to speed up conda installation
2. remove workdir copy of code base, and also remove pip installation since this should be covered in test script
3. pre-built image of CI in internal regular CI, if PR include change to ci/Dockerfile, it will build an temp image for test running within pre-merge

B. Add pre-merge jenkinsfile

C. Modify existing pom file to ref to released plugin jar for vulnerability scanning, as we do not publish plugin snapshots to mvn snapshots repo