### PR TITLE
register pytest.mark.compat marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "slow: mark as slow to run")
+    config.addinivalue_line("markers", "compat: mark as compatibility test")
 
 
 def pytest_collection_modifyitems(


### PR DESCRIPTION
... to silence this warning in the test logs:
```
PytestUnknownMarkWarning: Unknown pytest.mark.compat - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
```