### PR TITLE
Use CICD-dedicated image

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -30,7 +30,7 @@ import ipp.blossom.*
 
 def githubHelper // blossom github helper
 def TEMP_IMAGE_BUILD = true
-def IMAGE_PREMERGE = "${common.ARTIFACTORY_NAME}/sw-spark-docker/spark-rapids-ml:ubuntu20.04-cuda11.5.2-blossom"
+def IMAGE_PREMERGE = "${common.ARTIFACTORY_NAME}/sw-spark-docker/spark-rapids-ml:ubuntu20.04-blossom-ci"
 def cpuImage = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:rapids-databricks") // tooling image
 def PREMERGE_DOCKERFILE = 'ci/Dockerfile'
 def PREMERGE_TAG


### PR DESCRIPTION
There is an internal pipeline to help re-build CICD images every 4 hours.

To avoid frequently updating image name, we change it to `ubuntu20.04-blossom-ci`,
the image content will be mostly based on the default ARGS and ENVs in dockerfile.
