### PR TITLE
Create pyspark ml LinearRegressionModel

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Literal, Tuple, Type, Union
 import cudf
 import numpy as np
 import pandas as pd
-from pyspark import Row
+from pyspark import Row, SparkContext
 from pyspark.ml.classification import _RandomForestClassifierParams
 from pyspark.ml.param.shared import HasProbabilityCol
 from pyspark.sql import Column, DataFrame
@@ -142,7 +142,9 @@ class RandomForestClassifier(
 
         return label_col
 
-    def _create_pyspark_model(self, result: Row) -> "RandomForestClassificationModel":
+    def _create_pyspark_model(
+        self, sc: SparkContext, result: Row
+    ) -> "RandomForestClassificationModel":
         return RandomForestClassificationModel.from_row(result)
 
     def _is_classification(self) -> bool:

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 import cudf
 import numpy as np
 import pandas as pd
+from pyspark import SparkContext
 from pyspark.ml.clustering import _KMeansParams
 from pyspark.ml.linalg import Vector
 from pyspark.sql.dataframe import DataFrame
@@ -310,7 +311,7 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
             ]
         )
 
-    def _create_pyspark_model(self, result: Row) -> "KMeansModel":
+    def _create_pyspark_model(self, sc: SparkContext, result: Row) -> "KMeansModel":
         return KMeansModel.from_row(result)
 
 

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import cudf
 import numpy as np
 import pandas as pd
+from pyspark import SparkContext
 from pyspark.ml.feature import _PCAParams
 from pyspark.ml.linalg import DenseMatrix, DenseVector
 from pyspark.ml.param.shared import HasInputCols
@@ -233,7 +234,7 @@ class PCA(PCAClass, _CumlEstimator, _PCACumlParams):
             ]
         )
 
-    def _create_pyspark_model(self, result: Row) -> "PCAModel":
+    def _create_pyspark_model(self, sc: SparkContext, result: Row) -> "PCAModel":
         return PCAModel.from_row(result)
 
 

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -191,3 +191,9 @@ def get_logger(cls: type, level: str = "INFO") -> logging.Logger:
         logger.addHandler(handler)
 
     return logger
+
+
+def java_uid(sc: SparkContext, prefix: str) -> str:
+    """Returns a random UID that concatenates the given prefix, "_", and 12 random hex chars."""
+    assert sc._jvm is not None
+    return sc._jvm.org.apache.spark.ml.util.Identifiable.randomUID(prefix)

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -20,7 +20,7 @@ import cudf
 import numpy as np
 import pandas as pd
 import pytest
-from pyspark import Row, TaskContext
+from pyspark import Row, SparkContext, TaskContext
 from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark.ml.param.shared import HasInputCols, HasOutputCols
 from pyspark.sql import DataFrame
@@ -212,7 +212,9 @@ class SparkRapidsMLDummy(
             "dtype string, n_cols int, model_attribute_a int, model_attribute_b string"
         )
 
-    def _create_pyspark_model(self, result: Row) -> "SparkRapidsMLDummyModel":
+    def _create_pyspark_model(
+        self, sc: SparkContext, result: Row
+    ) -> "SparkRapidsMLDummyModel":
         assert result.dtype == np.dtype(np.float32).name
         assert result.n_cols == self.n
         assert result.model_attribute_a == 1024


### PR DESCRIPTION
It first deprecates the customized LinearRegressionModel, then just creates and returns the pyspark builtin LinearRegressionModel.