### PR TITLE
Fix a bug cuml parameters have not been updated

### DIFF
--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -178,17 +178,23 @@ class _CumlParams(_CumlClass, Params):
 
     def copy(self: P, extra: Optional["ParamMap"] = None) -> P:
         # override this function to update cuml_params if possible
+        instance: P = super().copy(extra)
+        cuml_params = instance.cuml_params.copy()
+
         if isinstance(extra, dict):
             for param, value in extra.items():
                 if isinstance(param, Param):
-                    self._set_cuml_param(param.name, value, silent=False)
+                    name = instance._get_cuml_param(param.name, silent=False)
+                    if name is not None:
+                        cuml_params[name] = value
                 else:
                     raise TypeError(
                         "Expecting a valid instance of Param, but received: {}".format(
                             param
                         )
                     )
-        return super().copy(extra)
+        instance._cuml_params = cuml_params
+        return instance
 
     def initialize_cuml_params(self) -> None:
         """

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -15,12 +15,25 @@
 #
 
 from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark.sql import SparkSession
 
 from .utils import _is_local
+
+if TYPE_CHECKING:
+    from pyspark.ml._typing import ParamMap
 
 P = TypeVar("P", bound="_CumlParams")
 
@@ -162,6 +175,20 @@ class _CumlParams(_CumlClass, Params):
     @num_workers.setter
     def num_workers(self, value: int) -> None:
         self._num_workers = value
+
+    def copy(self: P, extra: Optional["ParamMap"] = None) -> P:
+        # override this function to update cuml_params if possible
+        if isinstance(extra, dict):
+            for param, value in extra.items():
+                if isinstance(param, Param):
+                    self._set_cuml_param(param.name, value, silent=False)
+                else:
+                    raise TypeError(
+                        "Expecting a valid instance of Param, but received: {}".format(
+                            param
+                        )
+                    )
+        return super().copy(extra)
 
     def initialize_cuml_params(self) -> None:
         """
@@ -338,6 +365,27 @@ class _CumlParams(_CumlClass, Params):
 
         return num_workers
 
+    def _get_cuml_param(self, spark_param: str, silent: bool = True) -> Optional[str]:
+        param_map = self._param_mapping()
+
+        if spark_param in param_map:
+            cuml_param = param_map[spark_param]
+            if cuml_param is None:
+                if not silent:
+                    # if Spark Param is mapped to None, raise error
+                    raise ValueError(
+                        f"Spark Param '{spark_param}' is not supported by cuML."
+                    )
+            elif cuml_param == "":
+                # if Spark Param is mapped to empty string, warn and continue
+                if not silent:
+                    print(f"WARNING: Spark Param '{spark_param}' is not used by cuML.")
+                cuml_param = None
+
+            return cuml_param
+        else:
+            return None
+
     def _set_cuml_param(
         self, spark_param: str, spark_value: Any, silent: bool = True
     ) -> None:
@@ -357,22 +405,12 @@ class _CumlParams(_CumlClass, Params):
         ValueError
             If the Spark Param is explictly not supported.
         """
-        param_map = self._param_mapping()
-        if spark_param in param_map:
-            cuml_param = param_map[spark_param]
-            if cuml_param is None:
-                if not silent:
-                    # if Spark Param is mapped to None, raise error
-                    raise ValueError(
-                        f"Spark Param '{spark_param}' is not supported by cuML."
-                    )
-            elif cuml_param == "":
-                # if Spark Param is mapped to empty string, warn and continue
-                if not silent:
-                    print(f"WARNING: Spark Param '{spark_param}' is not used by cuML.")
-            else:
-                # if Spark Param is mapped to cuML parameter, set cuml_params
-                self._set_cuml_value(cuml_param, spark_value)
+
+        cuml_param = self._get_cuml_param(spark_param, silent)
+
+        if cuml_param is not None:
+            # if Spark Param is mapped to cuML parameter, set cuml_params
+            self._set_cuml_value(cuml_param, spark_value)
 
     def _set_cuml_value(self, k: str, v: Any) -> None:
         """

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -133,7 +133,12 @@ class SparkRapidsMLDummy(
     """
 
     def __init__(
-        self, m: int = 0, n: int = 0, partition_num: int = 0, **kwargs: Any
+        self,
+        m: int = 0,
+        n: int = 0,
+        partition_num: int = 0,
+        runtime_check: bool = True,
+        **kwargs: Any,
     ) -> None:
         #
 
@@ -142,6 +147,11 @@ class SparkRapidsMLDummy(
         self.m = m
         self.n = n
         self.partition_num = partition_num
+        self.runtime_check = runtime_check
+
+    """
+    PySpark estimator of CumlDummy
+    """
 
     def setInputCols(self, value: List[str]) -> "SparkRapidsMLDummy":
         return self._set(inputCols=value)
@@ -173,6 +183,8 @@ class SparkRapidsMLDummy(
         # it will throw exception since dataset is not picklable.
         self.test_pickle_dataframe = dataset
 
+        runtime_check = self.runtime_check
+
         def _cuml_fit(
             dfs: CumlInputType,
             params: Dict[str, Any],
@@ -187,19 +199,21 @@ class SparkRapidsMLDummy(
                 params[param_alias.part_sizes], params[param_alias.num_cols]
             )
 
-            assert pd.rank == context.partitionId()
-            assert len(pd.parts_rank_size) == partition_num
-            assert pd.m == m
-            assert pd.n == n
-
             assert param_alias.cuml_init in params
             init_params = params[param_alias.cuml_init]
-            assert init_params == {"a": 100, "k": 4, "x": 40.0}
             dummy = CumlDummy(**init_params)
-            assert dummy.a == 100
-            assert dummy.b == 20
-            assert dummy.k == 4
-            assert dummy.x == 40.0
+
+            if runtime_check:
+                assert pd.rank == context.partitionId()
+                assert len(pd.parts_rank_size) == partition_num
+                assert pd.m == m
+                assert pd.n == n
+
+                assert init_params == {"a": 100, "k": 4, "x": 40.0}
+                assert dummy.a == 100
+                assert dummy.b == 20
+                assert dummy.k == 4
+                assert dummy.x == 40.0
 
             import time
 
@@ -325,7 +339,9 @@ def test_dummy_params(gpu_number: int, tmp_path: str) -> None:
 
     # Spark constructor (with ignored param "gamma")
     spark_params = {"alpha": 2.0, "gamma": "test", "k": 1}
-    spark_dummy = SparkRapidsMLDummy(m=0, n=0, partition_num=0, **spark_params)
+    spark_dummy = SparkRapidsMLDummy(
+        m=0, n=0, partition_num=0, runtime_check=True, **spark_params
+    )
     expected_spark_params = default_spark_params.copy()
     expected_spark_params.update(spark_params)
     expected_cuml_params = default_cuml_params.copy()
@@ -334,7 +350,9 @@ def test_dummy_params(gpu_number: int, tmp_path: str) -> None:
 
     # cuML constructor
     cuml_params = {"a": 1.1, "k": 2, "x": 3.3}
-    cuml_dummy = SparkRapidsMLDummy(m=0, n=0, partition_num=0, **cuml_params)
+    cuml_dummy = SparkRapidsMLDummy(
+        m=0, n=0, partition_num=0, runtime_check=True, **cuml_params
+    )
     expected_spark_params = default_spark_params.copy()
     expected_spark_params.update(
         {
@@ -356,12 +374,16 @@ def test_dummy_params(gpu_number: int, tmp_path: str) -> None:
     # Spark constructor (with error param "beta")
     spark_params = {"alpha": 2.0, "beta": 0, "k": 1}
     with pytest.raises(ValueError, match="Spark Param 'beta' is not supported by cuML"):
-        spark_dummy = SparkRapidsMLDummy(m=0, n=0, partition_num=0, **spark_params)
+        spark_dummy = SparkRapidsMLDummy(
+            m=0, n=0, partition_num=0, runtime_check=True, **spark_params
+        )
 
     # cuML constructor (with unsupported param "b")
     cuml_params = {"a": 1.1, "b": 0, "k": 2, "x": 3.3}
     with pytest.raises(ValueError, match="Unsupported param 'b'"):
-        cuml_dummy = SparkRapidsMLDummy(m=0, n=0, partition_num=0, **cuml_params)
+        cuml_dummy = SparkRapidsMLDummy(
+            m=0, n=0, partition_num=0, runtime_check=True, **cuml_params
+        )
 
     # test the parameter copy
     dummy = SparkRapidsMLDummy()
@@ -442,6 +464,21 @@ def test_dummy(gpu_number: int, tmp_path: str) -> None:
             dummy2.fit(df, {dummy2.alpha: 9876.0})
         assert dummy2.cuml_params["a"] == 100
         assert dummy2.getOrDefault(dummy2.alpha) == 100
+
+        dummy3 = SparkRapidsMLDummy(
+            inputCols=input_cols,
+            a=100,
+            num_workers=gpu_number,
+            partition_num=ceiling_division(m, max_records_per_batch),
+            m=m,
+            n=n,
+            runtime_check=False,  # don't assert on the runtime.
+        )
+        model3 = dummy3.fit(df, {dummy3.alpha: 9876.0})
+        assert dummy3.cuml_params["a"] == 100
+        assert dummy3.getOrDefault(dummy3.alpha) == 100
+        assert model3.cuml_params["a"] == 9876.0
+        assert model3.getOrDefault(model3.alpha) == 9876.0
 
         # Transform the training dataset with a clean spark
         with CleanSparkSession() as clean_spark:

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -425,6 +425,15 @@ def test_dummy(gpu_number: int, tmp_path: str) -> None:
         model_loaded = SparkRapidsMLDummyModel.load(model_path)
         assert_model(model_loaded)
 
+        dummy2 = dummy.copy()
+        assert dummy2.cuml_params["a"] == 100
+        with pytest.raises(
+            Exception,
+            match="assert {'a': 9876, 'k': 4, 'x': 40.0} == {'a': 100, 'k': 4, 'x': 40.0}",
+        ):
+            dummy2.fit(df, {dummy2.alpha: 9876})
+        assert dummy2.cuml_params["a"] == 9876
+
         # Transform the training dataset with a clean spark
         with CleanSparkSession() as clean_spark:
             test_df = clean_spark.sparkContext.parallelize(data, m).toDF(input_cols)

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -363,6 +363,14 @@ def test_dummy_params(gpu_number: int, tmp_path: str) -> None:
     with pytest.raises(ValueError, match="Unsupported param 'b'"):
         cuml_dummy = SparkRapidsMLDummy(m=0, n=0, partition_num=0, **cuml_params)
 
+    # test the parameter copy
+    dummy = SparkRapidsMLDummy()
+    dummy2 = dummy.copy({dummy.alpha: 1111})
+    assert dummy.getOrDefault(dummy.alpha) == 1
+    assert dummy.cuml_params["a"] == 1
+    assert dummy2.getOrDefault(dummy.alpha) == 1111
+    assert dummy2.cuml_params["a"] == 1111
+
 
 def test_dummy(gpu_number: int, tmp_path: str) -> None:
     data = [
@@ -429,10 +437,11 @@ def test_dummy(gpu_number: int, tmp_path: str) -> None:
         assert dummy2.cuml_params["a"] == 100
         with pytest.raises(
             Exception,
-            match="assert {'a': 9876, 'k': 4, 'x': 40.0} == {'a': 100, 'k': 4, 'x': 40.0}",
+            match="assert {'a': 9876.0, 'k': 4, 'x': 40.0} == {'a': 100, 'k': 4, 'x': 40.0}",
         ):
-            dummy2.fit(df, {dummy2.alpha: 9876})
-        assert dummy2.cuml_params["a"] == 9876
+            dummy2.fit(df, {dummy2.alpha: 9876.0})
+        assert dummy2.cuml_params["a"] == 100
+        assert dummy2.getOrDefault(dummy2.alpha) == 100
 
         # Transform the training dataset with a clean spark
         with CleanSparkSession() as clean_spark:


### PR DESCRIPTION
When users call estimator.fit(df, {parameters}), it first copies the parameters into estimator, but it can't propagated them into cuml parameters.