### PR TITLE
revert db init script change

### DIFF
--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -33,6 +33,8 @@ ldconfig
 # install cudf, cuml and their rapids dependencies
 /databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} \
 cuml-cu11==${RAPIDS_VERSION} \
+pylibraft-cu11==${RAPIDS_VERSION} \
+rmm-cu11==${RAPIDS_VERSION} \
 --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml

--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -32,10 +32,10 @@ ldconfig
 
 # install cudf, cuml and their rapids dependencies
 /databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} \
-cuml-cu11==${RAPIDS_VERSION} \
-pylibraft-cu11==${RAPIDS_VERSION} \
-rmm-cu11==${RAPIDS_VERSION} \
---extra-index-url=https://pypi.nvidia.com
+    cuml-cu11==${RAPIDS_VERSION} \
+    pylibraft-cu11==${RAPIDS_VERSION} \
+    rmm-cu11==${RAPIDS_VERSION} \
+    --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml
 unzip ${SPARK_RAPIDS_ML_ZIP} -d /databricks/python3/lib/python3.8/site-packages

--- a/notebooks/dataproc/spark_rapids_ml.sh
+++ b/notebooks/dataproc/spark_rapids_ml.sh
@@ -8,6 +8,8 @@ mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"
 # install cudf and cuml
 pip install --upgrade pip
 pip install cudf-cu11==${RAPIDS_VERSION} cuml-cu11==${RAPIDS_VERSION} \
+    pylibraft-cu11==${RAPIDS_VERSION} \
+    rmm-cu11==${RAPIDS_VERSION} \
     --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -33,10 +33,10 @@ ldconfig
 
 # install cudf and cuml
 /databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} \
-cuml-cu11==${RAPIDS_VERSION} \
-pylibraft-cu11==${RAPIDS_VERSION} \
-rmm-cu11==${RAPIDS_VERSION} \
---extra-index-url=https://pypi.nvidia.com
+    cuml-cu11==${RAPIDS_VERSION} \
+    pylibraft-cu11==${RAPIDS_VERSION} \
+    rmm-cu11==${RAPIDS_VERSION} \
+    --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml
 unzip ${SPARK_RAPIDS_ML_ZIP} -d /databricks/python3/lib/python3.8/site-packages

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -34,6 +34,8 @@ ldconfig
 # install cudf and cuml
 /databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} \
 cuml-cu11==${RAPIDS_VERSION} \
+pylibraft-cu11==${RAPIDS_VERSION} \
+rmm-cu11==${RAPIDS_VERSION} \
 --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml

--- a/python/benchmark/dataproc/init_benchmark.sh
+++ b/python/benchmark/dataproc/init_benchmark.sh
@@ -16,6 +16,8 @@ mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"
 # install cudf and cuml
 pip install --upgrade pip
 pip install cudf-cu11==${RAPIDS_VERSION} cuml-cu11==${RAPIDS_VERSION} \
+    pylibraft-cu11==${RAPIDS_VERSION} \
+    rmm-cu11==${RAPIDS_VERSION} \
     --extra-index-url=https://pypi.nvidia.com
 
 # install benchmark files


### PR DESCRIPTION
It seemed pinning these dependencies wasn't necessary so removed them, but I just tried the benchmarks again and 23.04 versions of `rmm` and `pylibraft` were being pulled in causing the benchmarks to fail.

We still need 22.12 rapids version overall till we figure a10 issue on db so leaving that.