### PR TITLE
Override call_cuml_fit_func to use Dataframe, model saving+loading as numpy

### DIFF
--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -409,10 +409,6 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
             dtype=type(raw_data[0][0]).__name__,
         )
 
-        print(
-            type(raw_data[0][0]).__name__,
-        )
-
         model._num_workers = input_num_workers
 
         self._copyValues(model)
@@ -656,14 +652,14 @@ class UMAPModel(_CumlModel, UMAPClass, _UMAPCumlParams):
     @property
     def embedding(self) -> np.ndarray:
         if isinstance(self.embedding_, np.ndarray):
-            return self.embedding_
-        return self.embedding_.value
+            return self.embedding_.tolist()
+        return self.embedding_.value.tolist()
 
     @property
     def raw_data(self) -> np.ndarray:
         if isinstance(self.raw_data_, np.ndarray):
-            return self.raw_data_
-        return self.raw_data_.value
+            return self.raw_data_.tolist()
+        return self.raw_data_.value.tolist()
 
     def _get_cuml_transform_func(
         self, dataset: DataFrame, category: str = transform_evaluate.transform
@@ -678,8 +674,17 @@ class UMAPModel(_CumlModel, UMAPClass, _UMAPCumlParams):
 
             from .utils import cudf_to_cuml_array
 
-            embedding = self.embedding
-            raw_data = self.raw_data
+            embedding = (
+                self.embedding_
+                if isinstance(self.embedding_, np.ndarray)
+                else self.embedding_.value
+            )
+            raw_data = (
+                self.raw_data_
+                if isinstance(self.raw_data_, np.ndarray)
+                else self.raw_data_.value
+            )
+
             if embedding.dtype != np.float32:
                 embedding = embedding.astype(np.float32)
                 raw_data = raw_data.astype(np.float32)

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -674,6 +674,9 @@ class UMAPModel(_CumlModel, UMAPClass, _UMAPCumlParams):
 
             embedding = self.embedding
             raw_data = self.raw_data
+            if embedding.dtype != np.float32:
+                embedding = embedding.astype(np.float32)
+                raw_data = raw_data.astype(np.float32)
 
             if is_sparse(raw_data):
                 raw_data_cuml = SparseCumlArray(raw_data, convert_format=False)

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -385,14 +385,16 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
                 pd.concat(
                     [pd.Series(x) for x in pdf_output["embedding_"]], ignore_index=True
                 )
-            )
+            ),
+            dtype=np.float32,
         )
         raw_data = np.array(
             list(
                 pd.concat(
                     [pd.Series(x) for x in pdf_output["raw_data_"]], ignore_index=True
                 )
-            )
+            ),
+            dtype=np.float32,
         )
         del pdf_output
 
@@ -405,6 +407,10 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
             raw_data_=broadcast_raw_data,
             n_cols=len(raw_data[0]),
             dtype=type(raw_data[0][0]).__name__,
+        )
+
+        print(
+            type(raw_data[0][0]).__name__,
         )
 
         model._num_workers = input_num_workers
@@ -733,7 +739,9 @@ class UMAPModel(_CumlModel, UMAPClass, _UMAPCumlParams):
         )
 
     def get_model_attributes(self) -> Optional[Dict[str, Any]]:
-        """Override parent method to bring broadcast variables to driver before JSON serialization."""
+        """
+        Override parent method to bring broadcast variables to driver before JSON serialization.
+        """
         if not isinstance(self.embedding_, np.ndarray):
             self._model_attributes["embedding_"] = self.embedding_.value
         if not isinstance(self.raw_data_, np.ndarray):

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -303,7 +303,7 @@ def test_umap_model_persistence(tmp_path: str) -> None:
             assert embedding.shape == (100, 2)
             assert raw_data.shape == (100, 20)
             assert np.array_equal(raw_data, X.get())
-            assert model.dtype == "float64"
+            assert model.dtype == "float32"
             assert model.n_cols == X.shape[1]
 
         umap_model = umap.fit(df)

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -202,7 +202,7 @@ def test_spark_umap(
 @pytest.mark.parametrize("supervised", [True])
 @pytest.mark.parametrize("dataset", ["digits"])
 @pytest.mark.parametrize("n_neighbors", [10])
-@pytest.mark.parametrize("dtype", [cuml_supported_data_types[0]])
+@pytest.mark.parametrize("dtype", cuml_supported_data_types)
 @pytest.mark.parametrize("feature_type", [pyspark_supported_feature_types[0]])
 def test_spark_umap_fast(
     n_parts: int,
@@ -303,7 +303,7 @@ def test_umap_model_persistence(tmp_path: str) -> None:
             assert embedding.shape == (100, 2)
             assert raw_data.shape == (100, 20)
             assert np.array_equal(raw_data, X.get())
-            assert model.dtype == "float"
+            assert model.dtype == "float64"
             assert model.n_cols == X.shape[1]
 
         umap_model = umap.fit(df)


### PR DESCRIPTION
### override call_cuml_fit_func
- removed barrier stages, returns dataframe rather than rdd
- allows for:
   * coalesce() rather than repartition
   * toPandas() rather than collect
   * storing raw_data / embeddings as numpy rather than list
   * saving attributes as float32 rather than python float (float64)
- speedups below

dataset: **50,000 x 3000, float32, parquet**
| | fit runtime | transform runtime |
| -------- | -------- | -------- |
| rdd + repartition + collect (no overrides) | 58.5s | 29.2s |
| df + coalesce + collect (python lists) | 46.7s | 28.9s |
| df + coalesce + toPandas (numpy arrays) | 24.9s | 8.7s |

dataset: **100,000 x 3000, float32, parquet**
| | fit runtime | transform runtime |
| -------- | -------- | -------- |
| rdd + repartition + collect (no overrides) | 113.3s | 65.4s |
| df + coalesce + toPandas (numpy arrays) | 48.5s | 23.7s |

### override modelwriter / modelreader
- subclassed cumlmodelreader and cumlmodelwriter to handle numpy saving + loading
   * saves arrays with np.save, creates subdirectory for other model attributes ("metadata")
- allows for continuous use of numpy arrays between fit and transform phases
- saves memory and preserves float32 dtype 