### PR TITLE
Support crossvalidator persistence

### DIFF
--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -167,6 +167,7 @@ class _CumlEstimatorReader(MLReader):
     def load(self, path: str) -> "_CumlEstimator":
         metadata = DefaultParamsReader.loadMetadata(path, self.sc)
         cuml_estimator = self.estimator_cls()
+        cuml_estimator._resetUid(metadata["uid"])
         DefaultParamsReader.getAndSetParams(cuml_estimator, metadata)
         cuml_estimator._cuml_params = metadata["_cuml_params"]
         cuml_estimator._num_workers = metadata["_num_workers"]

--- a/python/src/spark_rapids_ml/tuning.py
+++ b/python/src/spark_rapids_ml/tuning.py
@@ -138,6 +138,8 @@ class CrossValidator(SparkCrossValidator):
 
     @staticmethod
     def _is_python_params_instance(metadata: Dict[str, Any]) -> bool:
+        # If it's not python module, pyspark will load spark_rapids_ml.tuning.CrossValidator
+        # from JVM package. So we need to hack here
         return metadata["class"].startswith(("pyspark.ml.", "spark_rapids_ml."))
 
     @classmethod

--- a/python/src/spark_rapids_ml/tuning.py
+++ b/python/src/spark_rapids_ml/tuning.py
@@ -54,6 +54,7 @@ class CrossValidator(SparkCrossValidator):
     >>> from pyspark.ml.evaluation import MulticlassClassificationEvaluator
     >>> from spark_rapids_ml.tuning import CrossValidator
     >>> from spark_rapids_ml.classification import RandomForestClassifier
+    >>> import tempfile
     >>> dataset = spark.createDataFrame(
     ...     [(Vectors.dense([0.0]), 0.0),
     ...      (Vectors.dense([0.4]), 1.0),
@@ -73,6 +74,16 @@ class CrossValidator(SparkCrossValidator):
     >>> cvModel.avgMetrics[0]
     1.0
     >>> evaluator.evaluate(cvModel.transform(dataset))
+    1.0
+    >>> path = tempfile.mkdtemp()
+    >>> model_path = path + "/model"
+    >>> cvModel.write().save(model_path)
+    >>> cvModelRead = CrossValidatorModel.read().load(model_path)
+    >>> cvModelRead.avgMetrics
+    [1.0, 1.0]
+    >>> evaluator.evaluate(cvModel.transform(dataset))
+    1.0
+    >>> evaluator.evaluate(cvModelRead.transform(dataset))
     1.0
 
     """

--- a/python/tests/test_random_forest.py
+++ b/python/tests/test_random_forest.py
@@ -816,7 +816,6 @@ def test_fit_multiple_in_single_pass(
 @pytest.mark.parametrize("data_shape", [(100, 8)], ids=idfn)
 def test_crossvalidator_random_forest(
     estimator_evaluator: Tuple[RandomForest, RandomForestEvaluator],
-    tmp_path: str,
     feature_type: str,
     data_type: np.dtype,
     data_shape: Tuple[int, int],

--- a/python/tests/test_tuning.py
+++ b/python/tests/test_tuning.py
@@ -20,15 +20,16 @@ import pytest
 from pyspark.ml.evaluation import RegressionEvaluator
 from pyspark.ml.tuning import CrossValidatorModel, ParamGridBuilder
 
-from python.tests.sparksession import CleanSparkSession
-from python.tests.utils import (
+from spark_rapids_ml.regression import RandomForestRegressor
+from spark_rapids_ml.tuning import CrossValidator
+
+from .sparksession import CleanSparkSession
+from .utils import (
     create_pyspark_dataframe,
     feature_types,
     idfn,
     make_regression_dataset,
 )
-from spark_rapids_ml.regression import RandomForestRegressor
-from spark_rapids_ml.tuning import CrossValidator
 
 
 @pytest.mark.parametrize("feature_type", [feature_types.vector])

--- a/python/tests/test_tuning.py
+++ b/python/tests/test_tuning.py
@@ -1,0 +1,97 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Tuple, Union
+
+import numpy as np
+import pytest
+from pyspark.ml.evaluation import RegressionEvaluator
+from pyspark.ml.tuning import CrossValidatorModel, ParamGridBuilder
+
+from python.tests.sparksession import CleanSparkSession
+from python.tests.utils import (
+    create_pyspark_dataframe,
+    feature_types,
+    idfn,
+    make_regression_dataset,
+)
+from spark_rapids_ml.regression import RandomForestRegressor
+from spark_rapids_ml.tuning import CrossValidator
+
+
+@pytest.mark.parametrize("feature_type", [feature_types.vector])
+@pytest.mark.parametrize("data_type", [np.float32])
+@pytest.mark.parametrize("data_shape", [(100, 8)], ids=idfn)
+def test_crossvalidator(
+    tmp_path: str,
+    feature_type: str,
+    data_type: np.dtype,
+    data_shape: Tuple[int, int],
+) -> None:
+    X, _, y, _ = make_regression_dataset(
+        datatype=data_type,
+        nrows=data_shape[0],
+        ncols=data_shape[1],
+    )
+
+    with CleanSparkSession() as spark:
+        df, features_col, label_col = create_pyspark_dataframe(
+            spark, feature_type, data_type, X, y
+        )
+        assert label_col is not None
+
+        rfc = RandomForestRegressor()
+        rfc.setFeaturesCol(features_col)
+        rfc.setLabelCol(label_col)
+
+        evaluator = RegressionEvaluator()
+        evaluator.setLabelCol(label_col)
+
+        grid = ParamGridBuilder().addGrid(rfc.maxBins, [3, 5]).build()
+
+        cv = CrossValidator(
+            estimator=rfc,
+            estimatorParamMaps=grid,
+            evaluator=evaluator,
+            numFolds=2,
+            seed=101,
+        )
+
+        def check_cv(cv_est: Union[CrossValidator, CrossValidatorModel]) -> None:
+            assert isinstance(cv_est, (CrossValidator, CrossValidatorModel))
+            assert isinstance(cv_est.getEstimator(), RandomForestRegressor)
+            assert isinstance(cv_est.getEvaluator(), RegressionEvaluator)
+            assert cv_est.getNumFolds() == 2
+            assert cv_est.getSeed() == 101
+            assert cv_est.getEstimatorParamMaps() == grid
+
+        check_cv(cv)
+
+        path = tmp_path + "/cv"
+        cv_path = f"{path}/cv"
+
+        cv.write().overwrite().save(cv_path)
+        cv_loaded = CrossValidator.load(cv_path)
+
+        check_cv(cv_loaded)
+
+        cv_model = cv.fit(df)
+        check_cv(cv_model)
+
+        cv_model_path = f"{path}/cv-model"
+        cv_model.write().overwrite().save(cv_model_path)
+        cv_model_loaded = CrossValidatorModel.load(cv_model_path)
+
+        check_cv(cv_model_loaded)

--- a/python/tests/test_tuning.py
+++ b/python/tests/test_tuning.py
@@ -95,3 +95,6 @@ def test_crossvalidator(
         cv_model_loaded = CrossValidatorModel.load(cv_model_path)
 
         check_cv(cv_model_loaded)
+        assert evaluator.evaluate(cv_model.transform(df)) == evaluator.evaluate(
+            cv_model_loaded.transform(df)
+        )


### PR DESCRIPTION
Our customized CrossValidator which reuses the built-in read/write of pyspark CrossValidator has been broken. The root cause is the read process tries to load **spark_rapids_ml.tuning.CrossValidator** from JVM domain because of pyspark hardcoding checking whether it is a python module according to the class name starting with "pyspark.ml" or not. Obviously, our customized CrossValidator starts from "spark_rapids_ml", so the read process tries to load it in JVM domain and finally finds nothing and throws the exception.
