### PR TITLE
update python location for cpu init

### DIFF
--- a/python/benchmark/databricks/init-cpu.sh
+++ b/python/benchmark/databricks/init-cpu.sh
@@ -4,6 +4,7 @@ SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/spark-rapids-ml.zip
 BENCHMARK_ZIP=/dbfs/path/to/benchmark.zip
 
 # install spark-rapids-ml
-unzip ${SPARK_RAPIDS_ML_ZIP} -d /databricks/python3/lib/python3.8/site-packages
-unzip ${BENCHMARK_ZIP} -d /databricks/python3/lib/python3.8/site-packages
+python_ver=`python --version | grep -oP '3\.[0-9]+'`
+unzip ${SPARK_RAPIDS_ML_ZIP} -d /databricks/python3/lib/python${python_ver}/site-packages
+unzip ${BENCHMARK_ZIP} -d /databricks/python3/lib/python${python_ver}/site-packages
 


### PR DESCRIPTION
omitted this in previous bump to 11.3 databricks runtime