### PR TITLE
stage level scheduling: set task cpu cores dynamically 

### DIFF
--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -721,7 +721,7 @@ class _CumlEstimator(Estimator, _CumlCaller):
             # to make spark-rapids-ml run successfully.
             #
             self.logger.warning(
-                "Stage level scheduling in spark-rapids-ml will not work"
+                "Stage level scheduling in spark-rapids-ml will not work "
                 "when spark.executor.resource.gpu.amount>1"
             )
             return rdd
@@ -767,6 +767,10 @@ class _CumlEstimator(Estimator, _CumlCaller):
 
         treqs = TaskResourceRequests().cpus(task_cores).resource("gpu", task_gpus)
         rp = ResourceProfileBuilder().require(treqs).build
+
+        self.logger.info(
+            f"Training tasks require the resource(cores={task_cores}, gpu={task_gpus})"
+        )
 
         return rdd.withResources(rp)
 


### PR DESCRIPTION
When spark-rapids is enabled, assign task cpus to executor cpus to not allow GPU ETL tasks to run alongside the training tasks to avoid OOM. If spark-rapids is not enabled, set task cpus to executor_cpus/2 +1 to allow CPU tasks to run alongside the training task.