### PR TITLE
update rapids python deps to 23.08

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,5 +37,5 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
 # install cuML
 ARG CUML_VER=23.08
 RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.5 \
+    mamba install -y -c rapidsai -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.5 \
     && mamba clean --all -f -y

--- a/docker/Dockerfile.pip
+++ b/docker/Dockerfile.pip
@@ -18,7 +18,7 @@ ARG CUDA_VERSION=11.8.0
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
 
 ARG PYSPARK_VERSION=3.3.1
-ARG RAPIDS_VERSION=23.6.0
+ARG RAPIDS_VERSION=23.8.0
 ARG ARCH=amd64
 #ARG ARCH=arm64
 # Install packages to build spark-rapids-ml

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -17,7 +17,7 @@
 ARG CUDA_VERSION=11.5.2
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04
 
-ARG CUML_VERSION=23.06
+ARG CUML_VERSION=23.08
 
 # Install packages to build spark-rapids-ml
 RUN apt update -y \

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = 'spark-rapids-ml'
 copyright = '2023, NVIDIA'
 author = 'NVIDIA'
-release = '23.6.0'
+release = '23.8.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.nvidia</groupId>
     <artifactId>rapids-4-spark-ml_2.12</artifactId>
-    <version>23.06.0-SNAPSHOT</version>
+    <version>23.08.0-SNAPSHOT</version>
     <name>RAPIDS Accelerator for Apache Spark ML</name>
     <description>The RAPIDS cuML library for Apache Spark</description>
     <inceptionYear>2021</inceptionYear>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark_2.12</artifactId>
-            <version>23.06.0</version>
+            <version>23.08.0</version>
         </dependency>
 
 

--- a/notebooks/aws-emr/init-bootstrap-action.sh
+++ b/notebooks/aws-emr/init-bootstrap-action.sh
@@ -8,7 +8,7 @@ sudo chmod a+rwx -R /sys/fs/cgroup/devices
 sudo yum install -y gcc openssl-devel bzip2-devel libffi-devel tar gzip wget make mysql-devel
 sudo bash -c "wget https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tgz && tar xzf Python-3.9.9.tgz && cd Python-3.9.9 && ./configure --enable-optimizations && make altinstall"
 
-RAPIDS_VERSION=23.6.0
+RAPIDS_VERSION=23.8.0
 
 # install scikit-learn 
 sudo /usr/local/bin/pip3.9 install scikit-learn

--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # set portion of path below after /dbfs/ to dbfs zip file location
 SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/zip/file
-# IMPORTANT: specify RAPIDS_VERSION fully 23.6.0 and not 23.6
-# also RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.6.0 and not 23.06.0)
+# IMPORTANT: specify RAPIDS_VERSION fully 23.8.0 and not 23.8
+# also RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
 # while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.06.0 and not 23.6.0)
-RAPIDS_VERSION=23.6.0
+RAPIDS_VERSION=23.8.0
 SPARK_RAPIDS_VERSION=23.06.0
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda11.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar

--- a/notebooks/dataproc/spark_rapids_ml.sh
+++ b/notebooks/dataproc/spark_rapids_ml.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RAPIDS_VERSION=23.6.0
+RAPIDS_VERSION=23.8.0
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"

--- a/python/README.md
+++ b/python/README.md
@@ -8,9 +8,9 @@ For simplicity, the following instructions just use Spark local mode, assuming a
 
 First, install RAPIDS cuML per [these instructions](https://rapids.ai/start.html).
 ```bash
-conda create -n rapids-23.06 \
+conda create -n rapids-23.08 \
     -c rapidsai -c conda-forge -c nvidia \
-    cuml=23.06 python=3.9 cudatoolkit=11.5
+    cuml=23.08 python=3.9 cudatoolkit=11.5
 ```
 
 **Note**: while testing, we recommend using conda or docker to simplify installation and isolate your environment while experimenting.  Once you have a working environment, you can then try installing directly, if necessary.
@@ -19,7 +19,7 @@ conda create -n rapids-23.06 \
 
 Once you have the conda environment, activate it and install the required packages.
 ```bash
-conda activate rapids-23.06
+conda activate rapids-23.08
 
 # for development access to notebooks, tests, and benchmarks
 git clone --branch main https://github.com/NVIDIA/spark-rapids-ml.git

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -2,10 +2,10 @@
 # set portion of path below after /dbfs/ to dbfs zip file location
 SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/spark-rapids-ml.zip
 BENCHMARK_ZIP=/dbfs/path/to/benchmark.zip
-# IMPORTANT: specify rapids fully 23.6.0 and not 23.6
-# also RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.6.0 and not 23.06.0)
+# IMPORTANT: specify rapids fully 23.8.0 and not 23.8
+# also RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
 # while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.06.0 and not 23.6.0)
-RAPIDS_VERSION=23.6.0
+RAPIDS_VERSION=23.8.0
 SPARK_RAPIDS_VERSION=23.06.0
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda11.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar

--- a/python/benchmark/databricks/process_bm_log.sh
+++ b/python/benchmark/databricks/process_bm_log.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-grep -oe '\(==* algo:.*==\|fit:........\|fit_time...........\|training::........\|parameters\|2023.*worker memory\|2023.*cuml fit\|2023.*fit complete\)' $1
+grep -oe '\(==* algo:.*==\|fit:........\|fit_time...........\|training::........\|parameters\)' $1

--- a/python/benchmark/databricks/process_bm_log.sh
+++ b/python/benchmark/databricks/process_bm_log.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-grep -oe '\(==* algo:.*==\|fit:........\|fit_time...........\|training::........\|parameters\)' $1
+grep -oe '\(==* algo:.*==\|fit:........\|fit_time...........\|training::........\|parameters\|2023.*worker memory\|2023.*cuml fit\|2023.*fit complete\)' $1

--- a/python/benchmark/dataproc/init_benchmark.sh
+++ b/python/benchmark/dataproc/init_benchmark.sh
@@ -8,7 +8,7 @@ function get_metadata_attribute() {
   /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
 }
 
-RAPIDS_VERSION=$(get_metadata_attribute rapids-version 23.6.0)
+RAPIDS_VERSION=$(get_metadata_attribute rapids-version 23.8.0)
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spark-rapids-ml"
-version = "23.6.0"
+version = "23.8.0"
 authors = [
   { name="Jinfeng Li", email="jinfeng@nvidia.com" },
   { name="Bobby Wang", email="bobwang@nvidia.com" },

--- a/python/src/spark_rapids_ml/__init__.py
+++ b/python/src/spark_rapids_ml/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "23.6.0"
+__version__ = "23.8.0"


### PR DESCRIPTION
Note this is also changing the ci Dockerfile to pull in 23.08 release.   Should be changed to 23.10 nightly when we move to that branch.