### PR TITLE
RF classifier: map rawPredictionCol to empty and show the warning

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -124,8 +124,16 @@ class _RFClassifierParams(
         return self._set(rawPredictionCol=value)
 
 
+class _RandomForestClassifierClass(_RandomForestClass):
+    @classmethod
+    def _param_mapping(cls) -> Dict[str, Optional[str]]:
+        mapping = super()._param_mapping()
+        mapping["rawPredictionCol"] = ""
+        return mapping
+
+
 class RandomForestClassifier(
-    _RandomForestClass,
+    _RandomForestClassifierClass,
     _RandomForestEstimator,
     _RandomForestCumlParams,
     _RFClassifierParams,

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -172,8 +172,6 @@ class RandomForestClassifier(
         The prediction column name.
     probabilityCol
         The column name for predicted class conditional probabilities.
-    rawPredictionCol:
-        The raw prediction column name.
     maxDepth:
         Maximum tree depth. Must be greater than 0.
     maxBins:
@@ -287,7 +285,6 @@ class RandomForestClassifier(
         labelCol: str = "label",
         predictionCol: str = "prediction",
         probabilityCol: str = "probability",
-        rawPredictionCol: str = "rawPrediction",
         maxDepth: int = 5,
         maxBins: int = 32,
         minInstancesPerNode: int = 1,
@@ -576,6 +573,7 @@ class LogisticRegressionClass(_CumlClass):
             "lowerBoundsOnIntercepts": None,
             "upperBoundsOnIntercepts": None,
             "maxBlockSizeInMB": None,
+            "rawPredictionCol": "",
         }
 
     @classmethod
@@ -608,7 +606,11 @@ class LogisticRegressionClass(_CumlClass):
 
 
 class _LogisticRegressionCumlParams(
-    _CumlParams, _LogisticRegressionParams, HasFeaturesCols, HasProbabilityCol
+    _CumlParams,
+    _LogisticRegressionParams,
+    HasFeaturesCols,
+    HasProbabilityCol,
+    HasRawPredictionCol,
 ):
     def getFeaturesCol(self) -> Union[str, List[str]]:  # type:ignore
         """
@@ -664,6 +666,14 @@ class _LogisticRegressionCumlParams(
         Sets the value of :py:attr:`probabilityCol`.
         """
         return self.set_params(probabilityCol=value)
+
+    def setRawPredictionCol(
+        self: "_LogisticRegressionCumlParams", value: str
+    ) -> "_LogisticRegressionCumlParams":
+        """
+        Sets the value of :py:attr:`rawPredictionCol`.
+        """
+        return self._set(rawPredictionCol=value)
 
 
 class LogisticRegression(

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -323,6 +323,8 @@ def test_compat(
 
         blor_model.setFeaturesCol("features")
         blor_model.setProbabilityCol("newProbability")
+        blor_model.setRawPredictionCol("newRawPrediction")
+        assert blor_model.getRawPredictionCol() == "newRawPrediction"
         assert blor_model.getProbabilityCol() == "newProbability"
 
         coefficients = blor_model.coefficients.toArray()
@@ -355,7 +357,7 @@ def test_compat(
 
         if isinstance(blor_model, SparkLogisticRegressionModel):
             assert array_equal(
-                output.rawPrediction.toArray(),
+                output.newRawPrediction.toArray(),
                 Vectors.dense([-2.4238, 2.4238]).toArray(),
             )
         else:


### PR DESCRIPTION
spark-rapids-ml doesn't support rawPredictionCol, this PR just remove it.