### PR TITLE
fix conda install commands

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,5 +37,5 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
 # install cuML
 ARG CUML_VER=23.08
 RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai-nightly -c nvidia -c conda-forge cuml=$CUML_VER python=3.9 cuda-toolkit=11.5 \
+    mamba install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.5 \
     && mamba clean --all -f -y

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -38,7 +38,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
 
 # install cuML
 
-RUN conda install -y -c rapidsai -c nvidia -c conda-forge python=3.9 cuda-toolkit=11.5 cuml=$CUML_VERSION \
+RUN conda install -y -c rapidsai -c conda-forge -c nvidia python=3.9 cudatoolkit=11.5 cuml=$CUML_VERSION \
     && conda clean --all -f -y
 
 # install python dependencies

--- a/python/README.md
+++ b/python/README.md
@@ -9,7 +9,7 @@ For simplicity, the following instructions just use Spark local mode, assuming a
 First, install RAPIDS cuML per [these instructions](https://rapids.ai/start.html).
 ```bash
 conda create -n rapids-23.06 \
-    -c rapidsai  -c conda-forge -c nvidia \
+    -c rapidsai -c conda-forge -c nvidia \
     cuml=23.06 python=3.9 cudatoolkit=11.5
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -9,7 +9,7 @@ For simplicity, the following instructions just use Spark local mode, assuming a
 First, install RAPIDS cuML per [these instructions](https://rapids.ai/start.html).
 ```bash
 conda create -n rapids-23.06 \
-    -c rapidsai -c nvidia -c conda-forge \
+    -c rapidsai  -c conda-forge -c nvidia \
     cuml=23.06 python=3.9 cudatoolkit=11.5
 ```
 


### PR DESCRIPTION
avoid cuda-toolkit and use [specified channel order](https://docs.rapids.ai/install#selector) which is apparently critical for correct cuda12/cuda11 dependencies.
23.08 will move to cuda-version from cudatoolkit so switched to that.