### PR TITLE
make spark-rapids-ml run on the driver without rapids libraries

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Callable, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Type, Union
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
+
 import numpy as np
 import pandas as pd
 from pyspark import Row
@@ -221,11 +223,11 @@ class RandomForestClassificationModel(
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],
-        Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
     ]:
         _construct_rf, _ = super()._get_cuml_transform_func(dataset)
 
-        def _predict(rf: CumlT, pdf: Union[cudf.DataFrame, np.ndarray]) -> pd.Series:
+        def _predict(rf: CumlT, pdf: Union["cudf.DataFrame", np.ndarray]) -> pd.Series:
             data = {}
             rf.update_labels = False
             data[pred.prediction] = rf.predict(pdf)

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -14,9 +14,21 @@
 # limitations under the License.
 #
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
+
 import numpy as np
 import pandas as pd
 from pyspark.ml.clustering import KMeansModel as SparkKMeansModel
@@ -390,7 +402,7 @@ class KMeansModel(KMeansClass, _CumlModelSupervised, _KMeansCumlParams):
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],
-        Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
     ]:
         cuml_alg_params = self.cuml_params.copy()
 

--- a/python/src/spark_rapids_ml/common/cuml_context.py
+++ b/python/src/spark_rapids_ml/common/cuml_context.py
@@ -22,8 +22,8 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import psutil
 
-# need this first to load shared ucx shared libraries from ucx-py instead of raft-dask
 if TYPE_CHECKING:
+    # need this first to load shared ucx shared libraries from ucx-py instead of raft-dask
     from ucp import Endpoint
     from pylibraft.common import Handle  # isort: split
     from raft_dask.common import UCX
@@ -48,9 +48,11 @@ class CumlContext:
         2. do all gather for all the workers to get the nccl unique uid.
         3. if require_ucx is true, initialize ucx and inject ucx together with nccl into a handle
         """
+        # need this first to load shared ucx shared libraries from ucx-py instead of raft-dask
         from pylibraft.common import Handle
         from raft_dask.common import UCX
         from raft_dask.common.nccl import nccl
+        from ucp import Endpoint
 
         self.enable = enable
         self._handle: Optional["Handle"] = None

--- a/python/src/spark_rapids_ml/common/cuml_context.py
+++ b/python/src/spark_rapids_ml/common/cuml_context.py
@@ -49,10 +49,10 @@ class CumlContext:
         3. if require_ucx is true, initialize ucx and inject ucx together with nccl into a handle
         """
         # need this first to load shared ucx shared libraries from ucx-py instead of raft-dask
-        from pylibraft.common import Handle
+        from ucp import Endpoint
+        from pylibraft.common import Handle  # isort: split
         from raft_dask.common import UCX
         from raft_dask.common.nccl import nccl
-        from ucp import Endpoint
 
         self.enable = enable
         self._handle: Optional["Handle"] = None

--- a/python/src/spark_rapids_ml/common/cuml_context.py
+++ b/python/src/spark_rapids_ml/common/cuml_context.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,21 +18,18 @@ import base64
 import json
 import os
 from asyncio import AbstractEventLoop
-from typing import Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import psutil
 
 # need this first to load shared ucx shared libraries from ucx-py instead of raft-dask
-from ucp import Endpoint
+if TYPE_CHECKING:
+    from ucp import Endpoint
+    from pylibraft.common import Handle  # isort: split
+    from raft_dask.common import UCX
+    from raft_dask.common.nccl import nccl
 
-from pylibraft.common import Handle  # isort: split
 from pyspark import BarrierTaskContext
-from raft_dask.common import UCX
-from raft_dask.common.comms_utils import (
-    inject_comms_on_handle,
-    inject_comms_on_handle_coll_only,
-)
-from raft_dask.common.nccl import nccl
 
 
 class CumlContext:
@@ -51,8 +48,12 @@ class CumlContext:
         2. do all gather for all the workers to get the nccl unique uid.
         3. if require_ucx is true, initialize ucx and inject ucx together with nccl into a handle
         """
+        from pylibraft.common import Handle
+        from raft_dask.common import UCX
+        from raft_dask.common.nccl import nccl
+
         self.enable = enable
-        self._handle: Optional[Handle] = None
+        self._handle: Optional["Handle"] = None
         self._loop: Optional[AbstractEventLoop] = None
 
         if not enable:
@@ -63,9 +64,9 @@ class CumlContext:
         self._require_ucx = require_ucx
 
         self._handle = Handle(n_streams=0)
-        self._nccl_comm: Optional[nccl] = None
+        self._nccl_comm: Optional["nccl"] = None
         self._nccl_unique_id = None
-        self._ucx: Optional[UCX] = None
+        self._ucx: Optional["UCX"] = None
         self._ucx_port = None
         self._ucx_eps = None
 
@@ -100,18 +101,22 @@ class CumlContext:
             self._ports = [json.loads(msg)[1] for msg in msgs]
 
     @property
-    def handle(self) -> Optional[Handle]:
+    def handle(self) -> Optional["Handle"]:
         return self._handle
 
     def __enter__(self) -> "CumlContext":
         if not self.enable:
             return self
 
+        from raft_dask.common.nccl import nccl
+
         # initialize nccl and inject it to the handle. A GPU must be assigned exclusively before init() is called
         self._nccl_comm = nccl()
         self._nccl_comm.init(self._nranks, self._nccl_unique_id, self._rank)
 
         if self._require_ucx is False:
+            from raft_dask.common.comms_utils import inject_comms_on_handle_coll_only
+
             inject_comms_on_handle_coll_only(
                 self._handle, self._nccl_comm, self._nranks, self._rank, True
             )
@@ -125,6 +130,8 @@ class CumlContext:
                     )
                 )
             )
+
+            from raft_dask.common.comms_utils import inject_comms_on_handle
 
             inject_comms_on_handle(
                 self._handle,
@@ -161,10 +168,10 @@ class CumlContext:
 
     @staticmethod
     async def _ucp_create_endpoints(
-        ucx_worker: UCX,
+        ucx_worker: "UCX",
         target_ip_ports: List[Tuple[str, int]],
         additional_timeout: float = 0.1,
-    ) -> Endpoint:
+    ) -> "Endpoint":
         """
         ucp initialization may require a larger additional_timeout a complex network environment
         """

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -31,7 +31,8 @@ from typing import (
     Union,
 )
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
 import numpy as np
 import pandas as pd
 from pyspark import RDD, TaskContext
@@ -613,7 +614,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],
-        Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
     ]:
         """
         Subclass must implement this function to return two functions,

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -15,9 +15,11 @@
 #
 
 import itertools
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
+
 import numpy as np
 import pandas as pd
 from pyspark.ml import Model
@@ -348,7 +350,7 @@ class PCAModel(PCAClass, _CumlModelWithColumns, _PCACumlParams):
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],
-        Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
     ]:
         cuml_alg_params = self.cuml_params.copy()
 

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -15,9 +15,21 @@
 #
 
 import asyncio
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
+
 import numpy as np
 import pandas as pd
 from pyspark.ml.functions import vector_to_array
@@ -578,7 +590,7 @@ class NearestNeighborsModel(
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],
-        Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
     ]:
         raise NotImplementedError(
             "'_CumlModel._get_cuml_transform_func' method is not implemented. Use 'kneighbors' instead."

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -1,6 +1,21 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
-import cupy
 from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark.sql import SparkSession
 
@@ -312,6 +327,8 @@ class _CumlParams(_CumlClass, Params):
                 if _is_local(sc):
                     # assume using all local GPUs for Spark local mode
                     # TODO suggest using more CPUs (e.g. local[*]) if number of GPUs > number of CPUs
+                    import cupy
+
                     num_workers = cupy.cuda.runtime.getDeviceCount()
                 else:
                     num_executors = int(

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -12,9 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
+
 import numpy as np
 import pandas as pd
 from pyspark import Row
@@ -487,7 +500,7 @@ class LinearRegressionModel(
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],
-        Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
     ]:
         coef_ = self.coef_
         intercept_ = self.intercept_
@@ -505,7 +518,7 @@ class LinearRegressionModel(
 
             return lr
 
-        def _predict(lr: CumlT, pdf: Union[cudf.DataFrame, np.ndarray]) -> pd.Series:
+        def _predict(lr: CumlT, pdf: Union["cudf.DataFrame", np.ndarray]) -> pd.Series:
             ret = lr.predict(pdf)
             return pd.Series(ret)
 

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -18,9 +18,21 @@ import json
 import math
 import pickle
 from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
+
 import numpy as np
 import pandas as pd
 from pyspark.ml.classification import DecisionTreeClassificationModel
@@ -440,7 +452,7 @@ class _RandomForestModel(
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],
-        Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
     ]:
         treelite_model = self._treelite_model
 
@@ -459,7 +471,7 @@ class _RandomForestModel(
 
             return rf
 
-        def _predict(rf: CumlT, pdf: Union[cudf.DataFrame, np.ndarray]) -> pd.Series:
+        def _predict(rf: CumlT, pdf: Union["cudf.DataFrame", np.ndarray]) -> pd.Series:
             rf.update_labels = False
             ret = rf.predict(pdf)
             return pd.Series(ret)

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,19 +16,12 @@
 import inspect
 import logging
 import sys
-from typing import Any, Callable, Dict, List, Literal, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Tuple, Union
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
+
 import numpy as np
-
-try:
-    # Compatible with older cuml version (before 23.02)
-    from cuml.common.array import CumlArray
-    from cuml.common.input_utils import input_to_cuml_array
-except ImportError:
-    from cuml.common import input_to_cuml_array
-    from cuml.internals.array import CumlArray
-
 from pyspark import BarrierTaskContext, SparkContext, TaskContext
 from pyspark.sql import SparkSession
 
@@ -152,9 +145,12 @@ def _concat_and_free(
     return concated
 
 
-def cudf_to_cuml_array(
-    gdf: Union[cudf.DataFrame, cudf.Series], order: str = "F"
-) -> CumlArray:
+def cudf_to_cuml_array(gdf: Union["cudf.DataFrame", "cudf.Series"], order: str = "F"):  # type: ignore
+    try:
+        # Compatible with older cuml version (before 23.02)
+        from cuml.common.input_utils import input_to_cuml_array
+    except ImportError:
+        from cuml.common import input_to_cuml_array
     cumlarray, _, _, _ = input_to_cuml_array(gdf, order=order)
     return cumlarray
 

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -14,9 +14,21 @@
 # limitations under the License.
 #
 
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 
-import cudf
+if TYPE_CHECKING:
+    import cudf
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -260,7 +272,7 @@ class SparkRapidsMLDummyModel(
         self, dataset: DataFrame
     ) -> Tuple[
         Callable[..., CumlT],
-        Callable[[CumlT, Union[cudf.DataFrame, np.ndarray]], pd.DataFrame],
+        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
     ]:
         model_attribute_a = self.model_attribute_a
 


### PR DESCRIPTION
This PR wraps the rapids libraries into the TYPE_CHECKING branch for mypy check, and moves the rapids libraries imports into the code which should run on the executor.

The current auto-infer cuml parameter solution still needs to import the cuml counterpart class, which still breaks the rule that the spark-rapids-ml application should run on the driver without rapids libraries and GPU. So we need to figure out how to refactor this part.