### PR TITLE
fix to gpu assignment under spark-rapids gpu enabled python worker

### DIFF
--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -249,10 +249,7 @@ class _CumlCommon(MLWritable, MLReadable):
         else:
             gpu_id = _get_gpu_id(context)
 
-        # always set CUDA_VISIBLE_DEVICES to assigned single gpu id for consistency with spark rapids plugin
-        # gpu enabled python worker setup
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
-        cupy.cuda.Device(0).use()
+        cupy.cuda.Device(gpu_id).use()
 
     @staticmethod
     def initialize_cuml_logging(verbose: Optional[Union[bool, int]]) -> None:

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -249,7 +249,10 @@ class _CumlCommon(MLWritable, MLReadable):
         else:
             gpu_id = _get_gpu_id(context)
 
-        cupy.cuda.Device(gpu_id).use()
+        # always set CUDA_VISIBLE_DEVICES to assigned single gpu id for consistency with spark rapids plugin
+        # gpu enabled python worker setup
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+        cupy.cuda.Device(0).use()
 
     @staticmethod
     def initialize_cuml_logging(verbose: Optional[Union[bool, int]]) -> None:

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -92,8 +92,9 @@ def _get_gpu_id(task_context: TaskContext) -> int:
     import os
 
     if "CUDA_VISIBLE_DEVICES" in os.environ and os.environ["CUDA_VISIBLE_DEVICES"]:
+        num_assigned = len(os.environ["CUDA_VISIBLE_DEVICES"].split(","))
         # when CUDA_VISIBLE_DEVICES is set and non-empty, use 0-th index entry
-        return 0
+        gpu_id = 0
     else:
         if task_context is None:
             # safety check.
@@ -103,8 +104,17 @@ def _get_gpu_id(task_context: TaskContext) -> int:
             raise RuntimeError(
                 "Couldn't get the gpu id, Please check the GPU resource configuration."
             )
+        num_assigned = len(resources["gpu"].addresses)
         # return the first gpu id.
-        return int(resources["gpu"].addresses[0].strip())
+        gpu_id = int(resources["gpu"].addresses[0].strip())
+
+    if num_assigned > 1:
+        logger = get_logger(_get_gpu_id)
+        logger.warn(
+            f"Task got assigned {num_assigned} GPUs but using only 1.  This could be a waste of GPU resources."
+        )
+
+    return gpu_id
 
 
 def _get_default_params_from_func(
@@ -126,11 +136,11 @@ def _get_default_params_from_func(
     return filtered_params_dict
 
 
-def _get_class_name(cls: type) -> str:
+def _get_class_or_callable_name(cls_or_callable: Union[type, Callable]) -> str:
     """
     Return the class name.
     """
-    return f"{cls.__module__}.{cls.__name__}"
+    return f"{cls_or_callable.__module__}.{cls_or_callable.__name__}"
 
 
 class PartitionDescriptor:
@@ -220,9 +230,11 @@ def dtype_to_pyspark_type(dtype: Union[np.dtype, str]) -> str:
 
 
 # similar to https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/spark/utils.py
-def get_logger(cls: type, level: str = "INFO") -> logging.Logger:
+def get_logger(
+    cls_or_callable: Union[type, Callable], level: str = "INFO"
+) -> logging.Logger:
     """Gets a logger by name, or creates and configures it for the first time."""
-    name = _get_class_name(cls)
+    name = _get_class_or_callable_name(cls_or_callable)
     logger = logging.getLogger(name)
 
     logger.setLevel(level)

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -91,10 +91,15 @@ def _get_gpu_id(task_context: TaskContext) -> int:
     """Get the gpu id from the task resources"""
     import os
 
-    if "CUDA_VISIBLE_DEVICES" in os.environ and os.environ["CUDA_VISIBLE_DEVICES"]:
-        num_assigned = len(os.environ["CUDA_VISIBLE_DEVICES"].split(","))
-        # when CUDA_VISIBLE_DEVICES is set and non-empty, use 0-th index entry
-        gpu_id = 0
+    if "CUDA_VISIBLE_DEVICES" in os.environ:
+        if os.environ["CUDA_VISIBLE_DEVICES"]:
+            num_assigned = len(os.environ["CUDA_VISIBLE_DEVICES"].split(","))
+            # when CUDA_VISIBLE_DEVICES is set and non-empty, use 0-th index entry
+            gpu_id = 0
+        else:
+            raise RuntimeError(
+                "Couldn't get gpu id since CUDA_VISIBLE_DEVICES is set to an empty string.  Please check the GPU resource configuration."
+            )
     else:
         if task_context is None:
             # safety check.

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -89,16 +89,22 @@ def _str_or_numerical(x: str) -> Union[str, float, int]:
 
 def _get_gpu_id(task_context: TaskContext) -> int:
     """Get the gpu id from the task resources"""
-    if task_context is None:
-        # safety check.
-        raise RuntimeError("_get_gpu_id should not be invoked from driver side.")
-    resources = task_context.resources()
-    if "gpu" not in resources:
-        raise RuntimeError(
-            "Couldn't get the gpu id, Please check the GPU resource configuration."
-        )
-    # return the first gpu id.
-    return int(resources["gpu"].addresses[0].strip())
+    import os
+
+    if "CUDA_VISIBLE_DEVICES" in os.environ and os.environ["CUDA_VISIBLE_DEVICES"]:
+        # when CUDA_VISIBLE_DEVICES is set and non-empty, use 0-th index entry
+        return 0
+    else:
+        if task_context is None:
+            # safety check.
+            raise RuntimeError("_get_gpu_id should not be invoked from driver side.")
+        resources = task_context.resources()
+        if "gpu" not in resources:
+            raise RuntimeError(
+                "Couldn't get the gpu id, Please check the GPU resource configuration."
+            )
+        # return the first gpu id.
+        return int(resources["gpu"].addresses[0].strip())
 
 
 def _get_default_params_from_func(


### PR DESCRIPTION
spark-rapids python worker daemon sets CUDA_VISIBLE_DEVICES for the launched python worker.   When this env var is set, various CUDA device APIs interpret supplied device indices as indices into the env var value's list vs global gpu ids.    Accordingly, this PR sets the gpu id in this case to 0 as the first entry of the list.

Relevant only for multiple-gpu executors.