### PR TITLE
Support mixed model for PCAModel

### DIFF
--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -429,6 +429,7 @@ class LinearRegressionModel(
         self._lr_ml_model: Optional[SparkLinearRegressionModel] = None
 
     def cpu(self) -> SparkLinearRegressionModel:
+        """Return the PySpark ML LinearRegressionModel"""
         if self._lr_ml_model is None:
             sc = _get_spark_session().sparkContext
             assert sc._jvm is not None


### PR DESCRIPTION
This PR provides `cpu()` to get the equivalent PySpark ML PCAModel