### PR TITLE
Enable stage-level scheduling only when it's on the standalone cluster

### DIFF
--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -73,6 +73,13 @@ def _is_local(sc: SparkContext) -> bool:
     return sc._jsc.sc().isLocal()  # type: ignore
 
 
+def _is_standalone_or_localcluster(sc: SparkContext) -> bool:
+    master = sc.getConf().get("spark.master")
+    return master is not None and (
+        master.startswith("spark://") or master.startswith("local-cluster")
+    )
+
+
 def _str_or_numerical(x: str) -> Union[str, float, int]:
     """
     Convert to int if x is str representation of integer,


### PR DESCRIPTION
stage-level scheduling with dynamic allocation disabled only works on the standalone and local-cluster mode according to https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala#L70