### PR TITLE
[Logistic Regression] Fix bug when regParam is set to 0

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -35,8 +35,7 @@ from .metrics.MulticlassMetrics import MulticlassMetrics
 if TYPE_CHECKING:
     from pyspark.ml._typing import ParamMap
 
-import sys
-
+import numpy as np
 import pandas as pd
 from pyspark import Row, keyword_only
 from pyspark.ml.classification import BinaryRandomForestClassificationSummary
@@ -581,10 +580,10 @@ class LogisticRegressionClass(_CumlClass):
                 logger = get_logger(cls)
                 logger.warn(
                     "no regularization is not supported yet. if regParam is set to 0,"
-                    + "it will be mapped to smallest positive float sys.float_info.min"
+                    + "it will be mapped to smallest positive float, i.e. numpy.finfo('float32').tiny"
                 )
 
-                return 1.0 / sys.float_info.min
+                return 1.0 / np.finfo("float32").tiny.item()
             else:
                 return 1.0 / x
 

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -580,7 +580,8 @@ class LogisticRegressionClass(_CumlClass):
             if x == 0.0:
                 logger = get_logger(cls)
                 logger.warn(
-                    "no regularization is not supported yet. regParam=0 will be map to smallest positive float sys.float_info.min"
+                    "no regularization is not supported yet. if regParam is set to 0,"
+                    + "it will be mapped to smallest positive float sys.float_info.min"
                 )
 
                 return 1.0 / sys.float_info.min

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -93,9 +93,9 @@ from .utils import (
     _ArrayOrder,
     _concat_and_free,
     _get_spark_session,
-    java_uid,
     dtype_to_pyspark_type,
     get_logger,
+    java_uid,
 )
 
 T = TypeVar("T")

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -754,6 +754,7 @@ class LogisticRegression(
         **kwargs: Any,
     ):
         super().__init__()
+        self.set_params(**self._input_kwargs)
 
         # TODO: remove this checking and set regParam to 0.0 once no regularization is supported
         if regParam == 0.0:
@@ -761,8 +762,6 @@ class LogisticRegression(
                 "no regularization is not supported yet. regParam is set to 1e-300"
             )
             self.set_params(**{"regParam": sys.float_info.min})
-
-        self.set_params(**self._input_kwargs)
 
     def _fit_array_order(self) -> _ArrayOrder:
         return "C"
@@ -779,9 +778,11 @@ class LogisticRegression(
             params: Dict[str, Any],
         ) -> Dict[str, Any]:
             init_parameters = params[param_alias.cuml_init]
+            print(f"debug init_parameters is f{init_parameters}")
 
             from cuml.linear_model.logistic_regression_mg import LogisticRegressionMG
 
+            print(f"debug init_parameters: f{init_parameters}")
             logistic_regression = LogisticRegressionMG(
                 handle=params[param_alias.handle],
                 **init_parameters,

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -760,7 +760,7 @@ class LogisticRegression(
         predictionCol: str = "prediction",
         probabilityCol: str = "probability",
         maxIter: int = 100,
-        regParam: float = 0.0,  # NOTE: the default value of regParam is actually set to 1e-300 on GPU
+        regParam: float = 0.0,  # NOTE: the default value of regParam is actually mapped to sys.float_info.min on GPU
         tol: float = 1e-6,
         fitIntercept: bool = True,
         num_workers: Optional[int] = None,

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -75,6 +75,17 @@ def test_toy_example(gpu_number: int) -> None:
         assert len(probs) == len(preds)
         assert [p[1] > 0.5 for p in probs] == [True, True, False, False]
 
+        # test with regParam set to 0
+        lr_regParam_zero = LogisticRegression(
+            regParam=0.0,
+        )
+        assert lr_regParam_zero.getRegParam() == sys.float_info.min
+        model = lr_regParam_zero.fit(df)
+        assert model.coefficients.toArray() == pytest.approx(
+            [-17.21179962158203, 17.220483779907227], abs=1e-6
+        )
+        assert model.intercept == pytest.approx(0.008539911359548569, abs=1e-6)
+
 
 def test_params(tmp_path: str) -> None:
     # Default params

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -289,12 +289,10 @@ def test_compat(
             *feature_cols
         )
 
+        assert _LogisticRegression().getRegParam() == 0.0
         if lr_types[0] is SparkLogisticRegression:
-            assert _LogisticRegression().getRegParam() == 0.0
             blor = _LogisticRegression(regParam=0.1, standardization=False)
         else:
-            assert _LogisticRegression().getRegParam() == 0
-            assert _LogisticRegression().cuml_params["C"] == 1.0 / sys.float_info.min
             warnings.warn("spark rapids ml does not accept standardization")
             blor = _LogisticRegression(regParam=0.1)
 


### PR DESCRIPTION
This PR fixes the bug that LogisticRegression(regParam=0).fit(df) throws a division by zero error. 
The error is due to __init__:self.set_params(**self._input_kwargs), where self._input_kwargs is {"regParam", 0}, and in this case, _param_value_mapping will set cuml param C to 0. 

The fix revised _param_value_mapping to set cuml param C to 1.0 / sys.float_info.min when regParam is 0, and throws a warning for the implicit mapping of regParam from 0 to sys.float_info.min. 