### PR TITLE
[DO NOT MERGE] Refactor knn

### DIFF
--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
+from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
-import asyncio
 import numpy as np
 import pandas as pd
-from enum import IntEnum
 from pyspark.ml.functions import vector_to_array
 from pyspark.ml.linalg import VectorUDT
 from pyspark.ml.param.shared import (
@@ -40,19 +40,15 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from spark_rapids_ml.core import (
-    CumlInputType,
-    _CumlCaller,
-    alias,
-    param_alias,
-)
+from spark_rapids_ml.core import CumlInputType, _CumlCaller, alias, param_alias
 from spark_rapids_ml.params import P, _CumlClass, _CumlParams
 from spark_rapids_ml.utils import _concat_and_free
 
 
-class Label(IntEnum):
-    DATA=0,
-    QUERY=1,
+class Label(Enum):
+    DATA = 0
+    QUERY = 1
+
 
 class NearestNeighborsClass(_CumlClass):
     @classmethod
@@ -171,9 +167,7 @@ class _NearestNeighborsCumlParams(_CumlParams, HasInputCol, HasLabelCol, HasInpu
         return new_rdd.toDF(schema=out_schema)
 
 
-class NearestNeighbors(
-    NearestNeighborsClass, _CumlCaller, _NearestNeighborsCumlParams
-):
+class NearestNeighbors(NearestNeighborsClass, _CumlCaller, _NearestNeighborsCumlParams):
     """
     Examples
     --------
@@ -277,7 +271,9 @@ class NearestNeighbors(
 
         return select_cols, multi_col_names, dimension, feature_type
 
-    def kneighbors(self, query_df: DataFrame, item_df: DataFrame) -> Tuple[DataFrame, DataFrame, DataFrame]:
+    def kneighbors(
+        self, query_df: DataFrame, item_df: DataFrame
+    ) -> Tuple[DataFrame, DataFrame, DataFrame]:
         """Return the exact nearest neighbors in item_df for each query in query_df. The data
         vectors (or equivalently item vectors) should be provided through the fit
         function (see Examples in the spark_rapids_ml.knn.NearestNeighbors). The

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -474,27 +474,27 @@ class NearestNeighbors(
         Parameters
         ----------
         query_df: pyspark.sql.DataFrame
-            the query_df dataframe. Each row represents a query vector.
+            Dataframe of query vectors.
+
         item_df: pyspark.sql.DataFrame
-            the item_df dataframe. Each row represents an item vector.
+            Dataframe of item vectors, which will be matched to the query vectors.
 
         distCol: str
-            the name of the output distance column
+            Name of the output distance column
 
         Returns
         -------
         knnjoin_df: pyspark.sql.DataFrame
-            the result dataframe that has three columns (item_df, query_df, distCol).
-            item_df column is of struct type that includes as fields all the columns of input item dataframe.
-            Similarly, query_df column is of struct type that includes as fields all the columns of input query dataframe.
-            distCol is the distance column. A row in knnjoin_df is in the format (v1, v2, dist(v1, v2)),
-            where item_vector v1 is one of the k nearest neighbors of query_vector v2 and their distance is dist(v1, v2).
+            Dataframe with three columns (query_df, item_df, distCol).
+            - query_df - struct type column that includes as fields all the columns of input query dataframe.
+            - item_df - struct type column that includes as fields all the columns of input item dataframe.
+            - distCol - the distance between the query vector and the item vector.
         """
 
         id_col_name = self.getIdCol()
 
         # call kneighbors then prepare return results
-        (item_df_withid, query_df_withid, knn_df) = self.kneighbors(query_df, item_df)
+        (query_df_withid, item_df_withid, knn_df) = self.kneighbors(query_df, item_df)
 
         from pyspark.sql.functions import arrays_zip, col, explode, struct
 
@@ -522,11 +522,11 @@ class NearestNeighbors(
         )
 
         if self.isSet(self.id_col):
-            knnjoin_df = knnjoin_df.select("item_df", "query_df", distCol)
+            knnjoin_df = knnjoin_df.select("query_df", "item_df", distCol)
         else:
             knnjoin_df = knnjoin_df.select(
-                knnjoin_df["item_df"].dropFields(id_col_name).alias("item_df"),
                 knnjoin_df["query_df"].dropFields(id_col_name).alias("query_df"),
+                knnjoin_df["item_df"].dropFields(id_col_name).alias("item_df"),
                 distCol,
             )
 


### PR DESCRIPTION
Draft PR for discussion purposes.

KNN does not fit the traditional Spark ML Estimator + Model paradigm.  You don't really need to "train" it, and there really isn't any "model state" to be stored in the Model (other than `k`).  That said, we currently have an Estimator implementation that is "fit" on a DataFrame, which really just returns a Model with a reference to that DataFrame.  Then, the Model has APIs to compute nearest neighbors between that stored DataFrame to another DataFrame passed into the function arguments.  While this does work, it also leads to issues with saving the associated Estimator and Model instances, since the DataFrame reference is not serializable.

So, one option is to find a way to serialize a DataFrame reference cleanly.

This PR propose another option which removes the Estimator/Model base classes entirely, and just represents KNN as a simple class with stateless APIs.  This is most similar to the classes in [stats.py](https://github.com/apache/spark/blob/master/python/pyspark/ml/stat.py).

I also investigated basing on the Transformer class, but that API generally just "transforms" a single DataFrame at a time, so once again, we'd need to store a secondary DataFrame reference somewhere.

Anyhow, I've also staged the PR in multiple commits to simplify the review (with the first commit being the most important).  Please feel free to comment (and/or reject this entirely), since I'm not sure if we're losing something important with this change.

