### PR TITLE
RF classification: Support transform and evaluate in a single pass

### DIFF
--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -15,20 +15,7 @@
 #
 
 import asyncio
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
-
-if TYPE_CHECKING:
-    import cudf
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -56,13 +43,17 @@ from pyspark.sql.types import (
 )
 
 from .core import (
-    CumlInputType,
     CumlT,
+    FitInputType,
+    _ConstructFunc,
     _CumlCaller,
     _CumlEstimatorSupervised,
     _CumlModel,
+    _EvaluateFunc,
+    _TransformFunc,
     alias,
     param_alias,
+    transform_evaluate,
 )
 from .params import P, _CumlClass, _CumlParams
 from .utils import _concat_and_free
@@ -299,7 +290,7 @@ class NearestNeighbors(
 
     def _get_cuml_fit_func(  # type: ignore
         self, dataset: DataFrame
-    ) -> Callable[[CumlInputType, Dict[str, Any]], Dict[str, Any],]:
+    ) -> Callable[[FitInputType, Dict[str, Any]], Dict[str, Any],]:
         """
         This class overrides _fit and will not call _get_cuml_fit_func.
         """
@@ -444,13 +435,13 @@ class NearestNeighborsModel(
         self,
         dataset: DataFrame,
         extra_params: Optional[List[Dict[str, Any]]] = None,
-    ) -> Callable[[CumlInputType, Dict[str, Any]], Dict[str, Any],]:
+    ) -> Callable[[FitInputType, Dict[str, Any]], Dict[str, Any],]:
         label_isdata = self._label_isdata
         label_isquery = self._label_isquery
         id_col_name = self.getIdCol()
 
         def _cuml_fit(
-            dfs: CumlInputType,
+            dfs: FitInputType,
             params: Dict[str, Any],
         ) -> Dict[str, Any]:
             from pyspark import BarrierTaskContext
@@ -570,11 +561,8 @@ class NearestNeighborsModel(
         )
 
     def _get_cuml_transform_func(
-        self, dataset: DataFrame
-    ) -> Tuple[
-        Callable[..., CumlT],
-        Callable[[CumlT, Union["cudf.DataFrame", np.ndarray]], pd.DataFrame],
-    ]:
+        self, dataset: DataFrame, category: str = transform_evaluate.transform
+    ) -> Tuple[_ConstructFunc, _TransformFunc, Optional[_EvaluateFunc],]:
         raise NotImplementedError(
             "'_CumlModel._get_cuml_transform_func' method is not implemented. Use 'kneighbors' instead."
         )

--- a/python/src/spark_rapids_ml/metrics/MulticlassMetrics.py
+++ b/python/src/spark_rapids_ml/metrics/MulticlassMetrics.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Dict
+
+
+class MulticlassMetrics:
+    """Metrics for multiclass classification."""
+
+    # This class is aligning with MulticlassMetrics scala version.
+
+    def __init__(
+        self,
+        num_class: int,
+        tp: Dict[float, float],
+        fp: Dict[float, float],
+        label: Dict[float, float],
+        label_count: int,
+    ) -> None:
+        if num_class <= 2:
+            raise RuntimeError(
+                f"MulticlassMetrics requires at least 3 classes. Found {num_class}"
+            )
+
+        self._num_classes = 3
+        self._tp_by_class = tp
+        self._fp_by_class = fp
+        self._label_count_by_class = label
+        self._label_count = label_count
+
+    def _precision(self, label: float) -> float:
+        """Returns precision for a given label (category)"""
+        tp = self._tp_by_class[label]
+        fp = self._fp_by_class[label]
+        return 0.0 if (tp + fp == 0) else tp / (tp + fp)
+
+    def _recall(self, label: float) -> float:
+        """Returns recall for a given label (category)"""
+        return self._tp_by_class[label] / self._label_count_by_class[label]
+
+    def _f_measure(self, label: float, beta: float = 1.0) -> float:
+        """Returns f-measure for a given label (category)"""
+        p = self._precision(label)
+        r = self._recall(label)
+        beta_sqrd = beta * beta
+        return 0.0 if (p + r == 0) else (1 + beta_sqrd) * p * r / (beta_sqrd * p + r)
+
+    def weighted_fmeasure(self, beta: float = 1.0) -> float:
+        """Returns weighted averaged f1-measure"""
+        sum = 0.0
+        for k, v in self._label_count_by_class.items():
+            sum += self._f_measure(k, beta) * v / self._label_count
+        return sum

--- a/python/src/spark_rapids_ml/metrics/__init__.py
+++ b/python/src/spark_rapids_ml/metrics/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#


### PR DESCRIPTION
This PR only supports transformEvalute for multi-classes.