### PR TITLE
remove erroneous spark.rapids.memory.gpu.reserve confs

### DIFF
--- a/python/benchmark/databricks/gpu_cluster_spec.sh
+++ b/python/benchmark/databricks/gpu_cluster_spec.sh
@@ -20,7 +20,6 @@ cat <<EOF
         "spark.sql.cache.serializer": "com.nvidia.spark.ParquetCachedBatchSerializer",
         "spark.rapids.memory.gpu.pooling.enabled": "false",
         "spark.rapids.sql.explain": "ALL",
-        "spark.rapids.memory.gpu.reserve": "20",
         "spark.sql.execution.sortBeforeRepartition": "false",
         "spark.rapids.sql.python.gpu.enabled": "true",
         "spark.rapids.memory.pinnedPool.size": "2G",

--- a/python/benchmark/dataproc/run_benchmark.sh
+++ b/python/benchmark/dataproc/run_benchmark.sh
@@ -21,8 +21,7 @@ gpu_args=$(cat <<EOF
 --num_gpus=2 \
 --spark_confs spark.executor.resource.gpu.amount=1 \
 --spark_confs spark.task.resource.gpu.amount=1 \
---spark_confs spark.rapids.memory.gpu.pooling.enabled=false \
---spark_confs spark.rapids.memory.gpu.reserve=90
+--spark_confs spark.rapids.memory.gpu.pooling.enabled=false
 EOF
 )
 

--- a/python/run_benchmark.sh
+++ b/python/run_benchmark.sh
@@ -116,7 +116,6 @@ cat <<EOF
 --spark_confs spark.sql.cache.serializer=com.nvidia.spark.ParquetCachedBatchSerializer \
 --spark_confs spark.rapids.memory.gpu.pooling.enabled=false \
 --spark_confs spark.rapids.sql.explain=ALL \
---spark_confs spark.rapids.memory.gpu.reserve=20 \
 --spark_confs spark.sql.execution.sortBeforeRepartition=false \
 --spark_confs spark.rapids.sql.format.parquet.reader.type=MULTITHREADED \
 --spark_confs spark.rapids.sql.format.parquet.multiThreadedRead.maxNumFilesParallel=20 \


### PR DESCRIPTION
Value is bytes (and not percentage as implied by these settings), so just removing these entirely.