### PR TITLE
bump ci docker image to use nightly 23.10 rapids deps

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,6 +37,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     && conda config --set solver libmamba
 
 # install cuML
-ARG CUML_VER=23.08
-RUN conda install -y -c rapidsai -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
+ARG CUML_VER=23.10
+RUN conda install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
     && conda clean --all -f -y


### PR DESCRIPTION
built image and ran regular unit tests and benchmark script.