### PR TITLE
RandomForest: Support fit multiple models in a single pass

### DIFF
--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -269,7 +269,9 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
         return "C"
 
     def _get_cuml_fit_func(
-        self, dataset: DataFrame
+        self,
+        dataset: DataFrame,
+        extra_params: Optional[List[Dict[str, Any]]] = None,
     ) -> Callable[[CumlInputType, Dict[str, Any]], Dict[str, Any],]:
         cls = self.__class__
 

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -427,7 +427,9 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                 for k, v in paramMap.items():
                     name = self._get_cuml_param(k.name, False)
                     assert name is not None
-                    tmp_fit_multiple_params[name] = v
+                    tmp_fit_multiple_params[name] = self._get_cuml_mapping_value(
+                        name, v
+                    )
                 fit_multiple_params.append(tmp_fit_multiple_params)
         params[param_alias.fit_multiple_params] = fit_multiple_params
 

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -536,7 +536,6 @@ class _FitMultipleIterator(Generic[CumlModel]):
     def __init__(
         self, fitMultipleModels: Callable[[], List[CumlModel]], numModels: int
     ):
-        """ """
         self.fitMultipleModels = fitMultipleModels
         self.numModels = numModels
         self.counter = 0

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -518,7 +518,7 @@ class _CumlCaller(_CumlParams, _CumlCommon):
 class _FitMultipleIterator(Generic[CumlModel]):
     """
     Used by default implementation of Estimator.fitMultiple to produce models in a thread safe
-    iterator. This class handles the gpu versioned of fitMultiple where all param maps should be
+    iterator. This class handles the gpu version of fitMultiple where all param maps should be
     fit in a single pass.
 
     Parameters

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -175,7 +175,9 @@ class PCA(PCAClass, _CumlEstimator, _PCACumlParams):
         return self.set_params(k=value)
 
     def _get_cuml_fit_func(
-        self, dataset: DataFrame
+        self,
+        dataset: DataFrame,
+        extra_params: Optional[List[Dict[str, Any]]] = None,
     ) -> Callable[[CumlInputType, Dict[str, Any]], Dict[str, Any],]:
         def _cuml_fit(
             dfs: CumlInputType,

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -440,8 +440,10 @@ class NearestNeighborsModel(
 
         return (self._item_df_withid, query_df_withid, knn_df)
 
-    def _get_cuml_fit_func(  # type: ignore
-        self, dataset: DataFrame
+    def _get_cuml_fit_func(
+        self,
+        dataset: DataFrame,
+        extra_params: Optional[List[Dict[str, Any]]] = None,
     ) -> Callable[[CumlInputType, Dict[str, Any]], Dict[str, Any],]:
         label_isdata = self._label_isdata
         label_isquery = self._label_isquery

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -318,7 +318,9 @@ class LinearRegression(
         return select_cols, multi_col_names, dimension, feature_type
 
     def _get_cuml_fit_func(
-        self, dataset: DataFrame
+        self,
+        dataset: DataFrame,
+        extra_params: Optional[List[Dict[str, Any]]] = None,
     ) -> Callable[[CumlInputType, Dict[str, Any]], Dict[str, Any],]:
         def _linear_regression_fit(
             dfs: CumlInputType,

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -372,14 +372,6 @@ class _RandomForestEstimator(
                     return {}
 
             rf_params = params[param_alias.cuml_init]
-            if rf_params["max_features"] == "auto":
-                if total_trees == 1:
-                    rf_params["max_features"] = 1.0
-                else:
-                    rf_params["max_features"] = (
-                        "sqrt" if is_classification else (1 / 3.0)
-                    )
-
             fit_multiple_params = params[param_alias.fit_multiple_params]
 
             if len(fit_multiple_params) == 0:

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -288,6 +288,22 @@ class _RandomForestEstimator(
             dfs: CumlInputType,
             params: Dict[str, Any],
         ) -> Dict[str, Any]:
+            # 1. prepare the dataset
+            X_list = [item[0] for item in dfs]
+            y_list = [item[1] for item in dfs]
+            if isinstance(X_list[0], pd.DataFrame):
+                X = pd.concat(X_list)
+                y = pd.concat(y_list)
+            else:
+                # should be list of np.ndarrays here
+                X = _concat_and_free(cast(List[np.ndarray], X_list))
+                y = _concat_and_free(cast(List[np.ndarray], y_list))
+
+            if is_classification:
+                from cuml import RandomForestClassifier as cuRf
+            else:
+                from cuml import RandomForestRegressor as cuRf
+
             from pyspark import BarrierTaskContext
 
             context = BarrierTaskContext.get()
@@ -304,70 +320,78 @@ class _RandomForestEstimator(
                         "sqrt" if is_classification else (1 / 3.0)
                     )
 
-            if is_classification:
-                from cuml import RandomForestClassifier as cuRf
-            else:
-                from cuml import RandomForestRegressor as cuRf
+            def _single_fit(rf: cuRf) -> Dict[str, Any]:
+                # Fit a random forest model on the dataset (X, y)
+                rf.fit(X, y, convert_dtype=False)
 
-            rf = cuRf(
-                n_estimators=n_estimators_per_worker[part_id],
-                output_type="cudf",
-                **rf_params,
-            )
+                # serialized_model is Dictionary type
+                serialized_model = rf._get_serialized_model()
+                pickled_model = pickle.dumps(serialized_model)
+                msg = base64.b64encode(pickled_model).decode("utf-8")
+                trees = rf.get_json()
+                data = {"model_bytes": msg, "model_json": trees}
+                messages = context.allGather(json.dumps(data))
 
-            X_list = [item[0] for item in dfs]
-            y_list = [item[1] for item in dfs]
-            if isinstance(X_list[0], pd.DataFrame):
-                X = pd.concat(X_list)
-                y = pd.concat(y_list)
-            else:
-                # should be list of np.ndarrays here
-                X = _concat_and_free(cast(List[np.ndarray], X_list))
-                y = _concat_and_free(cast(List[np.ndarray], y_list))
+                # concatenate the random forest in the worker0
+                if part_id == 0:
+                    mod_bytes = []
+                    mod_jsons = []
+                    for msg in messages:
+                        data = json.loads(msg)
+                        mod_bytes.append(
+                            pickle.loads(base64.b64decode(data["model_bytes"]))
+                        )
+                        mod_jsons.append(data["model_json"])
 
-            # Fit a random forest model on the dataset (X, y)
-            rf.fit(X, y, convert_dtype=False)
+                    all_tl_mod_handles = [
+                        rf._tl_handle_from_bytes(i) for i in mod_bytes
+                    ]
+                    rf._concatenate_treelite_handle(all_tl_mod_handles)
 
-            # serialized_model is Dictionary type
-            serialized_model = rf._get_serialized_model()
-            pickled_model = pickle.dumps(serialized_model)
-            msg = base64.b64encode(pickled_model).decode("utf-8")
-            trees = rf.get_json()
-            data = {"model_bytes": msg, "model_json": trees}
-            messages = context.allGather(json.dumps(data))
+                    from cuml.fil.fil import TreeliteModel
 
-            # concatenate the random forest in the worker0
+                    for tl_handle in all_tl_mod_handles:
+                        TreeliteModel.free_treelite_model(tl_handle)
+
+                    final_model_bytes = pickle.dumps(rf._get_serialized_model())
+                    final_model = base64.b64encode(final_model_bytes).decode("utf-8")
+                    result = {
+                        "treelite_model": final_model,
+                        "dtype": rf.dtype.name,
+                        "n_cols": rf.n_cols,
+                        "model_json": mod_jsons,
+                    }
+
+                    if is_classification:
+                        result["num_classes"] = rf.num_classes
+
+                    return result
+                else:
+                    return {}
+
+            fit_multiple_params = params[param_alias.fit_multiple_params]
+
+            if len(fit_multiple_params) == 0:
+                fit_multiple_params.append({})
+
+            models = []
+            for i in range(len(fit_multiple_params)):
+                tmp_rf_params = rf_params.copy()
+                tmp_rf_params.update(fit_multiple_params[i])
+                rf = cuRf(
+                    n_estimators=n_estimators_per_worker[part_id],
+                    output_type="cudf",
+                    **tmp_rf_params,
+                )
+                models.append(_single_fit(rf))
+                del rf
+
+            models_dict = {}
+
             if part_id == 0:
-                mod_bytes = []
-                mod_jsons = []
-                for msg in messages:
-                    data = json.loads(msg)
-                    mod_bytes.append(
-                        pickle.loads(base64.b64decode(data["model_bytes"]))
-                    )
-                    mod_jsons.append(data["model_json"])
-
-                all_tl_mod_handles = [rf._tl_handle_from_bytes(i) for i in mod_bytes]
-                rf._concatenate_treelite_handle(all_tl_mod_handles)
-
-                from cuml.fil.fil import TreeliteModel
-
-                for tl_handle in all_tl_mod_handles:
-                    TreeliteModel.free_treelite_model(tl_handle)
-
-                final_model_bytes = pickle.dumps(rf._get_serialized_model())
-                final_model = base64.b64encode(final_model_bytes).decode("utf-8")
-                result = {
-                    "treelite_model": [final_model],
-                    "dtype": rf.dtype.name,
-                    "n_cols": rf.n_cols,
-                    "model_json": [mod_jsons],
-                }
-                if is_classification:
-                    result["num_classes"] = rf.num_classes
-                return result
-            else:
-                return {}
+                for k in models[0].keys():
+                    models_dict[k] = [m[k] for m in models]
+            return models_dict
 
         return _rf_fit
 
@@ -385,6 +409,9 @@ class _RandomForestEstimator(
 
     def _require_nccl_ucx(self) -> Tuple[bool, bool]:
         return False, False
+
+    def _enable_fit_mulitple_in_single_pass(self) -> bool:
+        return True
 
 
 class _RandomForestModel(

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -398,7 +398,6 @@ class _RandomForestEstimator(
                         tmp_rf_params["max_features"] = (
                             "sqrt" if is_classification else (1 / 3.0)
                         )
-
                 rf = cuRf(
                     n_estimators=n_estimators_of_all_params[i][part_id],
                     output_type="cudf",

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -172,7 +172,9 @@ class SparkRapidsMLDummy(
         return self.set_params(**{"k": value})
 
     def _get_cuml_fit_func(
-        self, dataset: DataFrame
+        self,
+        dataset: DataFrame,
+        extra_params: Optional[List[Dict[str, Any]]] = None,
     ) -> Callable[[CumlInputType, Dict[str, Any]], Dict[str, Any],]:
         num_workers = self.num_workers
         partition_num = self.partition_num


### PR DESCRIPTION
This PR overrides fitMultiple for RandomForest to fit multiple models in a single pass.