### PR TITLE
update rapids dependencies to 23.4

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -35,7 +35,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
     && conda init
 
 # install cuML
-ARG CUML_VER=23.02
+ARG CUML_VER=23.04
 RUN conda install -c conda-forge mamba && \
     mamba install -y -c rapidsai -c nvidia -c conda-forge cuml=$CUML_VER python=3.8 cuda-toolkit=11.5 \
     && mamba clean --all -f -y

--- a/docker/Dockerfile.pip
+++ b/docker/Dockerfile.pip
@@ -18,7 +18,7 @@ ARG CUDA_VERSION=11.8.0
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04
 
 ARG PYSPARK_VERSION=3.3.1
-ARG RAPIDS_VERSION=23.02
+ARG RAPIDS_VERSION=23.4.0
 
 # Install packages to build spark-rapids-ml
 RUN apt-get update -y \
@@ -31,13 +31,14 @@ RUN apt-get update -y \
     && rm -rf /var/lib/apt/lists
 
 # install RAPIDS
+# using ~= pulls in micro version patches
 RUN pip install --no-cache-dir \
-    cudf-cu11==${RAPIDS_VERSION} \
-    cuml-cu11==${RAPIDS_VERSION} \
-    dask-cudf-cu11==${RAPIDS_VERSION} \
-    pylibraft-cu11==${RAPIDS_VERSION} \
-    raft-dask-cu11==${RAPIDS_VERSION} \
-    rmm-cu11==${RAPIDS_VERSION} \
+    cudf-cu11~=${RAPIDS_VERSION} \
+    cuml-cu11~=${RAPIDS_VERSION} \
+    dask-cudf-cu11~=${RAPIDS_VERSION} \
+    pylibraft-cu11~=${RAPIDS_VERSION} \
+    raft-dask-cu11~=${RAPIDS_VERSION} \
+    rmm-cu11~=${RAPIDS_VERSION} \
     --extra-index-url=https://pypi.nvidia.com
 
 # install python dependencies

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -17,7 +17,7 @@
 ARG CUDA_VERSION=11.5.2
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04
 
-ARG CUML_VERSION=23.02
+ARG CUML_VERSION=23.04
 
 # Install packages to build spark-rapids-ml
 RUN apt update -y \

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = 'spark-rapids-ml'
 copyright = '2023, NVIDIA'
 author = 'NVIDIA'
-release = '23.2.0'
+release = '23.4.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -41,7 +41,7 @@ If you already have a Databricks account, you can run the example notebooks on a
       spark.task.resource.gpu.amount 1
       spark.databricks.delta.preview.enabled true
       spark.python.worker.reuse true
-      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-22.12.0.jar:/databricks/spark/python
+      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-23.02.0.jar:/databricks/spark/python
       spark.sql.execution.arrow.maxRecordsPerBatch 100000
       spark.rapids.memory.gpu.minAllocFraction 0.0001
       spark.plugins com.nvidia.spark.SQLPlugin

--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # set portion of path below after /dbfs/ to dbfs zip file location
 SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/zip/file
-RAPIDS_VERSION=22.12.0
-SPARK_RAPIDS_VERSION=22.12.0
+# IMPORTANT: specify RAPIDS_VERSION fully 23.4.0 and not 23.4
+# also RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.4.0 and not 23.04.0)
+# while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.04.0 and not 23.4.0)
+RAPIDS_VERSION=23.4.0
+SPARK_RAPIDS_VERSION=23.02.0
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar
 
@@ -31,10 +34,11 @@ ldconfig
 /databricks/python/bin/pip install --upgrade pip
 
 # install cudf, cuml and their rapids dependencies
-/databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} \
-    cuml-cu11==${RAPIDS_VERSION} \
-    pylibraft-cu11==${RAPIDS_VERSION} \
-    rmm-cu11==${RAPIDS_VERSION} \
+# using ~= pulls in lates micro version patches
+/databricks/python/bin/pip install cudf-cu11~=${RAPIDS_VERSION} \
+    cuml-cu11~=${RAPIDS_VERSION} \
+    pylibraft-cu11~=${RAPIDS_VERSION} \
+    rmm-cu11~=${RAPIDS_VERSION} \
     --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml

--- a/notebooks/dataproc/spark_rapids_ml.sh
+++ b/notebooks/dataproc/spark_rapids_ml.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-RAPIDS_VERSION=23.2.0
+RAPIDS_VERSION=23.4.0
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"
 
 # install cudf and cuml
 pip install --upgrade pip
-pip install cudf-cu11==${RAPIDS_VERSION} cuml-cu11==${RAPIDS_VERSION} \
-    pylibraft-cu11==${RAPIDS_VERSION} \
-    rmm-cu11==${RAPIDS_VERSION} \
+pip install cudf-cu11~=${RAPIDS_VERSION} cuml-cu11~=${RAPIDS_VERSION} \
+    pylibraft-cu11~=${RAPIDS_VERSION} \
+    rmm-cu11~=${RAPIDS_VERSION} \
     --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml

--- a/python/README.md
+++ b/python/README.md
@@ -8,9 +8,9 @@ For simplicity, the following instructions just use Spark local mode, assuming a
 
 First, install RAPIDS cuML per [these instructions](https://rapids.ai/start.html).
 ```bash
-conda create -n rapids-23.02 \
+conda create -n rapids-23.04 \
     -c rapidsai -c nvidia -c conda-forge \
-    cuml=23.02 python=3.8 cudatoolkit=11.5
+    cuml=23.04 python=3.8 cudatoolkit=11.5
 ```
 
 **Note**: while testing, we recommend using conda or docker to simplify installation and isolate your environment while experimenting.  Once you have a working environment, you can then try installing directly, if necessary.
@@ -19,7 +19,7 @@ conda create -n rapids-23.02 \
 
 Once you have the conda environment, activate it and install the required packages.
 ```bash
-conda activate rapids-23.02
+conda activate rapids-23.04
 
 # for development access to notebooks, tests, and benchmarks
 git clone --branch main https://github.com/NVIDIA/spark-rapids-ml.git

--- a/python/benchmark/databricks/gpu_cluster_spec.sh
+++ b/python/benchmark/databricks/gpu_cluster_spec.sh
@@ -9,7 +9,7 @@ cat <<EOF
         "spark.task.cpus": "1",
         "spark.databricks.delta.preview.enabled": "true",
         "spark.python.worker.reuse": "true",
-        "spark.executorEnv.PYTHONPATH": "/databricks/jars/rapids-4-spark_2.12-22.12.0.jar:/databricks/spark/python",
+        "spark.executorEnv.PYTHONPATH": "/databricks/jars/rapids-4-spark_2.12-23.02.0.jar:/databricks/spark/python",
         "spark.sql.files.minPartitionNum": "2",
         "spark.sql.execution.arrow.maxRecordsPerBatch": "10000",
         "spark.executor.cores": "8",

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -2,8 +2,11 @@
 # set portion of path below after /dbfs/ to dbfs zip file location
 SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/spark-rapids-ml.zip
 BENCHMARK_ZIP=/dbfs/path/to/benchmark.zip
-RAPIDS_VERSION=22.12.0
-SPARK_RAPIDS_VERSION=22.12.0
+# IMPORTANT: specify rapids fully 23.4.0 and not 23.4
+# also RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.4.0 and not 23.04.0)
+# while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.04.0 and not 23.4.0)
+RAPIDS_VERSION=23.4.0
+SPARK_RAPIDS_VERSION=23.02.0
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar
 
@@ -32,10 +35,11 @@ ldconfig
 /databricks/python/bin/pip install --upgrade pip
 
 # install cudf and cuml
-/databricks/python/bin/pip install cudf-cu11==${RAPIDS_VERSION} \
-    cuml-cu11==${RAPIDS_VERSION} \
-    pylibraft-cu11==${RAPIDS_VERSION} \
-    rmm-cu11==${RAPIDS_VERSION} \
+# using ~= pulls in micro version patches
+/databricks/python/bin/pip install cudf-cu11~=${RAPIDS_VERSION} \
+    cuml-cu11~=${RAPIDS_VERSION} \
+    pylibraft-cu11~=${RAPIDS_VERSION} \
+    rmm-cu11~=${RAPIDS_VERSION} \
     --extra-index-url=https://pypi.nvidia.com
 
 # install spark-rapids-ml

--- a/python/benchmark/dataproc/init_benchmark.sh
+++ b/python/benchmark/dataproc/init_benchmark.sh
@@ -8,16 +8,17 @@ function get_metadata_attribute() {
   /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
 }
 
-RAPIDS_VERSION=$(get_metadata_attribute rapids-version 23.02)
+RAPIDS_VERSION=$(get_metadata_attribute rapids-version 23.4.0)
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"
 
 # install cudf and cuml
+# using ~= pulls in lates micro version patches
 pip install --upgrade pip
-pip install cudf-cu11==${RAPIDS_VERSION} cuml-cu11==${RAPIDS_VERSION} \
-    pylibraft-cu11==${RAPIDS_VERSION} \
-    rmm-cu11==${RAPIDS_VERSION} \
+pip install cudf-cu11~=${RAPIDS_VERSION} cuml-cu11~=${RAPIDS_VERSION} \
+    pylibraft-cu11~=${RAPIDS_VERSION} \
+    rmm-cu11~=${RAPIDS_VERSION} \
     --extra-index-url=https://pypi.nvidia.com
 
 # install benchmark files

--- a/python/benchmark/dataproc/start_cluster.sh
+++ b/python/benchmark/dataproc/start_cluster.sh
@@ -14,7 +14,7 @@ fi
 
 BENCHMARK_HOME=${BENCHMARK_HOME:-${GCS_BUCKET}/benchmark}
 CUDA_VERSION=${CUDA_VERSION:-11.8}
-RAPIDS_VERSION=${RAPIDS_VERSION:-23.02}
+RAPIDS_VERSION=${RAPIDS_VERSION:-23.4.0}
 
 gpu_args=$(cat <<EOF
 --master-accelerator type=nvidia-tesla-t4,count=1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spark-rapids-ml"
-version = "23.2.0"
+version = "23.4.0"
 authors = [
   { name="Jinfeng Li", email="jinfeng@nvidia.com" },
   { name="Bobby Wang", email="bobwang@nvidia.com" },

--- a/python/src/spark_rapids_ml/__init__.py
+++ b/python/src/spark_rapids_ml/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "23.2.0"
+__version__ = "23.4.0"


### PR DESCRIPTION
left spark rapids jar version at 23.02 as it is not yet updated to 23.04 in maven central

ran tests and benchmark ci docker image and on Databricks