### PR TITLE
Split deploy script [skip ci]

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -2,7 +2,7 @@
 # exit on first fail
 set -e
 
-# build pip package
+# build whl package
 pushd python
 pip install -r requirements_dev.txt && pip install -e .
 python -m build

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
-# exit on first fail
-set -e
+#
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -ex
 
 # build whl package
 pushd python

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,33 +1,9 @@
 #!/bin/bash
-
-# get version tag
-TAG=$(git describe --tag)
-if [[ $? != 0 ]]; then
-    echo "Can only deploy from a version tag."
-    exit 1
-fi
-
 # exit on first fail
 set -e
 
-# build and publish pip package
+# build pip package
 pushd python
 pip install -r requirements_dev.txt && pip install -e .
 python -m build
-# TODO: python -m twine upload --repository pypi dist/*
 popd
-
-# build and publish docs
-pushd docs
-make html
-git worktree add --track -b gh-pages _site origin/gh-pages
-cp -r build/html/* _site/api/python
-cp -r site/* _site
-pushd _site
-git add --all
-git commit -m "${TAG}"
-git push origin gh-pages
-popd #_site
-git worktree remove _site
-popd
-

--- a/ci/docs.sh
+++ b/ci/docs.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # get version tag
 TAG=$(git describe --tag)
@@ -7,8 +22,7 @@ if [[ $? != 0 ]]; then
     exit 1
 fi
 
-# exit on first fail
-set -e
+set -ex
 
 # build and publish docs
 pushd docs

--- a/ci/docs.sh
+++ b/ci/docs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# get version tag
+TAG=$(git describe --tag)
+if [[ $? != 0 ]]; then
+    echo "Can only deploy from a version tag."
+    exit 1
+fi
+
+# exit on first fail
+set -e
+
+# build and publish docs
+pushd docs
+make html
+git worktree add --track -b gh-pages _site origin/gh-pages
+cp -r build/html/* _site/api/python
+cp -r site/* _site
+pushd _site
+git add --all
+git commit -m "${TAG}"
+git push origin gh-pages
+popd #_site
+git worktree remove _site
+popd


### PR DESCRIPTION
split `deploy.sh` script into `deploy.sh` and `docs.sh`

deploy script would be responsible to build whl package only. It will be called in blossom pipeline.
