### PR TITLE
RFclassifier: Support entropy impurity when convering cuml trees to Spark

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -202,13 +202,6 @@ class RandomForestClassificationModel(
         self._rf_spark_model: Optional[SparkRandomForestClassificationModel] = None
 
     def cpu(self) -> SparkRandomForestClassificationModel:
-        if self.getImpurity() != "gini":
-            # TODO, support entropy impurity
-            raise ValueError(
-                "Can't convert to Spark RandomForestClassificationModel"
-                " when impurity is not gini"
-            )
-
         if self._rf_spark_model is None:
             sc = _get_spark_session().sparkContext
             assert sc._jvm is not None
@@ -218,7 +211,7 @@ class RandomForestClassificationModel(
 
             # Convert cuml trees to Spark trees
             trees = [
-                translate_trees(sc, trees)
+                translate_trees(sc, self.getImpurity(), trees)
                 for trees_json in self._model_json
                 for trees in json.loads(trees_json)
             ]


### PR DESCRIPTION
It depends on #200 which is already merged. Now it's open to review.

This PR supports entropy impurity for RandomForestClassificationModel when converting cuml trees to spark. And it adds a checking that compares if the prediction results are the same using Spark-Rapids-ML RandomForestClassificationModel and the CPU RandomForestClassificationModel model converted by `cpu()` API. 