### PR TITLE
Use specific version of mamba and install libarchive explicitly

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -36,6 +36,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
 
 # install cuML
 ARG CUML_VER=23.06
-RUN conda install -c conda-forge mamba && \
+RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
     mamba install -y -c rapidsai -c nvidia -c conda-forge cuml=$CUML_VER python=3.9 cuda-toolkit=11.5 \
     && mamba clean --all -f -y


### PR DESCRIPTION
recently mamba pkg installation is quite unstable https://github.com/mamba-org/mamba/issues?q=is%3Aissue

below failed our images build CIs intermittently (50%)
```
[2023-07-16T01:16:16.151Z]   File "/opt/conda/lib/python3.11/site-packages/libmambapy/__init__.py", line 4, in <module>
[2023-07-16T01:16:16.151Z]     from libmambapy.bindings import *  # noqa: F401,F403
[2023-07-16T01:16:16.151Z]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-07-16T01:16:16.151Z] ImportError: libarchive.so.13: cannot open shared object file: No such file or directory
```
this change is trying to install specific version of mamba and libarchive explicitly.
