### PR TITLE
cupy + arrow batching for low_rank_matrix

### DIFF
--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -18,8 +18,8 @@ import random
 from abc import abstractmethod
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
-import numpy as np
 import cupy as cp
+import numpy as np
 import pandas as pd
 from gen_data import DataGenBase, DefaultDataGen, main
 from pyspark.mllib.random import RandomRDDs
@@ -216,7 +216,9 @@ class LowRankMatrixDataGen(DataGenBase):
         del s
         del v
 
-        maxRecordsPerBatch = spark.sparkContext.getConf().get("spark.sql.execution.arrow.maxRecordsPerBatch")
+        maxRecordsPerBatch = spark.sparkContext.getConf().get(
+            "spark.sql.execution.arrow.maxRecordsPerBatch"
+        )
         if maxRecordsPerBatch is None:
             maxRecordsPerBatch = 10000
         # UDF for distributed generation of U and the resultant product U*S*V.T
@@ -231,7 +233,11 @@ class LowRankMatrixDataGen(DataGenBase):
                 data = cp.dot(u, sv_normed)
                 del u
                 for i in range(0, n_partition_rows, maxRecordsPerBatch):
-                    end_idx = i + maxRecordsPerBatch if i + maxRecordsPerBatch < n_partition_rows else n_partition_rows
+                    end_idx = (
+                        i + maxRecordsPerBatch
+                        if i + maxRecordsPerBatch < n_partition_rows
+                        else n_partition_rows
+                    )
                     yield pd.DataFrame(data=data[i:end_idx].get())
 
         return (

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -226,10 +226,10 @@ class LowRankMatrixDataGen(DataGenBase):
         # UDF for distributed generation of U and the resultant product U*S*V.T
         def make_matrix_udf(iter: Iterable[pd.DataFrame]) -> Iterable[pd.DataFrame]:
             for pdf in iter:
-                if use_gpu:
+                use_cupy = use_gpu
+                if use_cupy:
                     try:
                         import cupy as cp
-                        use_cupy = True
                     except ImportError:
                         use_cupy = False
                         logging.warning("cupy import failed; falling back to numpy.")

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -19,6 +19,7 @@ from abc import abstractmethod
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
 import numpy as np
+import cupy as cp
 import pandas as pd
 from gen_data import DataGenBase, DefaultDataGen, main
 from pyspark.mllib.random import RandomRDDs
@@ -171,6 +172,7 @@ class LowRankMatrixDataGen(DataGenBase):
             params["random_state"] = 1
 
         print(f"Passing {params} to make_low_rank_matrix")
+        print(f"Using device {cp.cuda.runtime.getDevice()}")
 
         rows = self.num_rows
         cols = self.num_cols
@@ -181,7 +183,7 @@ class LowRankMatrixDataGen(DataGenBase):
         if num_partitions is None:
             num_partitions = spark.sparkContext.defaultParallelism
 
-        generator = np.random.RandomState(params["random_state"])
+        cp.random.seed(params["random_state"])
         n = min(rows, cols)
         # If params not provided, set to defaults.
         effective_rank = params.get("effective_rank", 10)
@@ -197,33 +199,35 @@ class LowRankMatrixDataGen(DataGenBase):
 
         # Generate U, S, V, the SVD decomposition of the output matrix.
         # Code adapted from sklearn.datasets.make_low_rank_matrix().
-        singular_ind = np.arange(n, dtype=dtype)
-        low_rank = (1 - tail_strength) * np.exp(
+        singular_ind = cp.arange(n, dtype=dtype)
+        low_rank = (1 - tail_strength) * cp.exp(
             -1.0 * (singular_ind / effective_rank) ** 2
         )
-        tail = tail_strength * np.exp(-0.1 * singular_ind / effective_rank)
+        tail = tail_strength * cp.exp(-0.1 * singular_ind / effective_rank)
         # S and V are generated upfront, U is generated across partitions.
-        s = np.identity(n) * (low_rank + tail)
-        v, _ = linalg.qr(
-            generator.standard_normal(size=(cols, n)),
-            mode="economic",
-            check_finite=False,
+        s = cp.identity(n) * (low_rank + tail)
+        v, _ = cp.linalg.qr(
+            cp.random.standard_normal(size=(cols, n)),
+            mode="reduced",
         )
 
         # Precompute the S*V.T multiplicland with partition-wise normalization.
-        sv_normed = np.dot(s, v.T) * np.sqrt(1 / num_partitions)
+        sv_normed = cp.dot(s, v.T) * cp.sqrt(1 / num_partitions)
+        del s
+        del v
 
         # UDF for distributed generation of U and the resultant product U*S*V.T
         def make_matrix_udf(iter: Iterable[pd.DataFrame]) -> Iterable[pd.DataFrame]:
             for pdf in iter:
                 partition_index = pdf.iloc[0][0]
                 n_partition_rows = partition_sizes[partition_index]
-                u, _ = linalg.qr(
-                    generator.standard_normal(size=(n_partition_rows, n)),
-                    mode="economic",
-                    check_finite=False,
+                u, _ = cp.linalg.qr(
+                    cp.random.standard_normal(size=(n_partition_rows, n)),
+                    mode="reduced",
                 )
-                yield pd.DataFrame(data=np.dot(u, sv_normed))
+                data = cp.dot(u, sv_normed)
+                del u
+                yield pd.DataFrame(data=data.get())
 
         return (
             (

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -221,6 +221,7 @@ class LowRankMatrixDataGen(DataGenBase):
         )
         if maxRecordsPerBatch is None:
             maxRecordsPerBatch = 10000
+
         # UDF for distributed generation of U and the resultant product U*S*V.T
         def make_matrix_udf(iter: Iterable[pd.DataFrame]) -> Iterable[pd.DataFrame]:
             for pdf in iter:

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -226,15 +226,19 @@ class LowRankMatrixDataGen(DataGenBase):
 
                 partition_index = pdf.iloc[0][0]
                 n_partition_rows = partition_sizes[partition_index]
+                # Additional batch-wise normalization.
+                batch_norm = cp.sqrt(-(-n_partition_rows // maxRecordsPerBatch))
+                sv_normed = cp.dot(cp.asarray(sv_normed), batch_norm)
+                del batch_norm
                 for i in range(0, n_partition_rows, maxRecordsPerBatch):
                     end_idx = min(i + maxRecordsPerBatch, n_partition_rows)
                     u, _ = cp.linalg.qr(
                         cp.random.standard_normal(size=(end_idx - i, n)),
                         mode="reduced",
                     )
-                    data = cp.dot(u, cp.asarray(sv_normed))
+                    data = cp.dot(u, sv_normed).get()
                     del u
-                    yield pd.DataFrame(data=data.get())
+                    yield pd.DataFrame(data=data)
 
         return (
             (

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -226,15 +226,15 @@ class LowRankMatrixDataGen(DataGenBase):
 
                 partition_index = pdf.iloc[0][0]
                 n_partition_rows = partition_sizes[partition_index]
-                u, _ = cp.linalg.qr(
-                    cp.random.standard_normal(size=(n_partition_rows, n)),
-                    mode="reduced",
-                )
-                data = cp.dot(u, cp.asarray(sv_normed))
-                del u
                 for i in range(0, n_partition_rows, maxRecordsPerBatch):
                     end_idx = min(i + maxRecordsPerBatch, n_partition_rows)
-                    yield pd.DataFrame(data=data[i:end_idx].get())
+                    u, _ = cp.linalg.qr(
+                        cp.random.standard_normal(size=(end_idx - i, n)),
+                        mode="reduced",
+                    )
+                    data = cp.dot(u, cp.asarray(sv_normed))
+                    del u
+                    yield pd.DataFrame(data=data.get())
 
         return (
             (

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -23,7 +23,6 @@ import pandas as pd
 from gen_data import DataGenBase, DefaultDataGen, main
 from pyspark.mllib.random import RandomRDDs
 from pyspark.sql import DataFrame, SparkSession
-from scipy import linalg
 from sklearn.datasets import (
     make_blobs,
     make_classification,

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -234,11 +234,7 @@ class LowRankMatrixDataGen(DataGenBase):
                 data = cp.dot(u, cp.asarray(sv_normed))
                 del u
                 for i in range(0, n_partition_rows, maxRecordsPerBatch):
-                    end_idx = (
-                        i + maxRecordsPerBatch
-                        if i + maxRecordsPerBatch < n_partition_rows
-                        else n_partition_rows
-                    )
+                    end_idx = min(i + maxRecordsPerBatch, n_partition_rows)
                     yield pd.DataFrame(data=data[i:end_idx].get())
 
         return (

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -216,11 +216,11 @@ class LowRankMatrixDataGen(DataGenBase):
         del s
         del v
 
-        maxRecordsPerBatch = spark.sparkContext.getConf().get(
-            "spark.sql.execution.arrow.maxRecordsPerBatch"
+        maxRecordsPerBatch = int(
+            spark.sparkContext.getConf().get(
+                "spark.sql.execution.arrow.maxRecordsPerBatch", "10000"
+            )
         )
-        if maxRecordsPerBatch is None:
-            maxRecordsPerBatch = 10000
 
         # UDF for distributed generation of U and the resultant product U*S*V.T
         def make_matrix_udf(iter: Iterable[pd.DataFrame]) -> Iterable[pd.DataFrame]:

--- a/python/benchmark/gen_data_distributed.py
+++ b/python/benchmark/gen_data_distributed.py
@@ -228,7 +228,7 @@ class LowRankMatrixDataGen(DataGenBase):
                 n_partition_rows = partition_sizes[partition_index]
                 # Additional batch-wise normalization.
                 batch_norm = cp.sqrt(-(-n_partition_rows // maxRecordsPerBatch))
-                sv_normed = cp.dot(cp.asarray(sv_normed), batch_norm)
+                sv_batch_normed = cp.dot(cp.asarray(sv_normed), batch_norm)
                 del batch_norm
                 for i in range(0, n_partition_rows, maxRecordsPerBatch):
                     end_idx = min(i + maxRecordsPerBatch, n_partition_rows)
@@ -236,7 +236,7 @@ class LowRankMatrixDataGen(DataGenBase):
                         cp.random.standard_normal(size=(end_idx - i, n)),
                         mode="reduced",
                     )
-                    data = cp.dot(u, sv_normed).get()
+                    data = cp.dot(u, sv_batch_normed).get()
                     del u
                     yield pd.DataFrame(data=data)
 


### PR DESCRIPTION
- Low rank matrix changes:
   * Replaced numpy array operations with cupy
   * Added loop in UDF to yield data in maxRecordsPerBatch chunks for memory efficiency

#### speedups:

3000 cols, float32

- Low rank matrix:

| Samples | Numpy Runtime | Cupy Runtime |
| -------- | -------- | -------- |
| 100,000  | 83s | 43s   |
| 1,000,000  | 603s  | 335s   |

- Regression (low-rank case):

| Samples | Numpy Runtime | Cupy Runtime |
| -------- | -------- | -------- |
| 100,000  | 80s | 67s   |
| 1,000,000  | 675s  | 366s |

If these changes look OK, I'll add arrow batching to the rest of the functions, as well as cupy operations in the regression udf. 