### PR TITLE
Using namedtuple to replace global naming string

### DIFF
--- a/src/spark_rapids_ml/clustering.py
+++ b/src/spark_rapids_ml/clustering.py
@@ -33,12 +33,11 @@ from pyspark.sql.types import (
 )
 
 from spark_rapids_ml.core import (
-    INIT_PARAMETERS_NAME,
     CumlInputType,
     CumlT,
     _CumlEstimator,
-    _CumlModel,
     _CumlModelSupervised,
+    param_alias,
 )
 from spark_rapids_ml.params import HasFeaturesCols, P, _CumlClass, _CumlParams
 from spark_rapids_ml.utils import _concat_and_free, get_logger
@@ -261,9 +260,9 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
             from cuml.cluster.kmeans_mg import KMeansMG as CumlKMeansMG
 
             kmeans_object = CumlKMeansMG(
-                handle=params["handle"],
+                handle=params[param_alias.handle],
                 output_type="cudf",
-                **params[INIT_PARAMETERS_NAME],
+                **params[param_alias.init],
             )
             df_list = [x for (x, _, _) in dfs]
             if isinstance(df_list[0], pd.DataFrame):
@@ -287,7 +286,7 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 "cluster_centers_": [
                     kmeans_object.cluster_centers_.to_numpy().tolist()
                 ],
-                "n_cols": params["n"],
+                "n_cols": params[param_alias.num_cols],
                 "dtype": str(kmeans_object.dtype.name),
             }
 

--- a/src/spark_rapids_ml/clustering.py
+++ b/src/spark_rapids_ml/clustering.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -262,7 +262,7 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
             kmeans_object = CumlKMeansMG(
                 handle=params[param_alias.handle],
                 output_type="cudf",
-                **params[param_alias.init],
+                **params[param_alias.cuml_init],
             )
             df_list = [x for (x, _, _) in dfs]
             if isinstance(df_list[0], pd.DataFrame):

--- a/src/spark_rapids_ml/core.py
+++ b/src/spark_rapids_ml/core.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -96,9 +96,9 @@ pred = Pred("prediction", "probability")
 
 # Global parameter alias used by core and subclasses.
 ParamAlias = namedtuple(
-    "ParamAlias", ("init", "handle", "num_cols", "part_sizes", "loop")
+    "ParamAlias", ("cuml_init", "handle", "num_cols", "part_sizes", "loop")
 )
-param_alias = ParamAlias("cuml_init", "handle", "n", "part_sizes", "loop")
+param_alias = ParamAlias("cuml_init", "handle", "num_cols", "part_sizes", "loop")
 
 
 class _CumlEstimatorWriter(MLWriter):
@@ -396,7 +396,7 @@ class _CumlCaller(_CumlParams, _CumlCommon):
         is_local = _is_local(_get_spark_session().sparkContext)
 
         params: Dict[str, Any] = {
-            param_alias.init: self.cuml_params,
+            param_alias.cuml_init: self.cuml_params,
         }
 
         cuml_fit_func = self._get_cuml_fit_func(dataset)

--- a/src/spark_rapids_ml/feature.py
+++ b/src/spark_rapids_ml/feature.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -193,7 +193,7 @@ class PCA(PCAClass, _CumlEstimator, _PCACumlParams):
             pca_object = CumlPCAMG(
                 handle=params[param_alias.handle],
                 output_type="cudf",
-                **params[param_alias.init],
+                **params[param_alias.cuml_init],
             )
 
             pdesc = PartitionDescriptor.build(

--- a/src/spark_rapids_ml/feature.py
+++ b/src/spark_rapids_ml/feature.py
@@ -35,11 +35,11 @@ from pyspark.sql.types import (
 )
 
 from spark_rapids_ml.core import (
-    INIT_PARAMETERS_NAME,
     CumlInputType,
     CumlT,
     _CumlEstimator,
     _CumlModel,
+    param_alias,
 )
 from spark_rapids_ml.params import P, _CumlClass, _CumlParams
 from spark_rapids_ml.utils import PartitionDescriptor
@@ -191,12 +191,14 @@ class PCA(PCAClass, _CumlEstimator, _PCACumlParams):
             from cuml.decomposition.pca_mg import PCAMG as CumlPCAMG
 
             pca_object = CumlPCAMG(
-                handle=params["handle"],
+                handle=params[param_alias.handle],
                 output_type="cudf",
-                **params[INIT_PARAMETERS_NAME],
+                **params[param_alias.init],
             )
 
-            pdesc = PartitionDescriptor.build(params["part_sizes"], params["n"])
+            pdesc = PartitionDescriptor.build(
+                params[param_alias.part_sizes], params[param_alias.num_cols]
+            )
             pca_object.fit(
                 [x for x, _, _ in dfs],
                 pdesc.m,
@@ -218,7 +220,7 @@ class PCA(PCAClass, _CumlEstimator, _PCACumlParams):
                 "components_": [cpu_pc],
                 "explained_variance_ratio_": [cpu_explained_variance],
                 "singular_values_": [cpu_singular_values],
-                "n_cols": params["n"],
+                "n_cols": params[param_alias.num_cols],
                 "dtype": pca_object.dtype.name,
             }
 

--- a/src/spark_rapids_ml/knn.py
+++ b/src/spark_rapids_ml/knn.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -378,9 +378,9 @@ class NearestNeighborsModel(
 
             nn_object = cumlNN(
                 handle=params[param_alias.handle],
-                n_neighbors=params[param_alias.init]["n_neighbors"],
+                n_neighbors=params[param_alias.cuml_init]["n_neighbors"],
                 output_type="numpy",
-                verbose=params[param_alias.init]["verbose"],
+                verbose=params[param_alias.cuml_init]["verbose"],
             )
 
             item_list = []
@@ -445,7 +445,7 @@ class NearestNeighborsModel(
                 query_nrows=query_nrows,
                 ncols=params[param_alias.num_cols],
                 rank=rank,
-                n_neighbors=params[param_alias.init]["n_neighbors"],
+                n_neighbors=params[param_alias.cuml_init]["n_neighbors"],
                 convert_dtype=False,  # only np.float32 is supported in cuml. Should set to True for all other types
             )
 

--- a/src/spark_rapids_ml/knn.py
+++ b/src/spark_rapids_ml/knn.py
@@ -43,13 +43,13 @@ from pyspark.sql.types import (
 )
 
 from spark_rapids_ml.core import (
-    INIT_PARAMETERS_NAME,
     CumlInputType,
     CumlT,
     _CumlCaller,
     _CumlEstimatorSupervised,
     _CumlModel,
     alias,
+    param_alias,
 )
 from spark_rapids_ml.params import P, _CumlClass, _CumlParams
 
@@ -377,10 +377,10 @@ class NearestNeighborsModel(
             from cuml.neighbors.nearest_neighbors_mg import NearestNeighborsMG as cumlNN
 
             nn_object = cumlNN(
-                handle=params["handle"],
-                n_neighbors=params[INIT_PARAMETERS_NAME]["n_neighbors"],
+                handle=params[param_alias.handle],
+                n_neighbors=params[param_alias.init]["n_neighbors"],
                 output_type="numpy",
-                verbose=params[INIT_PARAMETERS_NAME]["verbose"],
+                verbose=params[param_alias.init]["verbose"],
             )
 
             item_list = []
@@ -422,7 +422,7 @@ class NearestNeighborsModel(
                 )
                 return result
 
-            messages = params["loop"].run_until_complete(
+            messages = params[param_alias.loop].run_until_complete(
                 asyncio.ensure_future(do_allGather())
             )
 
@@ -443,9 +443,9 @@ class NearestNeighborsModel(
                 query=query,
                 query_parts_to_ranks=query_parts_to_ranks,
                 query_nrows=query_nrows,
-                ncols=params["n"],
+                ncols=params[param_alias.num_cols],
                 rank=rank,
-                n_neighbors=params[INIT_PARAMETERS_NAME]["n_neighbors"],
+                n_neighbors=params[param_alias.init]["n_neighbors"],
                 convert_dtype=False,  # only np.float32 is supported in cuml. Should set to True for all other types
             )
 

--- a/src/spark_rapids_ml/regression.py
+++ b/src/spark_rapids_ml/regression.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -290,7 +290,7 @@ class LinearRegression(
             dfs: CumlInputType,
             params: Dict[str, Any],
         ) -> Dict[str, Any]:
-            init_parameters = params[param_alias.init]
+            init_parameters = params[param_alias.cuml_init]
 
             pdesc = PartitionDescriptor.build(
                 params[param_alias.part_sizes], params[param_alias.num_cols]

--- a/src/spark_rapids_ml/regression.py
+++ b/src/spark_rapids_ml/regression.py
@@ -32,11 +32,11 @@ from pyspark.sql.types import (
 )
 
 from spark_rapids_ml.core import (
-    INIT_PARAMETERS_NAME,
     CumlInputType,
     CumlT,
     _CumlEstimatorSupervised,
     _CumlModelSupervised,
+    param_alias,
 )
 from spark_rapids_ml.params import HasFeaturesCols, P, _CumlClass, _CumlParams
 from spark_rapids_ml.tree import (
@@ -290,9 +290,11 @@ class LinearRegression(
             dfs: CumlInputType,
             params: Dict[str, Any],
         ) -> Dict[str, Any]:
-            init_parameters = params[INIT_PARAMETERS_NAME]
+            init_parameters = params[param_alias.init]
 
-            pdesc = PartitionDescriptor.build(params["part_sizes"], params["n"])
+            pdesc = PartitionDescriptor.build(
+                params[param_alias.part_sizes], params[param_alias.num_cols]
+            )
 
             if init_parameters["alpha"] == 0:
                 # LR
@@ -358,7 +360,7 @@ class LinearRegression(
             }
 
             linear_regression = CumlLinearRegression(
-                handle=params["handle"],
+                handle=params[param_alias.handle],
                 output_type="cudf",
                 **init_parameters,
             )

--- a/src/spark_rapids_ml/tree.py
+++ b/src/spark_rapids_ml/tree.py
@@ -17,7 +17,7 @@ import base64
 import math
 import pickle
 from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import cudf
 import numpy as np
@@ -196,7 +196,7 @@ class _RandomForestEstimator(
             context = BarrierTaskContext.get()
             part_id = context.partitionId()
 
-            rf_params = params[param_alias.init]
+            rf_params = params[param_alias.cuml_init]
             rf_params.pop("n_estimators")
 
             if rf_params["max_features"] == "auto":

--- a/src/spark_rapids_ml/tree.py
+++ b/src/spark_rapids_ml/tree.py
@@ -29,11 +29,11 @@ from pyspark.sql import DataFrame
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 from spark_rapids_ml.core import (
-    INIT_PARAMETERS_NAME,
     CumlInputType,
     CumlT,
     _CumlEstimatorSupervised,
     _CumlModelSupervised,
+    param_alias,
 )
 from spark_rapids_ml.params import HasFeaturesCols, P, _CumlClass, _CumlParams
 from spark_rapids_ml.utils import _concat_and_free
@@ -196,7 +196,7 @@ class _RandomForestEstimator(
             context = BarrierTaskContext.get()
             part_id = context.partitionId()
 
-            rf_params = params[INIT_PARAMETERS_NAME]
+            rf_params = params[param_alias.init]
             rf_params.pop("n_estimators")
 
             if rf_params["max_features"] == "auto":

--- a/tests/test_common_estimator.py
+++ b/tests/test_common_estimator.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import cudf
 import numpy as np
@@ -184,8 +184,8 @@ class SparkRapidsMLDummy(
             assert pd.m == m
             assert pd.n == n
 
-            assert param_alias.init in params
-            init_params = params[param_alias.init]
+            assert param_alias.cuml_init in params
+            init_params = params[param_alias.cuml_init]
             assert init_params == {"a": 100, "k": 4, "x": 40.0}
             dummy = CumlDummy(**init_params)
             assert dummy.a == 100

--- a/tests/test_common_estimator.py
+++ b/tests/test_common_estimator.py
@@ -27,11 +27,11 @@ from pyspark.sql import DataFrame
 from pyspark.sql.types import StructType
 
 from spark_rapids_ml.core import (
-    INIT_PARAMETERS_NAME,
     CumlInputType,
     CumlT,
     _CumlEstimator,
     _CumlModel,
+    param_alias,
 )
 from spark_rapids_ml.params import _CumlClass, _CumlParams
 from spark_rapids_ml.utils import PartitionDescriptor
@@ -171,19 +171,21 @@ class SparkRapidsMLDummy(
         ) -> Dict[str, Any]:
             context = TaskContext.get()
             assert context is not None
-            assert "handle" in params
-            assert "part_sizes" in params
-            assert "n" in params
+            assert param_alias.handle in params
+            assert param_alias.part_sizes in params
+            assert param_alias.num_cols in params
 
-            pd = PartitionDescriptor.build(params["part_sizes"], params["n"])
+            pd = PartitionDescriptor.build(
+                params[param_alias.part_sizes], params[param_alias.num_cols]
+            )
 
             assert pd.rank == context.partitionId()
             assert len(pd.parts_rank_size) == partition_num
             assert pd.m == m
             assert pd.n == n
 
-            assert INIT_PARAMETERS_NAME in params
-            init_params = params[INIT_PARAMETERS_NAME]
+            assert param_alias.init in params
+            init_params = params[param_alias.init]
             assert init_params == {"a": 100, "k": 4, "x": 40.0}
             dummy = CumlDummy(**init_params)
             assert dummy.a == 100


### PR DESCRIPTION
We use the "global string" as the key of parameters with dictionary type passed from the core framework to the subclasses, which implies these "global strings" will be used in both core.py and other python files. What if we decide to change the naming for example "n" -> "num_cols", we need to change it everywhere. On the other hand, "global string" is easily mistaken. So I made this PR to use namedtuple to replace "global strings"