### PR TITLE
import from ucp first to load from correct ucx shared libs

### DIFF
--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -30,15 +30,10 @@ ldconfig
 # upgrade pip
 /databricks/python/bin/pip install --upgrade pip
 
-# install cudf
+# install cudf, cuml and their rapids dependencies
 /databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} \
 cuml-cu11==${RAPIDS_VERSION} \
-pylibraft-cu11==${RAPIDS_VERSION} \
-rmm-cu11==${RAPIDS_VERSION} \
 --extra-index-url=https://pypi.nvidia.com
-
-# rapids pip package patch: link ucx libraries in ucx-py to default location searched by raft_dask
-ln -s /databricks/python/lib/python3.8/site-packages/ucx_py_cu11.libs/ucx /usr/lib/ucx
 
 # install spark-rapids-ml
 unzip ${SPARK_RAPIDS_ML_ZIP} -d /databricks/python3/lib/python3.8/site-packages

--- a/notebooks/dataproc/spark_rapids_ml.sh
+++ b/notebooks/dataproc/spark_rapids_ml.sh
@@ -11,12 +11,7 @@ pip install --ignore-installed "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"
 # install cudf and cuml
 pip install cudf-cu11==${RAPIDS_VERSION} \
 cuml-cu11==${RAPIDS_VERSION} \
-pylibraft-cu11==${RAPIDS_VERSION} \
-rmm-cu11==${RAPIDS_VERSION} \
 --extra-index-url=https://pypi.nvidia.com
-
-# rapids pip package patch: link ucx libraries in ucx-py to default location searched by raft_dask
-ln -s /opt/conda/miniconda3/lib/python3.8/site-packages/ucx_py_cu11.libs/ucx /usr/lib/ucx
 
 # install spark-rapids-ml
 pip install spark-rapids-ml

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -39,9 +39,6 @@ pylibraft-cu11==${RAPIDS_VERSION} \
 rmm-cu11==${RAPIDS_VERSION} \
 --extra-index-url=https://pypi.nvidia.com
 
-# rapids pip package patch: link ucx libraries in ucx-py to default location searched by raft_dask
-ln -s /databricks/python/lib/python3.8/site-packages/ucx_py_cu11.libs/ucx /usr/lib/ucx
-
 # install spark-rapids-ml
 unzip ${SPARK_RAPIDS_ML_ZIP} -d /databricks/python3/lib/python3.8/site-packages
 unzip ${BENCHMARK_ZIP} -d /databricks/python3/lib/python3.8/site-packages

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -32,11 +32,8 @@ ldconfig
 /databricks/python/bin/pip install --upgrade pip
 
 # install cudf and cuml
-#/databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} cuml-cu11==${RAPIDS_VERSION} --extra-index-url=https://pypi.ngc.nvidia.com
 /databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} \
 cuml-cu11==${RAPIDS_VERSION} \
-pylibraft-cu11==${RAPIDS_VERSION} \
-rmm-cu11==${RAPIDS_VERSION} \
 --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml

--- a/python/src/spark_rapids_ml/common/cuml_context.py
+++ b/python/src/spark_rapids_ml/common/cuml_context.py
@@ -21,7 +21,11 @@ from asyncio import AbstractEventLoop
 from typing import Any, List, Optional, Tuple
 
 import psutil
-from pylibraft.common import Handle
+
+# need this first to load shared ucx shared libraries from ucx-py instead of raft-dask
+from ucp import Endpoint
+
+from pylibraft.common import Handle  # isort: split
 from pyspark import BarrierTaskContext
 from raft_dask.common import UCX
 from raft_dask.common.comms_utils import (
@@ -29,7 +33,6 @@ from raft_dask.common.comms_utils import (
     inject_comms_on_handle_coll_only,
 )
 from raft_dask.common.nccl import nccl
-from ucp import Endpoint
 
 
 class CumlContext:


### PR DESCRIPTION
This eliminates the need for the ucx symlink patch to the pip installed packages.