### PR TITLE
Run spark-rapids-ml on spark 3.4

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-pyspark>=3.2.1,<3.4
+pyspark>=3.2.1,<=3.4.0
 scikit-learn>=1.2.1

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -308,17 +308,17 @@ class _CumlParams(_CumlClass, Params):
                     num_workers = cupy.cuda.runtime.getDeviceCount()
                 else:
                     num_executors = int(
-                        spark.conf.get("spark.executor.instances", "-1")
+                        spark.conf.get("spark.executor.instances", "-1")  # type: ignore
                     )
                     if num_executors == -1:
                         jsc = spark.sparkContext._jsc.sc()
                         num_executors = len(jsc.statusTracker().getExecutorInfos()) - 1
 
                     gpus_per_executor = float(
-                        spark.conf.get("spark.executor.resource.gpu.amount", "1")
+                        spark.conf.get("spark.executor.resource.gpu.amount", "1")  # type: ignore
                     )
                     gpus_per_task = float(
-                        spark.conf.get("spark.task.resource.gpu.amount", "1")
+                        spark.conf.get("spark.task.resource.gpu.amount", "1")  # type: ignore
                     )
 
                     if gpus_per_task != 1:

--- a/python/tests/test_ucx.py
+++ b/python/tests/test_ucx.py
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import asyncio
 import json
 from typing import Iterator, List, Tuple

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,26 +52,22 @@ def test_clean_sparksession() -> None:
     conf = {"spark.sql.execution.arrow.maxRecordsPerBatch": str(1)}
     # Clean SparkSession with extra conf
     with CleanSparkSession(conf) as spark:
-        assert int(spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch")) == 1
+        assert spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch") == "1"
 
     # Clean SparkSession
     with CleanSparkSession() as spark:
-        assert (
-            int(spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch")) == 10000
-        )
+        assert spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch") == "10000"
 
     # Test Nested SparkSession
     with CleanSparkSession(conf) as spark:
-        assert int(spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch")) == 1
+        assert spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch") == "1"
 
         # Nested SparkSession will reset the conf
         with CleanSparkSession() as spark:
             assert (
-                int(spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch"))
-                == 10000
+                spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch")
+                == "10000"
             )
 
         # The conf has been reset.
-        assert (
-            int(spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch")) == 10000
-        )
+        assert spark.conf.get("spark.sql.execution.arrow.maxRecordsPerBatch") == "10000"


### PR DESCRIPTION
This PR makes spark-rapids-ml run against spark 3.4 by resolving the format checking. And it updates the requirements to the latest spark 3.4.0