### PR TITLE
another fix to array order

### DIFF
--- a/python/benchmark/benchmark/base.py
+++ b/python/benchmark/benchmark/base.py
@@ -87,6 +87,12 @@ class BenchmarkBase:
             action="store_true",
             help="do not stop spark session when finished",
         )
+        self._parser.add_argument(
+            "--verbose",
+            type=int,
+            default=0,
+            help="verbose param for cuml classes",
+        )
 
         self._add_class_arguments()
         self._add_extra_arguments()

--- a/python/benchmark/benchmark/base.py
+++ b/python/benchmark/benchmark/base.py
@@ -29,6 +29,10 @@ from pyspark.sql.functions import col
 from .utils import WithSparkSession, to_bool, with_benchmark
 
 
+def _set_max_cuml_verbose() -> int:
+    return 7
+
+
 class BenchmarkBase:
     """Based class for benchmarking.
 
@@ -89,9 +93,10 @@ class BenchmarkBase:
         )
         self._parser.add_argument(
             "--verbose",
-            type=int,
+            action="store_const",
+            const=7,
             default=0,
-            help="verbose param for cuml classes",
+            help="set cuml logging to max verbose level",
         )
 
         self._add_class_arguments()

--- a/python/benchmark/benchmark/base.py
+++ b/python/benchmark/benchmark/base.py
@@ -29,10 +29,6 @@ from pyspark.sql.functions import col
 from .utils import WithSparkSession, to_bool, with_benchmark
 
 
-def _set_max_cuml_verbose() -> int:
-    return 7
-
-
 class BenchmarkBase:
     """Based class for benchmarking.
 

--- a/python/benchmark/benchmark/bench_kmeans.py
+++ b/python/benchmark/benchmark/bench_kmeans.py
@@ -154,9 +154,9 @@ class BenchmarkKMeans(BenchmarkBase):
             params = self.class_params
             print(f"Passing {params} to KMeans")
 
-            gpu_estimator = KMeans(num_workers=num_gpus, verbose=self.args.verbose, **params).setPredictionCol(
-                output_col
-            )
+            gpu_estimator = KMeans(
+                num_workers=num_gpus, verbose=self.args.verbose, **params
+            ).setPredictionCol(output_col)
 
             if is_single_col:
                 gpu_estimator = gpu_estimator.setFeaturesCol(first_col)

--- a/python/benchmark/benchmark/bench_kmeans.py
+++ b/python/benchmark/benchmark/bench_kmeans.py
@@ -154,7 +154,7 @@ class BenchmarkKMeans(BenchmarkBase):
             params = self.class_params
             print(f"Passing {params} to KMeans")
 
-            gpu_estimator = KMeans(num_workers=num_gpus, **params).setPredictionCol(
+            gpu_estimator = KMeans(num_workers=num_gpus, verbose=self.args.verbose, **params).setPredictionCol(
                 output_col
             )
 

--- a/python/benchmark/benchmark/bench_linear_regression.py
+++ b/python/benchmark/benchmark/bench_linear_regression.py
@@ -49,7 +49,9 @@ class BenchmarkLinearRegression(BenchmarkBase):
         if self.args.num_gpus > 0:
             from spark_rapids_ml.regression import LinearRegression
 
-            lr = LinearRegression(num_workers=self.args.num_gpus, verbose=self.args.verbose, **params)
+            lr = LinearRegression(
+                num_workers=self.args.num_gpus, verbose=self.args.verbose, **params
+            )
             benchmark_string = "Spark Rapids ML LinearRegression training"
         else:
             from pyspark.ml.regression import LinearRegression as SparkLinearRegression

--- a/python/benchmark/benchmark/bench_linear_regression.py
+++ b/python/benchmark/benchmark/bench_linear_regression.py
@@ -49,7 +49,7 @@ class BenchmarkLinearRegression(BenchmarkBase):
         if self.args.num_gpus > 0:
             from spark_rapids_ml.regression import LinearRegression
 
-            lr = LinearRegression(num_workers=self.args.num_gpus, verbose=7, **params)
+            lr = LinearRegression(num_workers=self.args.num_gpus, verbose=self.args.verbose, **params)
             benchmark_string = "Spark Rapids ML LinearRegression training"
         else:
             from pyspark.ml.regression import LinearRegression as SparkLinearRegression

--- a/python/benchmark/benchmark/bench_nearest_neighbors.py
+++ b/python/benchmark/benchmark/bench_nearest_neighbors.py
@@ -81,7 +81,9 @@ class BenchmarkNearestNeighbors(BenchmarkBase):
                 )
 
             params = self.class_params
-            gpu_estimator = NearestNeighbors(num_workers=num_gpus, verbose=self.args.verbose, **params)
+            gpu_estimator = NearestNeighbors(
+                num_workers=num_gpus, verbose=self.args.verbose, **params
+            )
 
             if is_single_col:
                 gpu_estimator = gpu_estimator.setInputCol(first_col)

--- a/python/benchmark/benchmark/bench_nearest_neighbors.py
+++ b/python/benchmark/benchmark/bench_nearest_neighbors.py
@@ -81,7 +81,7 @@ class BenchmarkNearestNeighbors(BenchmarkBase):
                 )
 
             params = self.class_params
-            gpu_estimator = NearestNeighbors(num_workers=num_gpus, **params)
+            gpu_estimator = NearestNeighbors(num_workers=num_gpus, verbose=self.args.verbose, **params)
 
             if is_single_col:
                 gpu_estimator = gpu_estimator.setInputCol(first_col)

--- a/python/benchmark/benchmark/bench_pca.py
+++ b/python/benchmark/benchmark/bench_pca.py
@@ -151,7 +151,7 @@ class BenchmarkPCA(BenchmarkBase):
             params = self.class_params
             print(f"Passing {params} to PCA")
 
-            gpu_pca = PCA(num_workers=num_gpus, **params)
+            gpu_pca = PCA(num_workers=num_gpus, verbose=self.args.verbose, **params)
 
             if is_single_col:
                 output_col = "pca_features"

--- a/python/benchmark/benchmark/bench_random_forest.py
+++ b/python/benchmark/benchmark/bench_random_forest.py
@@ -74,7 +74,9 @@ class BenchmarkRandomForestClassifier(BenchmarkBase):
         if self.args.num_gpus > 0:
             from spark_rapids_ml.classification import RandomForestClassifier
 
-            rfc = RandomForestClassifier(num_workers=self.args.num_gpus, verbose=self.args.verbose, **params)
+            rfc = RandomForestClassifier(
+                num_workers=self.args.num_gpus, verbose=self.args.verbose, **params
+            )
             benchmark_string = "Spark Rapids ML RandomForestClassifier"
         else:
             from pyspark.ml.classification import (

--- a/python/benchmark/benchmark/bench_random_forest.py
+++ b/python/benchmark/benchmark/bench_random_forest.py
@@ -74,7 +74,7 @@ class BenchmarkRandomForestClassifier(BenchmarkBase):
         if self.args.num_gpus > 0:
             from spark_rapids_ml.classification import RandomForestClassifier
 
-            rfc = RandomForestClassifier(num_workers=self.args.num_gpus, **params)
+            rfc = RandomForestClassifier(num_workers=self.args.num_gpus, verbose=self.args.verbose, **params)
             benchmark_string = "Spark Rapids ML RandomForestClassifier"
         else:
             from pyspark.ml.classification import (
@@ -180,7 +180,7 @@ class BenchmarkRandomForestRegressor(BenchmarkBase):
             from spark_rapids_ml.regression import RandomForestRegressor
 
             rf = RandomForestRegressor(
-                num_workers=self.args.num_gpus, verbose=7, **params
+                num_workers=self.args.num_gpus, verbose=self.args.verbose, **params
             )
             benchmark_string = "Spark Rapids ML RandomForestRegressor"
         else:

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -32,7 +32,6 @@ from spark_rapids_ml.tree import (
     _RandomForestEstimator,
     _RandomForestModel,
 )
-from spark_rapids_ml.utils import _ArrayOrder
 
 
 class _RFClassifierParams(_RandomForestClassifierParams, HasProbabilityCol):

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -32,6 +32,7 @@ from spark_rapids_ml.tree import (
     _RandomForestEstimator,
     _RandomForestModel,
 )
+from spark_rapids_ml.utils import _ArrayOrder
 
 
 class _RFClassifierParams(_RandomForestClassifierParams, HasProbabilityCol):
@@ -179,9 +180,8 @@ class RandomForestClassificationModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        Literal["C", "F"],
     ]:
-        _construct_rf, _, array_order = super()._get_cuml_transform_func(dataset)
+        _construct_rf, _ = super()._get_cuml_transform_func(dataset)
 
         def _predict(rf: CumlT, pdf: Union[cudf.DataFrame, np.ndarray]) -> pd.Series:
             data = {}
@@ -197,7 +197,7 @@ class RandomForestClassificationModel(
 
             return pd.DataFrame(data)
 
-        return _construct_rf, _predict, array_order
+        return _construct_rf, _predict
 
     def _is_classification(self) -> bool:
         return True

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -179,8 +179,9 @@ class RandomForestClassificationModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        str
     ]:
-        _construct_rf, _ = super()._get_cuml_transform_func(dataset)
+        _construct_rf, _, array_order = super()._get_cuml_transform_func(dataset)
 
         def _predict(rf: CumlT, pdf: Union[cudf.DataFrame, np.ndarray]) -> pd.Series:
             data = {}
@@ -196,7 +197,7 @@ class RandomForestClassificationModel(
 
             return pd.DataFrame(data)
 
-        return _construct_rf, _predict
+        return _construct_rf, _predict, array_order
 
     def _is_classification(self) -> bool:
         return True

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Callable, Tuple, Type, Union
+from typing import Any, Callable, Literal, Tuple, Type, Union
 
 import cudf
 import numpy as np
@@ -179,7 +179,7 @@ class RandomForestClassificationModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        str
+        Literal["C", "F"],
     ]:
         _construct_rf, _, array_order = super()._get_cuml_transform_func(dataset)
 

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -269,7 +269,7 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 concated = pd.concat(df_list)
             else:
                 # should be list of np.ndarrays here
-                concated = _concat_and_free(cast(List[np.ndarray], df_list))
+                concated = _concat_and_free(cast(List[np.ndarray], df_list), order="C")
 
             kmeans_object.fit(
                 concated,
@@ -349,6 +349,7 @@ class KMeansModel(KMeansClass, _CumlModelSupervised, _KMeansCumlParams):
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        str
     ]:
         cuml_alg_params = self.cuml_params.copy()
 
@@ -376,4 +377,4 @@ class KMeansModel(KMeansClass, _CumlModelSupervised, _KMeansCumlParams):
             res = list(kmeans.predict(df, normalize_weights=False).to_numpy())
             return pd.Series(res)
 
-        return _construct_kmeans, _transform_internal
+        return _construct_kmeans, _transform_internal, "C"

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -14,18 +14,7 @@
 # limitations under the License.
 #
 
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import cudf
 import numpy as np

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -14,7 +14,18 @@
 # limitations under the License.
 #
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import cudf
 import numpy as np
@@ -349,7 +360,7 @@ class KMeansModel(KMeansClass, _CumlModelSupervised, _KMeansCumlParams):
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        str
+        Literal["C", "F"],
     ]:
         cuml_alg_params = self.cuml_params.copy()
 

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -24,8 +24,6 @@ from typing import (
     Dict,
     Iterator,
     List,
-    Literal,
-    Mapping,
     Optional,
     Tuple,
     Type,

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -24,6 +24,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal,
     Mapping,
     Optional,
     Tuple,
@@ -598,7 +599,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        str
+        Literal["C", "F"],
     ]:
         """
         Subclass must implement this function to return two functions,
@@ -684,9 +685,11 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
         is_local = _is_local(_get_spark_session().sparkContext)
 
         # Get the functions which will be passed into executor to run.
-        construct_cuml_object_func, cuml_transform_func, array_order = self._get_cuml_transform_func(
-            dataset
-        )
+        (
+            construct_cuml_object_func,
+            cuml_transform_func,
+            array_order,
+        ) = self._get_cuml_transform_func(dataset)
 
         def _transform_udf(pdf_iter: Iterator[pd.DataFrame]) -> pd.DataFrame:
             from pyspark import TaskContext
@@ -756,9 +759,11 @@ class _CumlModelSupervised(_CumlModel, HasPredictionCol):
         is_local = _is_local(_get_spark_session().sparkContext)
 
         # Get the functions which will be passed into executor to run.
-        construct_cuml_object_func, cuml_transform_func, array_order = self._get_cuml_transform_func(
-            dataset
-        )
+        (
+            construct_cuml_object_func,
+            cuml_transform_func,
+            array_order,
+        ) = self._get_cuml_transform_func(dataset)
 
         @pandas_udf(self._out_schema(dataset.schema))  # type: ignore
         def predict_udf(iterator: Iterator[pd.DataFrame]) -> Iterator[pd.Series]:

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -605,7 +605,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
         Subclass must implement this function to return two functions,
         1. a function to construct cuml counterpart instance
         2. a function to transform the dataset
-        and a preferred array order for converting single column array type to numpy arrays: One of "K", "F", "C", or "A"
+        and a preferred array order for converting single column array type to numpy arrays: "C" or "F"
 
         Eg,
 

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -15,7 +15,7 @@
 #
 
 import itertools
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, TypeVar, Union
 
 import cudf
 import numpy as np
@@ -361,7 +361,7 @@ class PCAModel(PCAClass, _CumlModel, _PCACumlParams):
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        str
+        Literal["C", "F"],
     ]:
         cuml_alg_params = self.cuml_params.copy()
 
@@ -394,7 +394,9 @@ class PCAModel(PCAClass, _CumlModel, _PCACumlParams):
             pca.components_ = cudf_to_cuml_array(
                 np.array(self.components_, order="F").astype(pca.dtype)
             )
-            pca.mean_ = cudf_to_cuml_array(np.array(self.mean_, order="F").astype(pca.dtype))
+            pca.mean_ = cudf_to_cuml_array(
+                np.array(self.mean_, order="F").astype(pca.dtype)
+            )
             pca.singular_values_ = cudf_to_cuml_array(
                 np.array(self.singular_values_, order="F").astype(pca.dtype)
             )

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -15,7 +15,7 @@
 #
 
 import itertools
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import cudf
 import numpy as np

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -361,7 +361,6 @@ class PCAModel(PCAClass, _CumlModel, _PCACumlParams):
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        Literal["C", "F"],
     ]:
         cuml_alg_params = self.cuml_params.copy()
 
@@ -422,5 +421,4 @@ class PCAModel(PCAClass, _CumlModel, _PCACumlParams):
                 res = list(res)
                 return pd.DataFrame({self.getOutputCol(): res})
 
-        # pca doesn't seem to have a preferred array type
-        return _construct_pca, _transform_internal, "F"
+        return _construct_pca, _transform_internal

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -15,7 +15,18 @@
 #
 
 import asyncio
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import cudf
 import numpy as np
@@ -41,6 +52,7 @@ from pyspark.sql.types import (
     StructField,
     StructType,
 )
+
 from spark_rapids_ml.core import (
     CumlInputType,
     CumlT,
@@ -490,7 +502,7 @@ class NearestNeighborsModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        str
+        Literal["C", "F"],
     ]:
         raise NotImplementedError(
             "'_CumlModel._get_cuml_transform_func' method is not implemented. Use 'kneighbors' instead."

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -15,18 +15,7 @@
 #
 
 import asyncio
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import cudf
 import numpy as np
@@ -502,7 +491,6 @@ class NearestNeighborsModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        Literal["C", "F"],
     ]:
         raise NotImplementedError(
             "'_CumlModel._get_cuml_transform_func' method is not implemented. Use 'kneighbors' instead."

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -41,7 +41,6 @@ from pyspark.sql.types import (
     StructField,
     StructType,
 )
-
 from spark_rapids_ml.core import (
     CumlInputType,
     CumlT,
@@ -52,6 +51,7 @@ from spark_rapids_ml.core import (
     param_alias,
 )
 from spark_rapids_ml.params import P, _CumlClass, _CumlParams
+from spark_rapids_ml.utils import _concat_and_free
 
 
 class NearestNeighborsClass(_CumlClass):
@@ -402,8 +402,9 @@ class NearestNeighborsModel(
                 item = [pd.concat(item_list)]
                 query = [pd.concat(query_list)]
             else:
-                item = [np.concatenate(item_list)]
-                query = [np.concatenate(query_list)]
+                # do not use item_list or query_list after this, as elements are freed
+                item = [_concat_and_free(item_list)]
+                query = [_concat_and_free(query_list)]
 
             item_row_number = [item_row_number]
             query_row_number = [query_row_number]
@@ -489,6 +490,7 @@ class NearestNeighborsModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        str
     ]:
         raise NotImplementedError(
             "'_CumlModel._get_cuml_transform_func' method is not implemented. Use 'kneighbors' instead."

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -15,7 +15,7 @@
 #
 
 import asyncio
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import cudf
 import numpy as np

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import cudf
 import numpy as np

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -12,7 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import cudf
 import numpy as np
@@ -452,7 +463,7 @@ class LinearRegressionModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        str
+        Literal["C", "F"],
     ]:
         coef_ = self.coef_
         intercept_ = self.intercept_

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -12,18 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import cudf
 import numpy as np
@@ -463,7 +452,6 @@ class LinearRegressionModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        Literal["C", "F"],
     ]:
         coef_ = self.coef_
         intercept_ = self.intercept_
@@ -485,7 +473,7 @@ class LinearRegressionModel(
             ret = lr.predict(pdf)
             return pd.Series(ret)
 
-        return _construct_lr, _predict, "F"
+        return _construct_lr, _predict
 
 
 class _RandomForestRegressorClass(_RandomForestClass):

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -452,6 +452,7 @@ class LinearRegressionModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        str
     ]:
         coef_ = self.coef_
         intercept_ = self.intercept_
@@ -462,7 +463,7 @@ class LinearRegressionModel(
             from cuml.linear_model.linear_regression_mg import LinearRegressionMG
 
             lr = LinearRegressionMG(output_type="numpy")
-            lr.coef_ = cudf_to_cuml_array(np.array(coef_).astype(dtype))
+            lr.coef_ = cudf_to_cuml_array(np.array(coef_, order="F").astype(dtype))
             lr.intercept_ = intercept_
             lr.n_cols = n_cols
             lr.dtype = np.dtype(dtype)
@@ -473,7 +474,7 @@ class LinearRegressionModel(
             ret = lr.predict(pdf)
             return pd.Series(ret)
 
-        return _construct_lr, _predict
+        return _construct_lr, _predict, "F"
 
 
 class _RandomForestRegressorClass(_RandomForestClass):

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -17,7 +17,7 @@ import base64
 import math
 import pickle
 from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import cudf
 import numpy as np
@@ -352,7 +352,7 @@ class _RandomForestModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        str
+        Literal["C", "F"],
     ]:
         treelite_model = self.treelite_model
 
@@ -375,5 +375,6 @@ class _RandomForestModel(
             rf.update_labels = False
             ret = rf.predict(pdf)
             return pd.Series(ret)
+
         # TBD: figure out why RF algo's warns regardless of what np array order is set
         return _construct_rf, _predict, "F"

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -17,7 +17,7 @@ import base64
 import math
 import pickle
 from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import cudf
 import numpy as np
@@ -36,7 +36,7 @@ from spark_rapids_ml.core import (
     param_alias,
 )
 from spark_rapids_ml.params import HasFeaturesCols, P, _CumlClass, _CumlParams
-from spark_rapids_ml.utils import _ArrayOrder, _concat_and_free
+from spark_rapids_ml.utils import _concat_and_free
 
 
 class _RandomForestClass(_CumlClass):

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -36,7 +36,7 @@ from spark_rapids_ml.core import (
     param_alias,
 )
 from spark_rapids_ml.params import HasFeaturesCols, P, _CumlClass, _CumlParams
-from spark_rapids_ml.utils import _concat_and_free
+from spark_rapids_ml.utils import _ArrayOrder, _concat_and_free
 
 
 class _RandomForestClass(_CumlClass):
@@ -352,7 +352,6 @@ class _RandomForestModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        Literal["C", "F"],
     ]:
         treelite_model = self.treelite_model
 
@@ -377,4 +376,4 @@ class _RandomForestModel(
             return pd.Series(ret)
 
         # TBD: figure out why RF algo's warns regardless of what np array order is set
-        return _construct_rf, _predict, "F"
+        return _construct_rf, _predict

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -352,6 +352,7 @@ class _RandomForestModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        str
     ]:
         treelite_model = self.treelite_model
 
@@ -374,5 +375,5 @@ class _RandomForestModel(
             rf.update_labels = False
             ret = rf.predict(pdf)
             return pd.Series(ret)
-
-        return _construct_rf, _predict
+        # TBD: figure out why RF algo's warns regardless of what np array order is set
+        return _construct_rf, _predict, "F"

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -32,6 +32,8 @@ except ImportError:
 from pyspark import BarrierTaskContext, SparkContext, TaskContext
 from pyspark.sql import SparkSession
 
+_ArrayOrder = Literal["C", "F"]
+
 
 def _get_spark_session() -> SparkSession:
     """Get or create spark session.
@@ -130,7 +132,7 @@ class PartitionDescriptor:
 
 
 def _concat_and_free(
-    np_array_list: List[np.ndarray], order: Literal["C", "F"] = "F"
+    np_array_list: List[np.ndarray], order: _ArrayOrder = "F"
 ) -> np.ndarray:
     """
     concatenates a list of compatible numpy arrays into a 'order' ordered output array,

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -16,7 +16,7 @@
 import inspect
 import logging
 import sys
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Tuple, Union
 
 import cudf
 import numpy as np
@@ -129,7 +129,9 @@ class PartitionDescriptor:
         return cls(total_rows, total_cols, rank, parts_rank_size)
 
 
-def _concat_and_free(np_array_list: List[np.ndarray], order="F") -> np.ndarray:
+def _concat_and_free(
+    np_array_list: List[np.ndarray], order: Literal["C", "F"] = "F"
+) -> np.ndarray:
     """
     concatenates a list of compatible numpy arrays into a 'order' ordered output array,
     in a memory efficient way.

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -129,9 +129,9 @@ class PartitionDescriptor:
         return cls(total_rows, total_cols, rank, parts_rank_size)
 
 
-def _concat_and_free(np_array_list: List[np.ndarray]) -> np.ndarray:
+def _concat_and_free(np_array_list: List[np.ndarray], order="F") -> np.ndarray:
     """
-    concatenates a list of compatible numpy arrays into a F ordered output array,
+    concatenates a list of compatible numpy arrays into a 'order' ordered output array,
     in a memory efficient way.
     Note: frees list elements so do not reuse after calling.
     """
@@ -142,7 +142,7 @@ def _concat_and_free(np_array_list: List[np.ndarray]) -> np.ndarray:
     else:
         concat_shape = (rows,)
     d_type = np_array_list[0].dtype
-    concated = np.empty(shape=concat_shape, order="F", dtype=d_type)
+    concated = np.empty(shape=concat_shape, order=order, dtype=d_type)
     np.concatenate(np_array_list, out=concated)
     del np_array_list[:]
     return concated

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import cudf
 import numpy as np
@@ -261,6 +261,7 @@ class SparkRapidsMLDummyModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Literal["C", "F"],
     ]:
         model_attribute_a = self.model_attribute_a
 
@@ -286,7 +287,7 @@ class SparkRapidsMLDummyModel(
                 # TODO: implement when adding single column test
                 raise NotImplementedError()
 
-        return _construct_dummy, _dummy_transform
+        return _construct_dummy, _dummy_transform, "F"
 
     def _out_schema(self, input_schema: StructType) -> Union[StructType, str]:
         return input_schema

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -261,7 +261,6 @@ class SparkRapidsMLDummyModel(
     ) -> Tuple[
         Callable[..., CumlT],
         Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
-        Literal["C", "F"],
     ]:
         model_attribute_a = self.model_attribute_a
 
@@ -287,7 +286,7 @@ class SparkRapidsMLDummyModel(
                 # TODO: implement when adding single column test
                 raise NotImplementedError()
 
-        return _construct_dummy, _dummy_transform, "F"
+        return _construct_dummy, _dummy_transform
 
     def _out_schema(self, input_schema: StructType) -> Union[StructType, str]:
         return input_schema

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-from spark_rapids_ml.utils import _get_default_params_from_func
+import numpy as np
+
+from spark_rapids_ml.utils import _concat_and_free, _get_default_params_from_func
 
 
 def test_get_default_params_from_func() -> None:
@@ -26,6 +28,22 @@ def test_get_default_params_from_func() -> None:
     assert len(params) == 3
     assert params["a"] == 1
     assert params["d"] == 4
+
+
+def test_concat_and_free() -> None:
+    a = np.array([[0.0, 1.0], [2.0, 3.0]], order="F")
+    arr_list = [a, a]
+    concat = _concat_and_free(arr_list, order="C")
+    assert len(arr_list) == 0
+    assert concat.flags["C_CONTIGUOUS"]
+    assert not concat.flags["F_CONTIGUOUS"]
+
+    a = np.array([[0.0, 1.0], [2.0, 3.0]], order="C")
+    arr_list = [a, a]
+    concat = _concat_and_free(arr_list)
+    assert len(arr_list) == 0
+    assert not concat.flags["C_CONTIGUOUS"]
+    assert concat.flags["F_CONTIGUOUS"]
 
 
 def test_clean_sparksession() -> None:


### PR DESCRIPTION
- Missed that different algos have differing preferred orderings for the input arrays for fit (e.g. KMeans prefers C vs F) (warnings were suppressed in benchmarks in some cases - kmeans)

- Similar for transform.  KMeans prefers C while LinearRegression prefers F.   RandomForest on transform warns about either ordering, and is TBD to figure out.   Also, 1-d arrays as noted before are still problematic and are TBDs.

- Applied _concat_and_free to KNN with its preferred ordering.

- Added verbose option to benchmarks.   `eg. ./run_bench.sh kmeans --verbose`