### PR TITLE
cast prediction col to double for LinearRegression and RandomForest

### DIFF
--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -532,6 +532,12 @@ class LinearRegressionModel(
 
         return _construct_lr, _predict
 
+    def _transform(self, dataset: DataFrame) -> DataFrame:
+        df = super()._transform(dataset)
+        return df.withColumn(
+            self.getPredictionCol(), df[self.getPredictionCol()].cast("double")
+        )
+
 
 class _RandomForestRegressorClass(_RandomForestClass):
     @classmethod

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -548,3 +548,9 @@ class _RandomForestModel(
 
         # TBD: figure out why RF algo's warns regardless of what np array order is set
         return _construct_rf, _predict
+
+    def _transform(self, dataset: DataFrame) -> DataFrame:
+        df = super()._transform(dataset)
+        return df.withColumn(
+            self.getPredictionCol(), df[self.getPredictionCol()].cast("double")
+        )

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -23,6 +23,7 @@ from pyspark.ml.linalg import Vectors
 from pyspark.ml.regression import LinearRegression as SparkLinearRegression
 from pyspark.ml.regression import LinearRegressionModel as SparkLinearRegressionModel
 from pyspark.sql.functions import array, col
+from pyspark.sql.types import DoubleType
 
 from spark_rapids_ml.regression import LinearRegression, LinearRegressionModel
 
@@ -240,6 +241,10 @@ def test_linear_regression_basic(
 
         # train a model
         lr_model = lr.fit(df)
+        assert (
+            lr_model.transform(df).schema[lr.getPredictionCol()].dataType
+            == DoubleType()
+        )
 
         assert isinstance(lr_model.cpu(), SparkLinearRegressionModel)
         assert_cuml_pyspark_model(lr_model, lr_model.cpu())

--- a/python/tests/test_random_forest.py
+++ b/python/tests/test_random_forest.py
@@ -26,6 +26,7 @@ from pyspark.ml.classification import RandomForestClassifier as SparkRFClassifie
 from pyspark.ml.linalg import Vectors
 from pyspark.ml.regression import RandomForestRegressionModel as SparkRFRegressionModel
 from pyspark.ml.regression import RandomForestRegressor as SparkRFRegressor
+from pyspark.sql.types import DoubleType
 from sklearn.metrics import r2_score
 
 from spark_rapids_ml.classification import (
@@ -226,6 +227,10 @@ def test_random_forest_basic(
 
         # train a model
         model = est.fit(df)
+        assert (
+            model.transform(df).schema[model.getPredictionCol()].dataType
+            == DoubleType()
+        )
 
         # model persistence
         path = tmp_path + "/random_forest_tests"


### PR DESCRIPTION
This PR keeps align with the pyspark counterparts for prediction datatype.