### PR TITLE
[hot fix] set pyspark upper bond dependency [skip ci]

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-pyspark>=3.2.1
+pyspark>=3.2.1,<3.4
 scikit-learn>=1.2.1


### PR DESCRIPTION
Recently, Spark has released 3.4.0 which has blocked our testing. After fixing the issues, we will update the pyspark upper bond dependency.