### PR TITLE
databricks updates

### DIFF
--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -1,24 +1,24 @@
 ## Running notebooks on Databricks
 
 If you already have a Databricks account, you can run the example notebooks on a Databricks cluster, as follows:
-- Install the [databricks-cli](https://docs.databricks.com/dev-tools/cli/index.html).
+- Install the latest [databricks-cli](https://docs.databricks.com/dev-tools/cli/index.html).
 - Configure it with your workspace URL and an [access token](https://docs.databricks.com/dev-tools/api/latest/authentication.html).  For demonstration purposes, we will configure a new [connection profile](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) named `spark-rapids-ml`.  If you already have a connection profile, just set the `PROFILE` environment variable accordingly and skip the configure step.
-  ```
+  ```bash
   export PROFILE=spark-rapids-ml
   databricks configure --token --profile ${PROFILE}
   ```
 - Create a zip file for the `spark-rapids-ml` package.
-  ```
+  ```bash
   cd spark-rapids-ml/python/src
   zip -r spark_rapids_ml.zip spark_rapids_ml
   ```
 - Copy the zip file to DBFS, setting `SAVE_DIR` to the directory of your choice.
-  ```"
+  ```bash
   export SAVE_DIR="/path/to/save/artifacts"
   databricks fs cp spark_rapids_ml.zip dbfs:${SAVE_DIR}/spark_rapids_ml.zip --profile ${PROFILE}
   ```
 - Edit the [init-pip-cuda-11.8.sh](init-pip-cuda-11.8.sh) init script to set the `SPARK_RAPIDS_ML_ZIP` variable to the DBFS location used above.
-  ```
+  ```bash
   cd spark-rapids-ml/notebooks/databricks
   sed -i"" -e "s;/path/to/zip/file;${SAVE_DIR}/spark_rapids_ml.zip;" init-pip-cuda-11.8.sh
   ```
@@ -28,13 +28,15 @@ If you already have a Databricks account, you can run the example notebooks on a
   - updates the CUDA runtime to 11.8 (required for Spark Rapids ML dependencies).
   - downloads and installs the [Spark-Rapids](https://github.com/NVIDIA/spark-rapids) plugin for accelerating data loading and Spark SQL.
   - installs various `cuXX` dependencies via pip.
-- Copy the modified `init-pip-cuda-11.8.sh` init script to DBFS.
+- Copy the modified `init-pip-cuda-11.8.sh` init script to your *workspace* (not DBFS) (ex. workspace directory: /Users/<databricks-user-name>/init_scripts).
+  ```bash
+  export WS_SAVE_DIR="/path/to/directory/in/workspace"
+  databricks workspace mkdirs $WS_SAVE_DIR --profile ${PROFILE}
+  databricks workspace import --format AUTO init-pip-cuda-11.8.sh ${WS_SAVE_DIR}/init-pip-cuda-11.8.sh --profile ${PROFILE}
   ```
-  databricks fs cp init-pip-cuda-11.8.sh dbfs:${SAVE_DIR}/init-pip-cuda-11.8.sh --profile ${PROFILE}
-  ```
-- Create a cluster using **Databricks 11.3 LTS ML GPU Runtime** using at least two single-gpu workers and add the following configurations to the **Advanced options**.
+- Create a cluster using **Databricks 12.2 LTS ML GPU Runtime** using at least two single-gpu workers and add the following configurations to the **Advanced options**.
   - **Init Scripts**
-    - add the DBFS path to the uploaded init script, e.g. `dbfs:/path/to/save/artifacts/init-pip-cuda-11.8.sh`.
+    - add the workspace path to the uploaded init script, e.g. `${WS_SAVE_DIR}/init-pip-cuda-11.8.sh`.
   - **Spark**
     - **Spark config**
       ```

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -1,7 +1,7 @@
 ## Running notebooks on Databricks
 
 If you already have a Databricks account, you can run the example notebooks on a Databricks cluster, as follows:
-- Install the latest [databricks-cli](https://docs.databricks.com/dev-tools/cli/index.html).
+- Install the latest [databricks-cli](https://docs.databricks.com/dev-tools/cli/index.html).  Note that Databricks has deprecated the legacy python based cli in favor of a self contained executable. Make sure the new version is first on the executables PATH after installation.
 - Configure it with your workspace URL and an [access token](https://docs.databricks.com/dev-tools/api/latest/authentication.html).  For demonstration purposes, we will configure a new [connection profile](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) named `spark-rapids-ml`.  If you already have a connection profile, just set the `PROFILE` environment variable accordingly and skip the configure step.
   ```bash
   export PROFILE=spark-rapids-ml
@@ -31,8 +31,8 @@ If you already have a Databricks account, you can run the example notebooks on a
 - Copy the modified `init-pip-cuda-11.8.sh` init script to your *workspace* (not DBFS) (ex. workspace directory: /Users/<databricks-user-name>/init_scripts).
   ```bash
   export WS_SAVE_DIR="/path/to/directory/in/workspace"
-  databricks workspace mkdirs $WS_SAVE_DIR --profile ${PROFILE}
-  databricks workspace import --format AUTO init-pip-cuda-11.8.sh ${WS_SAVE_DIR}/init-pip-cuda-11.8.sh --profile ${PROFILE}
+  databricks workspace mkdirs ${WS_SAVE_DIR} --profile ${PROFILE}
+  databricks workspace import --format AUTO --content $(base64 -i init-pip-cuda-11.8.sh) ${WS_SAVE_DIR}/init-pip-cuda-11.8.sh --profile ${PROFILE}
   ```
 - Create a cluster using **Databricks 12.2 LTS ML GPU Runtime** using at least two single-gpu workers and add the following configurations to the **Advanced options**.
   - **Init Scripts**

--- a/python/benchmark/databricks/README.md
+++ b/python/benchmark/databricks/README.md
@@ -20,16 +20,16 @@ This directory contains shell scripts for running larger scale benchmarks on Dat
     ```
 4. Next, in [this](./) directory, run the following to upload the files required to run the benchmarks:
     ```bash
-    #change below to desired dbfs location WITHOUT DBFS URI for uploading benchmarking related files
+    # change below to desired dbfs location WITHOUT DBFS URI for uploading benchmarking related files
     export BENCHMARK_HOME=/path/to/benchmark/files/in/dbfs
 
-    # The below is mainly for cluster init script as databricks requires these to be stored in the workspace.
+    # need separate directory for cluster init script as databricks requires these to be stored in the workspace and not dbfs
     # ex: /Users/<databricks-user-name>/benchmark
     export WS_BENCHMARK_HOME=/path/to/benchmark/files/in/workspace
 
     ./setup.sh
     ```
-    This will create and copy the files into a DBFS folder at the path specified by `BENCHMARK_HOME` and a cluster init script to the workspace folder specified by `WS_BENCHMARK_HOME`.   The script will not overwrite existing files and instead simply print the error message returned from databricks.  If overwrite is desired, first deleted the files and/or directories using `databricks fs rm [-r] <dbfs path>` for the dbfs files and `databricks workspace rm [-r] <workspace ath>` for the workspace files.
+    This will create and copy the files into a DBFS directory at the path specified by `BENCHMARK_HOME` and a cluster init script to the workspace directory specified by `WS_BENCHMARK_HOME`.   The script will not overwrite existing files and instead simply print the error message returned from databricks.  If overwrite is desired, first deleted the files and/or directories using `databricks fs rm [-r] <dbfs path>` for the dbfs files and `databricks workspace delete [--recursive] <workspace path>` for the workspace files.
     Note: Export `BENCHMARK_HOME`, `WS_BENCHMARK_HOME` and `DB_PROFILE` in any new/different shell in which subsequent steps may be run.
 
 ## Running the benchmarks

--- a/python/benchmark/databricks/README.md
+++ b/python/benchmark/databricks/README.md
@@ -4,9 +4,9 @@ This directory contains shell scripts for running larger scale benchmarks on Dat
 
 ## Setup
 
-1. Install [databricks-cli](https://docs.databricks.com/dev-tools/cli/index.html) on your local workstation.
+1. Install latest [databricks-cli](https://docs.databricks.com/dev-tools/cli/index.html) on your local workstation.   Note that Databricks has deprecated the legacy python based cli in favor of a self contained executable.  Make sure the new version is first on the executables PATH.
     ```bash
-    pip install databricks-cli --upgrade
+    curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
     ```
 
 2. Generate an [access token](https://docs.databricks.com/dev-tools/api/latest/authentication.html) for your Databricks workspace in the `User Settings` section of the workspace UI.
@@ -15,23 +15,22 @@ This directory contains shell scripts for running larger scale benchmarks on Dat
     ```bash
     export DB_PROFILE=aws
     databricks configure --token --profile $DB_PROFILE
-    # 
+    # Host: <copy-and-paste databricks workspace url>
     # Token: <copy-and-paste access token from UI>
     ```
-
-4. Configure the Databricks cli to use the jobs 2.0 api.
-    ```bash
-    databricks jobs configure --version=2.0 --profile $DB_PROFILE
-    ```
-
-5. Next, in [this](./) directory, run the following to upload the files required to run the benchmarks:
+4. Next, in [this](./) directory, run the following to upload the files required to run the benchmarks:
     ```bash
     #change below to desired dbfs location WITHOUT DBFS URI for uploading benchmarking related files
     export BENCHMARK_HOME=/path/to/benchmark/files/in/dbfs
+
+    # The below is mainly for cluster init script as databricks requires these to be stored in the workspace.
+    # ex: /Users/<databricks-user-name>/benchmark
+    export WS_BENCHMARK_HOME=/path/to/benchmark/files/in/workspace
+
     ./setup.sh
     ```
-    This will create and copy the files into a DBFS folder at the path specified by `BENCHMARK_HOME`.
-    Note: Export `BENCHMARK_HOME` and `DB_PROFILE` in any new/different shell in which subsequent steps may be run.
+    This will create and copy the files into a DBFS folder at the path specified by `BENCHMARK_HOME` and a cluster init script to the workspace folder specified by `WS_BENCHMARK_HOME`.   The script will not overwrite existing files and instead simply print the error message returned from databricks.  If overwrite is desired, first deleted the files and/or directories using `databricks fs rm [-r] <dbfs path>` for the dbfs files and `databricks workspace rm [-r] <workspace ath>` for the workspace files.
+    Note: Export `BENCHMARK_HOME`, `WS_BENCHMARK_HOME` and `DB_PROFILE` in any new/different shell in which subsequent steps may be run.
 
 ## Running the benchmarks
 
@@ -54,7 +53,7 @@ This directory contains shell scripts for running larger scale benchmarks on Dat
 
 4. **Cancelling** a run:  Hit `Ctrl-C` and then cancel the run with the last printed `runid` (check using `tail benchmark_log`) by executing:
   ```bash
-  databricks runs cancel --run-id <runid> --profile $DB_PROFILE
+  databricks jobs cancel-run <runid> --profile $DB_PROFILE
   ```
 
 5. The created clusters are configured to terminate after 30 min, but can be manually terminated or deleted via the Databricks UI.

--- a/python/benchmark/databricks/benchmark_utils.sh
+++ b/python/benchmark/databricks/benchmark_utils.sh
@@ -9,6 +9,10 @@ if [[ -z $BENCHMARK_HOME ]]; then
     exit 1
 fi
 
+if [[ -z $WS_BENCHMARK_HOME ]]; then
+    echo "please expoert WS_BENCHMARK_HOME per README.md"
+    exit 1
+fi
 
 create_cluster() {
     cluster_type=$1
@@ -21,14 +25,16 @@ create_cluster() {
     then
         cluster_id=`echo $cluster_record | cut -d ' ' -f 1`
         echo "found cluster named $cluster_name and id $cluster_id deleting ..."
-        databricks clusters delete --cluster-id $cluster_id --profile $DB_PROFILE
+        databricks clusters delete $cluster_id --profile $DB_PROFILE
     fi
+    
+    INIT_SCRIPT_DIR="${WS_BENCHMARK_HOME}/init_scripts"
 
     # sourcing allows variable substitution (e.g. cluster name) into cluster json specs
     cluster_spec=`source ${cluster_type}_cluster_spec.sh`
     echo $cluster_spec
 
-    create_response=$( databricks clusters create --json "$cluster_spec" --profile $DB_PROFILE )
+    create_response=$( databricks clusters create --no-wait --json "$cluster_spec" --profile $DB_PROFILE )
 
     cluster_id=$( echo $create_response | grep cluster_id | cut -d \" -f 4 )
     if [ -z $cluster_id ]
@@ -42,14 +48,19 @@ create_cluster() {
     echo "waiting for cluster ${cluster_id} to start"
     while [[ $cluster_status != \"RUNNING\" ]]; do
         sleep 10
-        cluster_status=$( databricks clusters get --cluster-id $cluster_id --profile $DB_PROFILE | grep -o \"RUNNING\" )
+        cluster_status=$( databricks clusters get $cluster_id --profile $DB_PROFILE | grep -o \"RUNNING\" )
         echo -n "."
     done
 }
 
 get_run_status() {
-    status=$( databricks runs get-output --run-id $run_id --profile ${DB_PROFILE} | grep life_cycle_state | grep -o '\(TERMINATED\|ERROR\)' | head -n 1 )
+    status=$( databricks jobs get-run $run_id --profile ${DB_PROFILE} | grep life_cycle_state | grep -o '\(TERMINATED\|ERROR\)' | head -n 1 )
 }
+
+get_task_run_id() {
+    task_run_id=$( databricks jobs get-run $run_id --profile ${DB_PROFILE} | grep run_id | grep -o '\([0-9]*\)' | tail -n 1 )
+}
+
 
 run_bm() {
 
@@ -60,18 +71,23 @@ run_bm() {
 json_string=`cat <<EOF
 {
     "run_name": "$algorithm",
-    "existing_cluster_id": "${cluster_id}",
-    "spark_python_task": {
-            "python_file": "dbfs:${BENCHMARK_HOME}/scripts/benchmark_runner.py",
-            "parameters": [
-                ${params_delimited},
-                "--num_gpus",
-                "${num_gpus}",
-                "--num_cpus",
-                "${num_cpus}",
-                "--no_shutdown"
-            ]
+    "tasks": [
+        {
+            "task_key": "run_task",
+            "existing_cluster_id": "${cluster_id}",
+            "spark_python_task": {
+                "python_file": "dbfs:${BENCHMARK_HOME}/scripts/benchmark_runner.py",
+                "parameters": [
+                    ${params_delimited},
+                    "--num_gpus",
+                    "${num_gpus}",
+                    "--num_cpus",
+                    "${num_cpus}",
+                    "--no_shutdown"
+                ]
+            }
         }
+    ]               
 }
 EOF
 `
@@ -81,7 +97,7 @@ EOF
     TIME_LIMIT=3600
     fi
 
-    submit_response=$( databricks runs submit --json "$json_string" --profile ${DB_PROFILE} )
+    submit_response=$( databricks jobs submit --no-wait --json "$json_string" --profile ${DB_PROFILE} )
     echo ${submit_response} | grep run_id > /dev/null
     if [[ $? != 0 ]]; then
         echo "error submitting run"
@@ -101,14 +117,15 @@ EOF
         if [[ $TIME_LIMIT != "" ]] && (( $duration > $TIME_LIMIT ))
         then
             echo "\ntime limit of $TIME_LIMIT minutes exceeded, canceling run"
-            databricks runs cancel --run-id $run_id --profile $DB_PROFILE
+            databricks jobs cancel-run $run_id --profile $DB_PROFILE
         fi
         sleep 10
         duration=$(( $duration + 10 ))
         get_run_status
     done
 
-    databricks runs get-output --run-id $run_id --profile ${DB_PROFILE}
+    get_task_run_id
+    databricks jobs get-run-output $task_run_id --profile ${DB_PROFILE}
     if [[ $status == "ERROR" ]]; then
         echo "An error was encountered during run.  Exiting."
         exit 1

--- a/python/benchmark/databricks/cpu_cluster_spec.sh
+++ b/python/benchmark/databricks/cpu_cluster_spec.sh
@@ -28,8 +28,8 @@ cat <<EOF
     "enable_elastic_disk": false,
     "init_scripts": [
         {
-            "dbfs": {
-                "destination": "dbfs:${BENCHMARK_HOME}/init_script/init-cpu.sh"
+            "workspace": {
+                "destination": "${INIT_SCRIPT_DIR}/init-cpu.sh"
             }
         }
     ],

--- a/python/benchmark/databricks/gpu_cluster_spec.sh
+++ b/python/benchmark/databricks/gpu_cluster_spec.sh
@@ -3,7 +3,7 @@ cat <<EOF
 {
     "num_workers": $num_gpus,
     "cluster_name": "$cluster_name",
-    "spark_version": "11.3.x-gpu-ml-scala2.12",
+    "spark_version": "12.2.x-gpu-ml-scala2.12",
     "spark_conf": {
         "spark.task.resource.gpu.amount": "0.25",
         "spark.task.cpus": "1",
@@ -55,8 +55,8 @@ cat <<EOF
     "enable_elastic_disk": false,
     "init_scripts": [
         {
-            "dbfs": {
-                "destination": "dbfs:${BENCHMARK_HOME}/init_script/init-pip-cuda-11.8.sh"
+            "workspace": {
+                "destination": "${INIT_SCRIPT_DIR}/init-pip-cuda-11.8.sh"
             }
         }
     ],

--- a/python/benchmark/databricks/setup.sh
+++ b/python/benchmark/databricks/setup.sh
@@ -49,7 +49,6 @@ databricks workspace mkdirs ${INIT_SCRIPT_DIR} --profile ${DB_PROFILE} ${DB_OVER
 for init_script in init-pip-cuda-11.8.sh init-cpu.sh
 do
 # NOTE: on linux delete the .bu after -i
-# NOTE: the language specified for the workspace import doesn't seem to impact the upload in this case, but is a required option"
     sed -e "s#/path/to/spark-rapids-ml\.zip#${SPARK_RAPIDS_ML_ZIP}#g" -e "s#/path/to/benchmark\.zip#${BENCHMARK_ZIP}#g" $init_script > ${init_script}.updated && \
     databricks workspace import --format AUTO --content $(base64 -i ${init_script}.updated) ${INIT_SCRIPT_DIR}/${init_script} --profile ${DB_PROFILE} ${DB_OVERWRITE}
 done

--- a/python/benchmark/databricks/setup.sh
+++ b/python/benchmark/databricks/setup.sh
@@ -12,34 +12,44 @@ if [[ -z $BENCHMARK_HOME ]]; then
     exit 1
 fi
 
+if [[ -z $WS_BENCHMARK_HOME ]]; then
+    echo "please expoert WS_BENCHMARK_HOME per README.md"
+    exit 1
+fi
+
 SPARK_RAPIDS_ML_HOME='../..'
 
 echo "**** copying benchmarking related files to ${BENCHMARK_HOME} ****"
 
-INIT_SCRIPT_DIR="${BENCHMARK_HOME}/init_scripts"
+INIT_SCRIPT_DIR="${WS_BENCHMARK_HOME}/init_scripts"
 SPARK_RAPIDS_ML_ZIP="${BENCHMARK_HOME}/zips/spark-rapids-ml.zip"
 BENCHMARK_ZIP="${BENCHMARK_HOME}/zips/benchmark.zip"
 BENCHMARK_SCRIPTS="${BENCHMARK_HOME}/scripts"
+databricks fs mkdirs dbfs:${BENCHMARK_HOME}/zips --profile $DB_PROFILE
+databricks fs mkdirs dbfs:${BENCHMARK_HOME}/scripts --profile $DB_PROFILE
 
 pushd ${SPARK_RAPIDS_ML_HOME}/benchmark && rm -f benchmark.zip && \
 zip -r benchmark.zip benchmark && \
-databricks fs cp benchmark.zip dbfs:${BENCHMARK_ZIP} --profile ${DB_PROFILE} ${DB_OVERWRITE} && \
+databricks fs cp benchmark.zip dbfs:${BENCHMARK_ZIP} --profile ${DB_PROFILE} ${DB_OVERWRITE}
 popd
 
 pushd ${SPARK_RAPIDS_ML_HOME} && \
 ls benchmark
-databricks fs cp benchmark/benchmark_runner.py dbfs:${BENCHMARK_SCRIPTS}/benchmark_runner.py --profile  ${DB_PROFILE} ${DB_OVERWRITE} && \
+databricks fs cp benchmark/benchmark_runner.py dbfs:${BENCHMARK_SCRIPTS}/benchmark_runner.py --profile  ${DB_PROFILE} ${DB_OVERWRITE}
 popd
 
 pushd ${SPARK_RAPIDS_ML_HOME}/src && rm -f spark-rapids-ml.zip && \
 zip -r spark-rapids-ml.zip spark_rapids_ml && \
-databricks fs cp spark-rapids-ml.zip dbfs:${SPARK_RAPIDS_ML_ZIP} --profile ${DB_PROFILE} ${DB_OVERWRITE} && \
+databricks fs cp spark-rapids-ml.zip dbfs:${SPARK_RAPIDS_ML_ZIP} --profile ${DB_PROFILE} ${DB_OVERWRITE}
 popd
 
+# create workspace directory
+databricks workspace mkdirs ${INIT_SCRIPT_DIR} --profile ${DB_PROFILE} ${DB_OVERWRITE}
 # point cpu and gpu cluster init scripts to new files and upload
 for init_script in init-pip-cuda-11.8.sh init-cpu.sh
 do
 # NOTE: on linux delete the .bu after -i
+# NOTE: the language specified for the workspace import doesn't seem to impact the upload in this case, but is a required option"
     sed -e "s#/path/to/spark-rapids-ml\.zip#${SPARK_RAPIDS_ML_ZIP}#g" -e "s#/path/to/benchmark\.zip#${BENCHMARK_ZIP}#g" $init_script > ${init_script}.updated && \
-    databricks fs cp ${init_script}.updated dbfs:${BENCHMARK_HOME}/init_script/${init_script} --profile ${DB_PROFILE} ${DB_OVERWRITE}
+    databricks workspace import --format AUTO --content $(base64 -i ${init_script}.updated) ${INIT_SCRIPT_DIR}/${init_script} --profile ${DB_PROFILE} ${DB_OVERWRITE}
 done


### PR DESCRIPTION
- runtime from 11.3 to 12.2
- cluster init script in workspace
- latest version of databricks cli (old one didn't support workspace imports for non-python scripts)
- use 2.1 api for clusters, runs, etc.  as latest cli only supports 2.1
