### PR TITLE
Upgrade cuml from 23.06 to 23.08 in pytests and ci

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,5 +37,5 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
 # install cuML
 ARG CUML_VER=23.08
 RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai -c nvidia -c conda-forge cuml=$CUML_VER python=3.9 cuda-toolkit=11.5 \
+    mamba install -y -c rapidsai-nightly -c nvidia -c conda-forge cuml=$CUML_VER python=3.9 cuda-toolkit=11.5 \
     && mamba clean --all -f -y

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -35,7 +35,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
     && conda init
 
 # install cuML
-ARG CUML_VER=23.06
+ARG CUML_VER=23.08
 RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
     mamba install -y -c rapidsai -c nvidia -c conda-forge cuml=$CUML_VER python=3.9 cuda-toolkit=11.5 \
     && mamba clean --all -f -y

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -202,6 +202,7 @@ class LinearRegressionClass(_CumlClass):
         return {
             "algorithm": "eig",
             "fit_intercept": True,
+            "copy_X": None,
             "normalize": False,
             "verbose": False,
             "alpha": 0.0001,
@@ -498,6 +499,7 @@ class LinearRegression(
                         "fit_intercept",
                         "normalize",
                         "verbose",
+                        "copy_X",
                     ]
                 else:
                     if init_parameters["l1_ratio"] == 0:
@@ -548,6 +550,10 @@ class LinearRegression(
                 final_init_parameters = {
                     k: v for k, v in init_parameters.items() if k in supported_params
                 }
+
+                # cuml adds copy_X argument since 23.08
+                if "copy_X" in final_init_parameters:
+                    final_init_parameters["copy_X"] = False
 
                 linear_regression = CumlLinearRegression(
                     handle=params[param_alias.handle],

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -98,6 +98,12 @@ def test_default_cuml_params() -> None:
         [CumlLinearRegression, Ridge, CD], ["handle", "output_type"]
     )
     spark_params = LinearRegression()._get_cuml_params_default()
+
+    import cuml
+    from packaging import version
+
+    if version.parse(cuml.__version__) < version.parse("23.08.00"):
+        spark_params.pop("copy_X")
     assert cuml_params == spark_params
 
 


### PR DESCRIPTION
Fixed an issue in LinearRegression that adds the copy_X init argument to match cuml 23.08 LinearRegression init argument list. 