### PR TITLE
Make spark-rapids-ml run against cuml23.02

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,12 @@ authors = [
 ]
 description = "Apache Spark integration with RAPIDS and cuML"
 readme = "README.md"
-requires-python = ">=3.8,<3.10"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Environment :: GPU :: NVIDIA CUDA :: 11",

--- a/src/spark_rapids_ml/classification.py
+++ b/src/spark_rapids_ml/classification.py
@@ -186,7 +186,14 @@ class RandomForestClassificationModel(
             data = {}
             rf.update_labels = False
             data[pred.prediction] = rf.predict(pdf)
-            data[pred.probability] = pd.Series(list(rf.predict_proba(pdf)))
+            probs = rf.predict_proba(pdf)
+            if isinstance(probs, pd.DataFrame):
+                # For 2302, when input is multi-cols, the output will be DataFrame
+                data[pred.probability] = pd.Series(probs.values.tolist())
+            else:
+                # should be np.ndarray
+                data[pred.probability] = pd.Series(list(probs))
+
             return pd.DataFrame(data)
 
         return _construct_rf, _predict

--- a/src/spark_rapids_ml/feature.py
+++ b/src/spark_rapids_ml/feature.py
@@ -380,7 +380,10 @@ class PCAModel(PCAClass, _CumlModel, _PCACumlParams):
             from cuml.decomposition.pca_mg import PCAMG as CumlPCAMG
 
             pca = CumlPCAMG(output_type="cudf", **cuml_alg_params)
+
+            # Compatible with older cuml versions (before 23.02)
             pca._n_components = pca.n_components
+            pca.n_components_ = pca.n_components
 
             from spark_rapids_ml.utils import cudf_to_cuml_array
 

--- a/src/spark_rapids_ml/utils.py
+++ b/src/spark_rapids_ml/utils.py
@@ -20,8 +20,15 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 
 import cudf
 import numpy as np
-from cuml.common.array import CumlArray
-from cuml.common.input_utils import input_to_cuml_array
+
+try:
+    # Compatible with older cuml version (before 23.02)
+    from cuml.common.array import CumlArray
+    from cuml.common.input_utils import input_to_cuml_array
+except ImportError:
+    from cuml.common import input_to_cuml_array
+    from cuml.internals.array import CumlArray
+
 from pyspark import BarrierTaskContext, SparkContext, TaskContext
 from pyspark.sql import SparkSession
 


### PR DESCRIPTION
With this PR, spark-rapids-ml can run on both cuml 22.10 and cuml 23.02. ( I didn't test 22.12) 