### PR TITLE
Auto infer to the prediction name for different algorithms

### DIFF
--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -342,9 +342,6 @@ class PCAModel(PCAClass, _CumlModelWithColumns, _PCACumlParams):
 
         return self._pca_ml_model
 
-    def _get_prediction_name(self) -> str:
-        return self.getOutputCol()
-
     def _get_cuml_transform_func(
         self, dataset: DataFrame
     ) -> Tuple[


### PR DESCRIPTION
Previously, we needed to manually add the prediction name for different algorithms when transforming. Eg, for PCA, we needed to specify "outputCol" while for others, we needed to specify "predictionCol". This is in-convenience, So I made this PR to auto-try the prediction name by matching HasPredictionCol and HasOutputCol.