### PR TITLE
updating remaining 23.02 in dataproc README; fix long knn test

### DIFF
--- a/notebooks/dataproc/README.md
+++ b/notebooks/dataproc/README.md
@@ -27,7 +27,7 @@ If you already have a Dataproc account, you can run the example notebooks on a D
 - Create a cluster with at least two single-gpu workers.  **Note**: in addition to the initialization script from above, this also uses the standard [initialization actions](https://github.com/GoogleCloudDataproc/initialization-actions) for installing the GPU drivers and RAPIDS:
   ```
   export CUDA_VERSION=11.8
-  export RAPIDS_VERSION=23.02
+  export RAPIDS_VERSION=23.4
 
   gcloud dataproc clusters create $USER-spark-rapids-ml \
   --image-version=2.0.29-ubuntu18 \

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -204,7 +204,7 @@ def test_example(gpu_number: int, tmp_path: str) -> None:
 
         assert len(knnjoin_queries) == len(query)
         for i in range(len(knnjoin_queries)):
-            if i is 2:
+            if i == 2:
                 assert array_equal(knnjoin_queries[i]["features"], query[i][0])
             else:
                 assert knnjoin_queries[i]["features"] == query[i][0]
@@ -358,17 +358,10 @@ def test_nearest_neighbors(
             item_df_withid.select(alias.row_number).toPandas()[alias.row_number]
         )
 
-        self_distance = [kdist[0] for kdist in distances]
-        assert array_equal(self_distance, [0.0 for i in range(data_shape[0])])
-        cuml_self_distance = [kdist[0] for kdist in cuml_distances]
-        assert array_equal(cuml_self_distance, [0.0 for i in range(data_shape[0])], 0.1)
-
-        # test kneighbors: compare non-self distances
+        # test kneighbors: compare distances
         assert len(distances) == len(cuml_distances)
-        nonself_distances = [knn[1:] for knn in distances]
-        cuml_nonself_distances = [knn[1:] for knn in cuml_distances]
         for i in range(len(distances)):
-            assert array_equal(nonself_distances[i], cuml_nonself_distances[i])
+            assert array_equal(distances[i], cuml_distances[i])
 
         # test exactNearestNeighborsJoin
         with pytest.raises(ValueError):


### PR DESCRIPTION
Updating knn test to compare cuml single node and spark rapids ml to each other, instead of to 0 for self-distance check.   Seems in 23.04 single node and mnmg knn now use similar code paths that use less accurate but faster distance computation:  https://docs.rapids.ai/api/cuml/stable/api/#cuml.neighbors.NearestNeighbors.kneighbors (see `two_pass_precision`) option.