### PR TITLE
Support stage level scheduling

### DIFF
--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -699,7 +699,8 @@ class _CumlEstimator(Estimator, _CumlCaller):
         # each training task requires cpu cores > total executor cores/2 which can
         # ensure each training task be sent to different executor.
         task_cores = (int(executor_cores) // 2) + 1
-        task_gpus = 0.1 if task_gpu_amount is None else float(task_gpu_amount)
+        # To ensure the training task take the whole GPU exclusively
+        task_gpus = 1.0
 
         treqs = TaskResourceRequests().cpus(task_cores).resource("gpu", task_gpus)
         rp = ResourceProfileBuilder().require(treqs).build

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -696,13 +696,10 @@ class _CumlEstimator(Estimator, _CumlCaller):
         from pyspark.resource.profile import ResourceProfileBuilder
         from pyspark.resource.requests import TaskResourceRequests
 
-        # each training task requires cpu cores > total executor cores/2 which can
-        # ensure each training task be sent to different executor.
-        task_cores = (int(executor_cores) // 2) + 1
-        # To ensure the training task take the whole GPU exclusively
-        task_gpus = 1.0
-
-        treqs = TaskResourceRequests().cpus(task_cores).resource("gpu", task_gpus)
+        # Each training task requires only 1 cpu cores to allow other cpu tasks
+        # running alongside the training tasks
+        # and requires 1 gpu to ensure the training task be sent to different executors
+        treqs = TaskResourceRequests().cpus(1).resource("gpu", 1.0)
         rp = ResourceProfileBuilder().require(treqs).build
 
         return rdd.withResources(rp)

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -680,6 +680,10 @@ class _CumlEstimator(Estimator, _CumlCaller):
             task_cores = (int(executor_cores) // 2) + 1
             treqs = TaskResourceRequests().cpus(task_cores)
             rp = ResourceProfileBuilder().require(treqs).build
+
+            self.logger.warning(
+                f"Each training task requires task.cores: {task_cores}"
+            )
             return rdd.withResources(rp)
 
     def _fit_internal(

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -223,7 +223,6 @@ class _CumlModelReader(MLReader):
 class _CumlCommon(MLWritable, MLReadable):
     def __init__(self) -> None:
         super().__init__()
-        self.logger = get_logger(self.__class__)
 
     @staticmethod
     def set_gpu_device(
@@ -616,6 +615,7 @@ class _CumlEstimator(Estimator, _CumlCaller):
 
     def __init__(self) -> None:
         super().__init__()
+        self.logger = get_logger(self.__class__)
 
     @abstractmethod
     def _create_pyspark_model(self, result: Row) -> "_CumlModel":

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -699,7 +699,7 @@ class _CumlEstimator(Estimator, _CumlCaller):
         # each training task requires cpu cores > total executor cores/2 which can
         # ensure each training task be sent to different executor.
         task_cores = (int(executor_cores) // 2) + 1
-        task_gpus = 0.01 if task_gpu_amount is None else float(task_gpu_amount)
+        task_gpus = 0.1 if task_gpu_amount is None else float(task_gpu_amount)
 
         treqs = TaskResourceRequests().cpus(task_cores).resource("gpu", task_gpus)
         rp = ResourceProfileBuilder().require(treqs).build


### PR DESCRIPTION
The precondition that stage-level scheduling can work in the spark-rapids-ml is the executors have already grabbed the GPU resource at every beginning even for the ETL phase. The stage-level scheduling in spark-rapids-ml won’t require extra executors, instead, it just requires existing different resources for different stages.
