### PR TITLE
Support mixed model for Rf regression model

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -63,6 +63,7 @@ _default_conf = {
     "spark.python.worker.reuse": "false",
     "spark.driver.host": "127.0.0.1",
     "spark.task.maxFailures": "1",
+    "spark.driver.memory": "5g",
     "spark.sql.execution.pyspark.udf.simplifiedTraceback.enabled": "false",
     "spark.sql.pyspark.jvmStacktrace.enabled": "true",
 }


### PR DESCRIPTION
This is the final PR to support random forest mixed model. Since the model size passed from executor to driver resulted in OOM of java space, I just increased the driver/executor memory to bypass this issue. Later I will check how to improve this part.