### PR TITLE
Rework to get default cuml parameters

### DIFF
--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -45,15 +45,15 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from spark_rapids_ml.core import (
+from .core import (
     CumlInputType,
     CumlT,
     _CumlEstimator,
     _CumlModelSupervised,
     param_alias,
 )
-from spark_rapids_ml.params import HasFeaturesCols, P, _CumlClass, _CumlParams
-from spark_rapids_ml.utils import (
+from .params import HasFeaturesCols, P, _CumlClass, _CumlParams
+from .utils import (
     _ArrayOrder,
     _concat_and_free,
     _get_spark_session,
@@ -63,12 +63,6 @@ from spark_rapids_ml.utils import (
 
 
 class KMeansClass(_CumlClass):
-    @classmethod
-    def _cuml_cls(cls) -> List[type]:
-        from cuml import KMeans
-
-        return [KMeans]
-
     @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
         return {
@@ -82,16 +76,18 @@ class KMeansClass(_CumlClass):
             "weightCol": None,
         }
 
-    @classmethod
-    def _param_excludes(cls) -> List[str]:
-        """
-        For some reason, spark-rapids-ml may not support all the parameters.
-        In that case, we need to explicitly exclude them.
-        """
-        return [
-            "handle",
-            "output_type",
-        ]
+    def _get_cuml_params_default(self) -> Dict[str, Any]:
+        return {
+            "n_clusters": 8,
+            "max_iter": 300,
+            "tol": 0.0001,
+            "verbose": False,
+            "random_state": 1,
+            "init": "scalable-k-means++",
+            "n_init": 1,
+            "oversampling_factor": 2.0,
+            "max_samples_per_batch": 32768,
+        }
 
 
 class _KMeansCumlParams(_CumlParams, _KMeansParams, HasFeaturesCols):

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -31,8 +31,6 @@ from typing import (
     Union,
 )
 
-if TYPE_CHECKING:
-    import cudf
 import numpy as np
 import pandas as pd
 from pyspark import RDD, TaskContext
@@ -65,9 +63,9 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from spark_rapids_ml.common.cuml_context import CumlContext
-from spark_rapids_ml.params import _CumlParams
-from spark_rapids_ml.utils import (
+from .common.cuml_context import CumlContext
+from .params import _CumlParams
+from .utils import (
     _ArrayOrder,
     _get_gpu_id,
     _get_spark_session,
@@ -77,6 +75,7 @@ from spark_rapids_ml.utils import (
 )
 
 if TYPE_CHECKING:
+    import cudf
     from cuml.cluster.kmeans_mg import KMeansMG
     from cuml.decomposition.pca_mg import PCAMG
 

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 
 import numpy as np
 import pandas as pd
-from pyspark.ml import Model
 from pyspark.ml.common import _py2java
 from pyspark.ml.feature import PCAModel as SparkPCAModel
 from pyspark.ml.feature import _PCAParams
@@ -39,15 +38,15 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from spark_rapids_ml.core import (
+from .core import (
     CumlInputType,
     CumlT,
     _CumlEstimator,
     _CumlModelWithColumns,
     param_alias,
 )
-from spark_rapids_ml.params import P, _CumlClass, _CumlParams
-from spark_rapids_ml.utils import (
+from .params import P, _CumlClass, _CumlParams
+from .utils import (
     PartitionDescriptor,
     _get_spark_session,
     dtype_to_pyspark_type,
@@ -57,25 +56,16 @@ from spark_rapids_ml.utils import (
 
 class PCAClass(_CumlClass):
     @classmethod
-    def _cuml_cls(cls) -> List[type]:
-        from cuml import PCA
-
-        return [PCA]
-
-    @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
         return {"k": "n_components"}
 
-    @classmethod
-    def _param_excludes(cls) -> List[str]:
-        return [
-            "copy",
-            "handle",
-            "iterated_power",
-            "output_type",
-            "random_state",
-            "tol",
-        ]
+    def _get_cuml_params_default(self) -> Dict[str, Any]:
+        return {
+            "n_components": None,
+            "svd_solver": "auto",
+            "verbose": False,
+            "whiten": False,
+        }
 
 
 class _PCACumlParams(_CumlParams, _PCAParams, HasInputCols):

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -55,7 +55,7 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from spark_rapids_ml.core import (
+from .core import (
     CumlInputType,
     CumlT,
     _CumlCaller,
@@ -64,36 +64,17 @@ from spark_rapids_ml.core import (
     alias,
     param_alias,
 )
-from spark_rapids_ml.params import P, _CumlClass, _CumlParams
-from spark_rapids_ml.utils import _concat_and_free
+from .params import P, _CumlClass, _CumlParams
+from .utils import _concat_and_free
 
 
 class NearestNeighborsClass(_CumlClass):
     @classmethod
-    def _cuml_cls(cls) -> List[type]:
-        from cuml import NearestNeighbors as cumlNearestNeighbors
-        from cuml.neighbors.nearest_neighbors_mg import (
-            NearestNeighborsMG,  # to include the batch_size parameter that exists in the MG class
-        )
-
-        return [cumlNearestNeighbors, NearestNeighborsMG]
-
-    @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
         return {"k": "n_neighbors"}
 
-    @classmethod
-    def _param_excludes(cls) -> List[str]:
-        return [
-            "handle",
-            "algorithm",
-            "metric",
-            "p",
-            "algo_params",
-            "metric_expanded",
-            "metric_params",
-            "output_type",
-        ]
+    def _get_cuml_params_default(self) -> Dict[str, Any]:
+        return {"n_neighbors": 5, "verbose": False, "batch_size": 2000000}
 
 
 class _NearestNeighborsCumlParams(_CumlParams, HasInputCol, HasLabelCol, HasInputCols):

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -50,40 +50,26 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from spark_rapids_ml.core import (
+from .core import (
     CumlInputType,
     CumlT,
     _CumlEstimatorSupervised,
     _CumlModelSupervised,
     param_alias,
 )
-from spark_rapids_ml.params import HasFeaturesCols, P, _CumlClass, _CumlParams
-from spark_rapids_ml.tree import (
+from .params import HasFeaturesCols, P, _CumlClass, _CumlParams
+from .tree import (
     _RandomForestClass,
     _RandomForestCumlParams,
     _RandomForestEstimator,
     _RandomForestModel,
 )
-from spark_rapids_ml.utils import (
-    PartitionDescriptor,
-    _get_spark_session,
-    cudf_to_cuml_array,
-    java_uid,
-)
+from .utils import PartitionDescriptor, _get_spark_session, cudf_to_cuml_array, java_uid
 
 T = TypeVar("T")
 
 
 class LinearRegressionClass(_CumlClass):
-    @classmethod
-    def _cuml_cls(cls) -> List[type]:
-        # from cuml.dask.linear_model import LinearRegression
-        from cuml.linear_model.linear_regression import LinearRegression
-        from cuml.linear_model.ridge import Ridge
-        from cuml.solvers import CD
-
-        return [LinearRegression, Ridge, CD]
-
     @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
         return {
@@ -119,9 +105,20 @@ class LinearRegressionClass(_CumlClass):
             }.get(x, None),
         }
 
-    @classmethod
-    def _param_excludes(cls) -> List[str]:
-        return ["handle", "output_type"]
+    def _get_cuml_params_default(self) -> Dict[str, Any]:
+        return {
+            "algorithm": "eig",
+            "fit_intercept": True,
+            "normalize": False,
+            "verbose": False,
+            "alpha": 0.0001,
+            "solver": "eig",
+            "loss": "squared_loss",
+            "l1_ratio": 0.15,
+            "max_iter": 1000,
+            "tol": 0.001,
+            "shuffle": True,
+        }
 
 
 class _LinearRegressionCumlParams(

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -73,29 +73,6 @@ from .utils import (
 
 class _RandomForestClass(_CumlClass):
     @classmethod
-    def _cuml_cls(cls) -> List[type]:
-        from cuml.ensemble.randomforest_common import BaseRandomForestModel
-
-        return [BaseRandomForestModel]
-
-    @classmethod
-    def _param_excludes(cls) -> List[str]:
-        return [
-            "handle",
-            "output_type",
-            "accuracy_metric",
-            "dtype",
-            "criterion",
-            "min_weight_fraction_leaf",
-            "max_leaf_nodes",
-            "min_impurity_split",
-            "oob_score",
-            "n_jobs",
-            "warm_start",
-            "class_weight",
-        ]
-
-    @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
         return {
             "maxBins": "n_bins",
@@ -138,6 +115,24 @@ class _RandomForestClass(_CumlClass):
 
         return {
             "max_features": _tree_mapping,
+        }
+
+    def _get_cuml_params_default(self) -> Dict[str, Any]:
+        return {
+            "n_streams": 4,
+            "n_estimators": 100,
+            "max_depth": 16,
+            "max_features": "auto",
+            "n_bins": 128,
+            "bootstrap": True,
+            "verbose": False,
+            "min_samples_leaf": 1,
+            "min_samples_split": 2,
+            "max_samples": 1.0,
+            "max_leaves": -1,
+            "min_impurity_decrease": 0.0,
+            "random_state": None,
+            "max_batch_size": 4096,
         }
 
 

--- a/python/tests/test_kmeans.py
+++ b/python/tests/test_kmeans.py
@@ -32,6 +32,7 @@ from .utils import (
     create_pyspark_dataframe,
     cuml_supported_data_types,
     feature_types,
+    get_default_cuml_parameters,
     idfn,
     pyspark_supported_feature_types,
 )
@@ -51,6 +52,14 @@ def assert_centers_equal(
         b_center = b_clusters[i]
         assert len(a_center) == len(b_center)
         assert a_center == pytest.approx(b_center, tolerance)
+
+
+def test_default_cuml_params() -> None:
+    from cuml import KMeans as CumlKMeans
+
+    cuml_params = get_default_cuml_parameters([CumlKMeans], ["handle", "output_type"])
+    spark_params = KMeans()._get_cuml_params_default()
+    assert cuml_params == spark_params
 
 
 def test_kmeans_params(gpu_number: int, tmp_path: str) -> None:

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -33,6 +33,7 @@ from .utils import (
     create_pyspark_dataframe,
     cuml_supported_data_types,
     feature_types,
+    get_default_cuml_parameters,
     idfn,
     make_regression_dataset,
     pyspark_supported_feature_types,
@@ -78,6 +79,20 @@ def train_with_cuml_linear_regression(
 
     lr.fit(X, y)
     return lr
+
+
+def test_default_cuml_params() -> None:
+    from cuml.linear_model.linear_regression import (
+        LinearRegression as CumlLinearRegression,
+    )
+    from cuml.linear_model.ridge import Ridge
+    from cuml.solvers import CD
+
+    cuml_params = get_default_cuml_parameters(
+        [CumlLinearRegression, Ridge, CD], ["handle", "output_type"]
+    )
+    spark_params = LinearRegression()._get_cuml_params_default()
+    assert cuml_params == spark_params
 
 
 @pytest.mark.parametrize("reg", [0.0, 0.7])

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -13,9 +13,33 @@ from .sparksession import CleanSparkSession
 from .utils import (
     array_equal,
     create_pyspark_dataframe,
+    get_default_cuml_parameters,
     idfn,
     pyspark_supported_feature_types,
 )
+
+
+def test_default_cuml_params() -> None:
+    from cuml import NearestNeighbors as CumlNearestNeighbors
+    from cuml.neighbors.nearest_neighbors_mg import (
+        NearestNeighborsMG,  # to include the batch_size parameter that exists in the MG class
+    )
+
+    cuml_params = get_default_cuml_parameters(
+        [CumlNearestNeighbors, NearestNeighborsMG],
+        [
+            "handle",
+            "algorithm",
+            "metric",
+            "p",
+            "algo_params",
+            "metric_expanded",
+            "metric_params",
+            "output_type",
+        ],
+    )
+    spark_params = NearestNeighbors()._get_cuml_params_default()
+    assert cuml_params == spark_params
 
 
 def test_example(gpu_number: int, tmp_path: str) -> None:

--- a/python/tests/test_pca.py
+++ b/python/tests/test_pca.py
@@ -33,12 +33,31 @@ from .utils import (
     assert_params,
     create_pyspark_dataframe,
     cuml_supported_data_types,
+    get_default_cuml_parameters,
     idfn,
     pyspark_supported_feature_types,
 )
 
 PCAType = TypeVar("PCAType", Type[SparkPCA], Type[PCA])
 PCAModelType = TypeVar("PCAModelType", Type[SparkPCAModel], Type[PCAModel])
+
+
+def test_default_cuml_params() -> None:
+    from cuml import PCA as CumlPCA
+
+    cuml_params = get_default_cuml_parameters(
+        [CumlPCA],
+        [
+            "copy",
+            "handle",
+            "iterated_power",
+            "output_type",
+            "random_state",
+            "tol",
+        ],
+    )
+    spark_params = PCA()._get_cuml_params_default()
+    assert cuml_params == spark_params
 
 
 def test_fit(gpu_number: int) -> None:

--- a/python/tests/test_random_forest.py
+++ b/python/tests/test_random_forest.py
@@ -44,6 +44,7 @@ from .utils import (
     create_pyspark_dataframe,
     cuml_supported_data_types,
     feature_types,
+    get_default_cuml_parameters,
     idfn,
     make_classification_dataset,
     make_regression_dataset,
@@ -73,6 +74,31 @@ RandomForestModelType = TypeVar(
     Type[RandomForestClassificationModel],
     Type[RandomForestRegressionModel],
 )
+
+
+@pytest.mark.parametrize("Estimator", [RandomForestClassifier, RandomForestRegressor])
+def test_default_cuml_params(Estimator: RandomForest) -> None:
+    from cuml.ensemble.randomforest_common import BaseRandomForestModel
+
+    cuml_params = get_default_cuml_parameters(
+        [BaseRandomForestModel],
+        [
+            "handle",
+            "output_type",
+            "accuracy_metric",
+            "dtype",
+            "criterion",
+            "min_weight_fraction_leaf",
+            "max_leaf_nodes",
+            "min_impurity_split",
+            "oob_score",
+            "n_jobs",
+            "warm_start",
+            "class_weight",
+        ],
+    )
+    spark_params = Estimator()._get_cuml_params_default()
+    assert cuml_params == spark_params
 
 
 @pytest.mark.parametrize("RFEstimator", [RandomForestClassifier, RandomForestRegressor])

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -27,7 +27,7 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.model_selection import train_test_split
 
 from spark_rapids_ml.params import _CumlParams
-from spark_rapids_ml.utils import dtype_to_pyspark_type
+from spark_rapids_ml.utils import _get_default_params_from_func, dtype_to_pyspark_type
 
 FeatureTypes = namedtuple("FeatureTypes", ("vector", "array", "multi_cols"))
 feature_types = FeatureTypes("vector", "array", "multi_cols")
@@ -188,3 +188,12 @@ def make_classification_dataset(
         dataset = _make_classification_dataset_uncached(nrows, ncols, **kwargs)
 
     return map(lambda arr: arr.astype(datatype), dataset)
+
+
+def get_default_cuml_parameters(
+    cuml_classes: List[type], excludes: List[str] = []
+) -> Dict[str, Any]:
+    params = {}
+    for cuml_cls in cuml_classes:
+        params.update(_get_default_params_from_func(cuml_cls, excludes))
+    return params


### PR DESCRIPTION
This PR hardcodes all the default parameters which were inferred previously in order not to break the rule that spark-rapids-ml should run on the driver side without rapids dependencies.

And adds unit test to catch up with the cuml which may change the parameters.