### PR TITLE
update references to spark-cuml branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ python -m build
 ### Build and preview docs
 ```bash
 # if adding new files/modules, run this first:
-# sphinx-apidoc -f -o docs/source src/spark_rapids_ml
+# sphinx-apidoc -f -o docs/source python/src/spark_rapids_ml
 cd docs
 make html
 

--- a/docker/Dockerfile.pip
+++ b/docker/Dockerfile.pip
@@ -50,7 +50,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 ### END OF CACHE ###
 
-#ARG RAPIDS_ML_VER=spark-cuml
+#ARG RAPIDS_ML_VER=main
 #RUN git clone -b branch-$RAPIDS_ML_VER https://github.com/NVIDIA/spark-rapids-ml.git
 COPY . /spark-rapids-ml
 WORKDIR /spark-rapids-ml/python

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -48,7 +48,7 @@ RUN pip install --no-cache-dir "pyspark>=3.2.1" "scikit-learn>=1.2.1" \
 
 ### END OF CACHE ###
 
-#ARG RAPIDS_ML_VER=spark-cuml
+#ARG RAPIDS_ML_VER=main
 #RUN git clone -b branch-$RAPIDS_ML_VER https://github.com/NVIDIA/spark-rapids-ml.git
 COPY . /spark-rapids-ml
 WORKDIR /spark-rapids-ml/python

--- a/docs/site/get-started/databricks.md
+++ b/docs/site/get-started/databricks.md
@@ -4,5 +4,5 @@ parent: Getting Started
 ---
 # Getting Started on Databricks
 
-See [these instructions](https://github.com/NVIDIA/spark-rapids-ml/blob/spark-cuml/notebooks/databricks/README.md)
+See [these instructions](https://github.com/NVIDIA/spark-rapids-ml/blob/main/notebooks/databricks/README.md)
 

--- a/docs/site/get-started/local.md
+++ b/docs/site/get-started/local.md
@@ -4,4 +4,4 @@ parent: Getting Started
 ---
 # Getting Started on a Local Server
 
-See [these instructions](https://github.com/NVIDIA/spark-rapids-ml/blob/spark-cuml/README_python.md)
+See [these instructions](https://github.com/NVIDIA/spark-rapids-ml/blob/main/python/README.md)

--- a/docs/source/spark_rapids_ml.rst
+++ b/docs/source/spark_rapids_ml.rst
@@ -44,6 +44,14 @@ spark\_rapids\_ml.feature module
    :undoc-members:
    :show-inheritance:
 
+spark\_rapids\_ml.knn module
+----------------------------
+
+.. automodule:: spark_rapids_ml.knn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 spark\_rapids\_ml.params module
 -------------------------------
 

--- a/python/README.md
+++ b/python/README.md
@@ -21,10 +21,15 @@ Once you have the conda environment, activate it and install the required packag
 ```bash
 conda activate rapids-23.02
 
-git clone --branch spark-cuml https://github.com/NVIDIA/spark-rapids-ml.git
+# for development access to notebooks, tests, and benchmarks
+git clone --branch main https://github.com/NVIDIA/spark-rapids-ml.git
 cd spark-rapids-ml/python
 pip install -r requirements.txt
 pip install -e .
+
+# OPTIONAL: for package installation only
+pip install -r https://raw.githubusercontent.com/NVIDIA/spark-rapids-ml/main/python/requirements.txt
+pip install spark-rapids-ml
 ```
 
 ## Examples

--- a/python/benchmark/databricks/init-cpu.sh
+++ b/python/benchmark/databricks/init-cpu.sh
@@ -3,7 +3,7 @@
 SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/spark-rapids-ml.zip
 BENCHMARK_ZIP=/dbfs/path/to/benchmark.zip
 
-# install spark-cuml
+# install spark-rapids-ml
 unzip ${SPARK_RAPIDS_ML_ZIP} -d /databricks/python3/lib/python3.8/site-packages
 unzip ${BENCHMARK_ZIP} -d /databricks/python3/lib/python3.8/site-packages
 

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -42,7 +42,7 @@ rmm-cu11==${RAPIDS_VERSION} \
 # rapids pip package patch: link ucx libraries in ucx-py to default location searched by raft_dask
 ln -s /databricks/python/lib/python3.8/site-packages/ucx_py_cu11.libs/ucx /usr/lib/ucx
 
-# install spark-cuml
+# install spark-rapids-ml
 unzip ${SPARK_RAPIDS_ML_ZIP} -d /databricks/python3/lib/python3.8/site-packages
 unzip ${BENCHMARK_ZIP} -d /databricks/python3/lib/python3.8/site-packages
 


### PR DESCRIPTION
Replacing with "main" as the most stable link for latest released version.

Also:
- add knn API docs
- fix some references to spark-cuml
- fix CONTRIBUTING.md
