### PR TITLE
Fix bug: change container name to adapt to blossom-lib refactor [skip ci]

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -132,7 +132,7 @@ pipeline {
 
                     stash(name: "source_tree", includes: "**")
 
-                    container('docker-build') {
+                    container('cpu') {
                         // check if pre-merge dockerfile modified
                         def dockerfileModified = sh(returnStdout: true,
                             script: 'BASE=$(git --no-pager log --oneline -1 | awk \'{ print $NF }\'); ' +


### PR DESCRIPTION
Change container name from `docker-build` to `cpu` to adapt to the blossom-lib refactor