### PR TITLE
Add method exactNearestNeighborsJoin to match pyspark LSH approxSimilarityJoin

### DIFF
--- a/python/benchmark/benchmark/bench_nearest_neighbors.py
+++ b/python/benchmark/benchmark/bench_nearest_neighbors.py
@@ -93,7 +93,7 @@ class BenchmarkNearestNeighbors(BenchmarkBase):
             )
 
             def transform(model: NearestNeighborsModel, df: DataFrame) -> DataFrame:
-                (query_df, item_df, knn_df) = model.kneighbors(df)
+                (item_df_withid, query_df_withid, knn_df) = model.kneighbors(df)
                 knn_df.count()
                 return knn_df
 

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -88,7 +88,7 @@ CumlInputType = Union[List[_SinglePdDataFrameBatchType], List[_SingleNpArrayBatc
 
 # Global constant for defining column alias
 Alias = namedtuple("Alias", ("data", "label", "row_number"))
-alias = Alias("cuml_values", "cuml_label", "id")
+alias = Alias("cuml_values", "cuml_label", "unique_id")
 
 # Global prediction names
 Pred = namedtuple("Pred", ("prediction", "probability"))

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -534,6 +534,7 @@ class NearestNeighborsModel(
     ) -> DataFrame:
         """
         This function returns the k exact nearest neighbors (knn) in item_df of each query vector in query_df.
+        item_df is the dataframe passed to the fit function of the NearestNeighbors estimator.
         Note that the knn relationship is asymmetric with respect to the input datasets (e.g., if x is a knn of y
         , y is not necessarily a knn of x).
 

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -1,7 +1,9 @@
-from typing import Tuple
+from typing import List, Tuple
 
 import numpy as np
+import pandas as pd
 import pytest
+from pyspark.sql import DataFrame
 from sklearn.datasets import make_blobs
 
 from spark_rapids_ml.knn import NearestNeighbors
@@ -28,11 +30,11 @@ def test_example(gpu_number: int) -> None:
     ]
 
     query = [
-        ([0.0, 0.0], "aa"),
-        ([1.0, 1.0], "bb"),
-        ([4.1, 4.1], "cc"),
-        ([8.0, 8.0], "dd"),
-        ([9.0, 9.0], "ee"),
+        ([0.0, 0.0], "qa"),
+        ([1.0, 1.0], "qb"),
+        ([4.1, 4.1], "qc"),
+        ([8.0, 8.0], "qd"),
+        ([9.0, 9.0], "qe"),
     ]
 
     topk = 2
@@ -48,9 +50,9 @@ def test_example(gpu_number: int) -> None:
         gpu_knn = gpu_knn.setK(topk)
 
         gpu_model = gpu_knn.fit(data_df)
-        query_df_withid, item_df_withid, knn_df = gpu_model.kneighbors(query_df)
-        query_df_withid.show()
+        (item_df_withid, query_df_withid, knn_df) = gpu_model.kneighbors(query_df)
         item_df_withid.show()
+        query_df_withid.show()
         knn_df.show()
 
         # check knn results
@@ -64,7 +66,7 @@ def test_example(gpu_number: int) -> None:
         index_rows = indices_df.collect()
         indices = [r.indices for r in index_rows]
 
-        def assert_distances_equal(distances):
+        def assert_distances_equal(distances: List[List[float]]) -> None:
             assert len(distances) == len(query)
             assert array_equal(distances[0], [math.sqrt(2.0), math.sqrt(8.0)])
             assert array_equal(distances[1], [0.0, math.sqrt(2.0)])
@@ -74,32 +76,102 @@ def test_example(gpu_number: int) -> None:
             assert array_equal(distances[3], [0.0, math.sqrt(2.0)])
             assert array_equal(distances[4], [math.sqrt(2.0), math.sqrt(8.0)])
 
-        def assert_indices_equal(indices):
+        def assert_indices_equal(indices: List[List[int]]) -> None:
+            assert len(indices) == len(query)
+            assert indices[0] == [0, 1]
+            assert indices[1] == [0, 1]
+            assert indices[2] == [3, 4]
+            assert indices[3] == [7, 6]
+            assert indices[4] == [7, 6]
 
-        assert array_equal(distances[0], [math.sqrt(2.0), math.sqrt(8.0)])
-        assert indices[0] == [0, 1]
+        assert_distances_equal(distances=distances)
+        assert_indices_equal(indices=indices)
 
-        assert array_equal(distances[1], [0.0, math.sqrt(2.0)])
-        assert indices[1] == [0, 1]
-
-        assert array_equal(
-            distances[2], [math.sqrt(0.01 + 0.01), math.sqrt(0.81 + 0.81)]
-        )
-        assert indices[2] == [3, 4]
-
-        assert array_equal(distances[3], [0.0, math.sqrt(2.0)])
-        assert indices[3] == [7, 6]
-
-        assert array_equal(distances[4], [math.sqrt(2.0), math.sqrt(8.0)])
-        assert indices[4] == [7, 6]
-
-        # throw an error if transform function is called
+        # test transform: throw an error if transform function is called
         with pytest.raises(NotImplementedError):
             gpu_model.transform(query_df)
 
-            
         # test exactNearestNeighborsJoin
-        res = gpu_model.exactNearestNeighborsJoin(data_df, query_df, topk)
+        knnjoin_df = gpu_model.exactNearestNeighborsJoin(
+            data_df, query_df, topk, distCol="distCol"
+        )
+        knnjoin_df.show()
+
+        assert len(knnjoin_df.dtypes) == 3
+        assert knnjoin_df.dtypes[0] == (
+            "datasetA",
+            "struct<features:array<float>,metadata:string>",
+        )
+        assert knnjoin_df.dtypes[1] == (
+            "datasetB",
+            "struct<features:array<float>,metadata:string>",
+        )
+        assert knnjoin_df.dtypes[2] == ("distCol", "float")
+
+        def assert_knn_metadata_equal(knn_metadata: List[List[str]]) -> None:
+            """
+            This is equivalent to assert_indices_equal but replaces indices with item_metadata.
+            """
+            assert len(knn_metadata) == len(query)
+            assert knn_metadata[0] == ["a", "b"]
+            assert knn_metadata[1] == ["a", "b"]
+            assert knn_metadata[2] == ["d", "e"]
+            assert knn_metadata[3] == ["h", "g"]
+            assert knn_metadata[4] == ["h", "g"]
+
+        reconstructed_knn_df = reconstruct_knn_df(
+            knnjoin_df=knnjoin_df, row_identifier_col="metadata", distCol="distCol"
+        )
+
+        reconstructed_rows = reconstructed_knn_df.collect()
+        reconstructed_knn_metadata = [r.indices for r in reconstructed_rows]
+        assert_knn_metadata_equal(reconstructed_knn_metadata)
+        reconstructed_distances = [r.distances for r in reconstructed_rows]
+        assert_distances_equal(reconstructed_distances)
+        reconstructed_query_ids = [r.query_id for r in reconstructed_rows]
+        assert reconstructed_query_ids == ["qa", "qb", "qc", "qd", "qe"]
+
+        knnjoin_items = (
+            knnjoin_df.select(
+                knnjoin_df["datasetA.features"].alias("features"),
+                knnjoin_df["datasetA.metadata"].alias("metadata"),
+            )
+            .distinct()
+            .sort("metadata")
+            .collect()
+        )
+
+        assert len(knnjoin_items) == len([0, 1, 3, 4, 6, 7])
+        assert knnjoin_items[0]["features"] == data[0][0]
+        assert knnjoin_items[0]["metadata"] == data[0][1]
+        assert knnjoin_items[1]["features"] == data[1][0]
+        assert knnjoin_items[1]["metadata"] == data[1][1]
+        assert knnjoin_items[2]["features"] == data[3][0]
+        assert knnjoin_items[2]["metadata"] == data[3][1]
+        assert knnjoin_items[3]["features"] == data[4][0]
+        assert knnjoin_items[3]["metadata"] == data[4][1]
+        assert knnjoin_items[4]["features"] == data[6][0]
+        assert knnjoin_items[4]["metadata"] == data[6][1]
+        assert knnjoin_items[5]["features"] == data[7][0]
+        assert knnjoin_items[5]["metadata"] == data[7][1]
+
+        knnjoin_queries = (
+            knnjoin_df.select(
+                knnjoin_df["datasetB.features"].alias("features"),
+                knnjoin_df["datasetB.metadata"].alias("metadata"),
+            )
+            .distinct()
+            .sort("metadata")
+            .collect()
+        )
+
+        assert len(knnjoin_queries) == len(query)
+        for i in range(len(knnjoin_queries)):
+            if i is 2:
+                assert array_equal(knnjoin_queries[i]["features"], query[i][0])
+            else:
+                assert knnjoin_queries[i]["features"] == query[i][0]
+            assert knnjoin_queries[i]["metadata"] == query[i][1]
 
 
 def test_example_with_id(gpu_number: int) -> None:
@@ -115,11 +187,11 @@ def test_example_with_id(gpu_number: int) -> None:
     ]
 
     query = [
-        (201, [0.0, 0.0], "aa"),
-        (202, [1.0, 1.0], "bb"),
-        (203, [4.1, 4.1], "cc"),
-        (204, [8.0, 8.0], "dd"),
-        (205, [9.0, 9.0], "ee"),
+        (201, [0.0, 0.0], "qa"),
+        (202, [1.0, 1.0], "qb"),
+        (203, [4.1, 4.1], "qc"),
+        (204, [8.0, 8.0], "qd"),
+        (205, [9.0, 9.0], "qe"),
     ]
 
     topk = 2
@@ -135,9 +207,9 @@ def test_example_with_id(gpu_number: int) -> None:
         gpu_knn = gpu_knn.setK(topk)
 
         gpu_model = gpu_knn.fit(data_df)
-        query_df, item_df, knn_df = gpu_model.kneighbors(query_df)
-        query_df.show()
-        item_df.show()
+        item_df_withid, query_df_withid, knn_df = gpu_model.kneighbors(query_df)
+        item_df_withid.show()
+        query_df_withid.show()
         knn_df.show()
 
         distances_df = knn_df.select("distances")
@@ -146,11 +218,39 @@ def test_example_with_id(gpu_number: int) -> None:
         indices = indices_df.collect()
         indices = [r[0] for r in indices]
 
-        assert indices[0] == [101, 102]
-        assert indices[1] == [101, 102]
-        assert indices[2] == [104, 105]
-        assert indices[3] == [108, 107]
-        assert indices[4] == [108, 107]
+        def assert_indices_equal(indices: List[List[int]]) -> None:
+            assert indices[0] == [101, 102]
+            assert indices[1] == [101, 102]
+            assert indices[2] == [104, 105]
+            assert indices[3] == [108, 107]
+            assert indices[4] == [108, 107]
+
+        # test exactNearestNeighborsJoin
+        knnjoin_df = gpu_model.exactNearestNeighborsJoin(
+            data_df, query_df, topk, distCol="distCol"
+        )
+        knnjoin_df.show()
+
+        assert len(knnjoin_df.dtypes) == 3
+        assert knnjoin_df.dtypes[0] == (
+            "datasetA",
+            f"struct<id:int,features:array<float>,metadata:string>",
+        )
+        assert knnjoin_df.dtypes[1] == (
+            "datasetB",
+            "struct<id:int,features:array<float>,metadata:string>",
+        )
+        assert knnjoin_df.dtypes[2] == ("distCol", "float")
+
+        reconstructed_knn_df = reconstruct_knn_df(
+            knnjoin_df=knnjoin_df, row_identifier_col="id", distCol="distCol"
+        )
+
+        reconstructed_rows = reconstructed_knn_df.collect()
+        reconstructed_knn_indices = [r.indices for r in reconstructed_rows]
+        assert_indices_equal(reconstructed_knn_indices)
+        reconstructed_query_ids = [r.query_id for r in reconstructed_rows]
+        assert reconstructed_query_ids == [201, 202, 203, 204, 205]
 
 
 @pytest.mark.parametrize(
@@ -200,20 +300,20 @@ def test_nearest_neighbors(
             n_neighbors=n_neighbors, batch_size=batch_size
         ).setInputCol(features_col)
 
-        # obtain spark results
+        # test kneighbors: obtain spark results
         knn_model = knn_est.fit(data_df)
         query_df = data_df
-        (query_df_withid, item_df_withid, knn_df) = knn_model.kneighbors(query_df)
+        (item_df_withid, query_df_withid, knn_df) = knn_model.kneighbors(query_df)
 
         distances_df = knn_df.select("distances")
         indices_df = knn_df.select("indices")
-        # compare spark results with cuml results
+        # test kneighbors: compare spark results with cuml results
         distances = distances_df.collect()
         distances = [r[0] for r in distances]
         indices = indices_df.collect()
         indices = [r[0] for r in indices]
 
-        # compare top-1 nn indices(self) and distances(self)
+        # test kneighbors: compare top-1 nn indices(self) and distances(self)
         self_index = [knn[0] for knn in indices]
         assert self_index == list(range(data_shape[0]))
         cuml_self_index = [knn[0] for knn in cuml_indices]
@@ -224,12 +324,24 @@ def test_nearest_neighbors(
         cuml_self_distance = [kdist[0] for kdist in cuml_distances]
         assert array_equal(cuml_self_distance, [0.0 for i in range(data_shape[0])], 0.1)
 
-        # compare non-self distances
+        # test kneighbors: compare non-self distances
         assert len(distances) == len(cuml_distances)
         nonself_distances = [knn[1:] for knn in distances]
         cuml_nonself_distances = [knn[1:] for knn in cuml_distances]
         for i in range(len(distances)):
             assert array_equal(nonself_distances[i], cuml_nonself_distances[i])
+
+        # test exactNearestNeighborsJoin
+        with pytest.raises(ValueError):
+            knn_model.exactNearestNeighborsJoin(
+                item_df_withid, query_df_withid, n_neighbors
+            )
+        knn_model.setIdCol(item_df_withid.dtypes[0][0])
+        knnjoin_df = knn_model.exactNearestNeighborsJoin(
+            item_df_withid, query_df_withid, n_neighbors
+        )
+        reconstructed_knn_df = reconstruct_knn_df(knnjoin_df)
+        assert reconstructed_knn_df.collect() == knn_df.collect()
 
 
 def test_lsh_spark_compat(gpu_number: int) -> None:
@@ -240,37 +352,167 @@ def test_lsh_spark_compat(gpu_number: int) -> None:
     topk = 2
 
     with CleanSparkSession() as spark:
-        dataA = [(0, Vectors.dense([1.0, 1.0]), "d0"),
-                 (1, Vectors.dense([1.0, -1.0]), "d1"),
-                 (2, Vectors.dense([-1.0, -1.0]), "d2"),
-                 (3, Vectors.dense([-1.0, 1.0]), "d3")]
-        dfA = spark.createDataFrame(dataA, ["id", "features", "meta"])
+        dataA = [
+            (
+                0,
+                Vectors.dense([1.0, 1.0]),
+            ),
+            (
+                1,
+                Vectors.dense([1.0, -1.0]),
+            ),
+            (
+                2,
+                Vectors.dense([-1.0, -1.0]),
+            ),
+            (
+                3,
+                Vectors.dense([-1.0, 1.0]),
+            ),
+        ]
+        dfA = spark.createDataFrame(dataA, ["id", "features"])
 
-        dataB = [(4, Vectors.dense([1.0, 0.0]), "q4"),
-                 (5, Vectors.dense([-1.0, 0.0]), "q5"),
-                 (6, Vectors.dense([0.0, 1.0]), "q6"),
-                 (7, Vectors.dense([0.0, -1.0]), "q7")]
-        dfB = spark.createDataFrame(dataB, ["id", "features", "meta"])
-
-        brp = BucketedRandomProjectionLSH(inputCol="features", outputCol="hashes", bucketLength=5.0,
-                                  numHashTables=3)
-
-        model = brp.fit(dfA)
-        res = model.approxSimilarityJoin(dfA, dfB, 1.5, distCol="EuclideanDistance")
+        dataB = [
+            (
+                4,
+                Vectors.dense([1.0, 0.0]),
+            ),
+            (
+                5,
+                Vectors.dense([-1.0, 0.0]),
+            ),
+            (
+                6,
+                Vectors.dense([0.0, 1.0]),
+            ),
+            (
+                7,
+                Vectors.dense([0.0, -1.0]),
+            ),
+        ]
+        dfB = spark.createDataFrame(dataB, ["id", "features"])
         dfA.show()
         dfB.show()
-        res.show(truncate=False)
-        print(res.schema)
-        print("\n")
-        print(res.dtypes)
 
-        
-        # implement approxNearestNeighborsJoin(dfA, dfB, k, distCol="EuclideanDistance")
+        # get CPU results
+        brp = BucketedRandomProjectionLSH(
+            inputCol="features", outputCol="hashes", bucketLength=5.0, numHashTables=3
+        )
+        model = brp.fit(dfA)
+        spark_res = model.approxSimilarityJoin(
+            dfA, dfB, 1.5, distCol="EuclideanDistance"
+        )
+        spark_res.show(truncate=False)
 
-        gpu_knn = NearestNeighbors(num_workers=gpu_number)
-        gpu_knn = gpu_knn.setInputCol("features")
-        gpu_knn = gpu_knn.setIdCol("id")
-        gpu_knn = gpu_knn.setK(topk)
+        # get GPU results with exactNearestNeighborsJoin(dfA, dfB, k, distCol="EuclideanDistance")
+        gpu_knn = NearestNeighbors(inputCol="features", id_col="id")
         gpu_model = gpu_knn.fit(dfA)
-        res = gpu_model.approxNearestNeighborsJoin(dfA, dfB, topk)
-        res.show()
+        gpu_res = gpu_model.exactNearestNeighborsJoin(
+            dfA, dfB, topk, distCol="EuclideanDistance"
+        )
+        gpu_res.show()
+
+        # check results
+        def check_dtypes(res_df: DataFrame, from_spark: bool) -> None:
+            assert len(res_df.dtypes) == 3
+            assert res_df.dtypes[0][0] == "datasetA"
+            assert res_df.dtypes[1][0] == "datasetB"
+            assert res_df.dtypes[2][0] == "EuclideanDistance"
+
+            if from_spark:
+                assert res_df.dtypes[0][1].startswith(
+                    "struct<id:bigint,features:vector"
+                )
+                assert res_df.dtypes[1][1].startswith(
+                    "struct<id:bigint,features:vector"
+                )
+                assert res_df.dtypes[2][1] == "double"
+            else:
+                assert res_df.dtypes[0][1] == "struct<id:bigint,features:vector>"
+                assert res_df.dtypes[1][1] == "struct<id:bigint,features:vector>"
+                assert res_df.dtypes[2][1] == "float"
+
+        check_dtypes(res_df=spark_res, from_spark=True)
+        check_dtypes(res_df=gpu_res, from_spark=False)
+
+        items = gpu_res.select(
+            gpu_res["datasetA.id"], gpu_res["datasetA.features"]
+        ).collect()
+        assert len(items) == topk * len(dataB)
+        for item in items:
+            id = item.id
+            features = item.features
+            assert features == dataA[id][1]
+
+        queries = gpu_res.select(
+            gpu_res["datasetB.id"], gpu_res["datasetB.features"]
+        ).collect()
+        for query in queries:
+            id = query.id
+            features = query.features
+            assert features == dataB[id - 4][1]
+
+        knn_results = reconstruct_knn_df(
+            gpu_res, row_identifier_col="id", distCol="EuclideanDistance"
+        ).collect()
+        assert knn_results[0]["query_id"] == 4
+        assert knn_results[0]["indices"] == [1, 0] or knn_results[0]["indices"] == [
+            0,
+            1,
+        ]
+        assert knn_results[0]["distances"] == [1.0, 1.0]
+
+        assert knn_results[1]["query_id"] == 5
+        assert knn_results[1]["indices"] == [2, 3] or knn_results[1]["indices"] == [
+            3,
+            2,
+        ]
+        assert knn_results[1]["distances"] == [1.0, 1.0]
+
+        assert knn_results[2]["query_id"] == 6
+        assert knn_results[2]["indices"] == [3, 0] or knn_results[1]["indices"] == [
+            0,
+            3,
+        ]
+        assert knn_results[2]["distances"] == [1.0, 1.0]
+
+        assert knn_results[3]["query_id"] == 7
+        assert knn_results[3]["indices"] == [2, 1] or knn_results[1]["indices"] == [
+            1,
+            2,
+        ]
+        assert knn_results[3]["distances"] == [1.0, 1.0]
+
+
+def reconstruct_knn_df(
+    knnjoin_df: DataFrame, row_identifier_col: str = "id", distCol: str = "distCol"
+) -> DataFrame:
+    """
+    This function accepts the returned dataframe (denoted as knnjoin_df) of exactNearestNeighborsjoin,
+    then reconstructs the returned dataframe (i.e. knn_df) of kneighbors.
+    """
+    knn_df: DataFrame = knnjoin_df.select(
+        knnjoin_df[f"datasetB.{row_identifier_col}"].alias(f"query_id"),
+        knnjoin_df[f"datasetA.{row_identifier_col}"].alias("index"),
+        knnjoin_df[distCol].alias("distance"),
+    )
+
+    def functor(pdf: pd.DataFrame) -> pd.DataFrame:
+        pdf = pdf.sort_values(by=["distance"])
+        indices = pdf["index"].tolist()
+        distances = pdf["distance"].tolist()
+        query_id = pdf[f"query_id"].tolist()[0]
+
+        return pd.DataFrame(
+            {"query_id": [query_id], "indices": [indices], "distances": [distances]}
+        )
+
+    knn_df = knn_df.groupBy("query_id").applyInPandas(
+        functor,
+        schema=f"query_id {knn_df.dtypes[0][1]}, "
+        + f"indices array<{knn_df.dtypes[1][1]}>, "
+        + f"distances array<{knn_df.dtypes[2][1]}>",
+    )
+
+    knn_df = knn_df.sort("query_id")
+    return knn_df


### PR DESCRIPTION
The method leverages the existing kneighbors() function.
Tests and docstring added. 
 