### PR TITLE
changes to databricks init script for updated kernel drivers

### DIFF
--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -65,7 +65,6 @@ If you already have a Databricks account, you can run the example notebooks on a
     - **Environment variables**
       ```
       LIBCUDF_CUFILE_POLICY=OFF
-      LD_LIBRARY_PATH=/usr/local/cuda/compat:/usr/local/cuda/lib64
       NCCL_DEBUG=INFO
       ```
 - Start the configured cluster.

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -28,7 +28,10 @@ If you already have a Databricks account, you can run the example notebooks on a
   - updates the CUDA runtime to 11.8 (required for Spark Rapids ML dependencies).
   - downloads and installs the [Spark-Rapids](https://github.com/NVIDIA/spark-rapids) plugin for accelerating data loading and Spark SQL.
   - installs various `cuXX` dependencies via pip.
-- Copy the modified `init-pip-cuda-11.8.sh` init script to your *workspace* (not DBFS) (ex. workspace directory: /Users/<databricks-user-name>/init_scripts).
+
+  **Note**: as of the last update of this README, Azure Databricks requires a CUDA driver forward compatibility package.  Uncomment the designated lines for this in the init script.  AWS Databricks does not need this and leave the lines commented in that case.
+
+- Copy the modified `init-pip-cuda-11.8.sh` init script to your *workspace* (not DBFS) (ex. workspace directory: /Users/< databricks-user-name >/init_scripts).
   ```bash
   export WS_SAVE_DIR="/path/to/directory/in/workspace"
   databricks workspace mkdirs ${WS_SAVE_DIR} --profile ${PROFILE}
@@ -66,6 +69,10 @@ If you already have a Databricks account, you can run the example notebooks on a
       ```
       LIBCUDF_CUFILE_POLICY=OFF
       NCCL_DEBUG=INFO
+      ```
+    - **Additional Environment variable for Azure Databricks**
+      ```
+      LD_LIBRARY_PATH=/usr/local/cuda/compat:/usr/local/cuda/lib64
       ```
 - Start the configured cluster.
 - Select your workspace and upload the desired [notebook](../) via `Import` in the drop down menu for your workspace.

--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -13,6 +13,18 @@ curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RA
 wget https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run
 sh cuda_11.8.0_520.61.05_linux.run --silent --toolkit
 
+# install forward compatibility package due to old driver
+# uncomment below lines on Azure Databricks
+# distro=ubuntu2004
+# arch=x86_64
+# apt-key del 7fa2af80
+# wget https://developer.download.nvidia.com/compute/cuda/repos/$distro/$arch/cuda-keyring_1.0-1_all.deb
+# dpkg -i cuda-keyring_1.0-1_all.deb
+# apt-get update
+# apt-get install -y cuda-compat-11-8
+# export LD_LIBRARY_PATH=/usr/local/cuda/compat:/usr/local/cuda/lib64
+# ldconfig
+
 # reset symlink and update library loading paths
 rm /usr/local/cuda
 ln -s /usr/local/cuda-11.8 /usr/local/cuda

--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -13,22 +13,9 @@ curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RA
 wget https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run
 sh cuda_11.8.0_520.61.05_linux.run --silent --toolkit
 
-# install forward compatibility package due to old driver
-distro=ubuntu2004
-arch=x86_64
-apt-key del 7fa2af80
-wget https://developer.download.nvidia.com/compute/cuda/repos/$distro/$arch/cuda-keyring_1.0-1_all.deb
-dpkg -i cuda-keyring_1.0-1_all.deb
-apt-get update
-apt-get install -y cuda-compat-11-8
-
-
 # reset symlink and update library loading paths
-# **** set LD_LIBRARY_PATH as below in env var section of cluster config in DB cluster UI ****
 rm /usr/local/cuda
 ln -s /usr/local/cuda-11.8 /usr/local/cuda
-export LD_LIBRARY_PATH=/usr/local/cuda/compat:/usr/local/cuda/lib64
-ldconfig
 
 # upgrade pip
 /databricks/python/bin/pip install --upgrade pip

--- a/python/benchmark/databricks/gpu_cluster_spec.sh
+++ b/python/benchmark/databricks/gpu_cluster_spec.sh
@@ -48,7 +48,6 @@ cat <<EOF
     },
     "spark_env_vars": {
         "LIBCUDF_CUFILE_POLICY": "OFF",
-        "LD_LIBRARY_PATH": "/usr/local/cuda/compat:/usr/local/cuda/lib64",
         "NCCL_DEBUG": "INFO"
     },
     "autotermination_minutes": 30,

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -14,22 +14,10 @@ curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RA
 wget https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run
 sh cuda_11.8.0_520.61.05_linux.run --silent --toolkit
 
-# install forward compatibility package due to old driver
-distro=ubuntu2004
-arch=x86_64
-apt-key del 7fa2af80
-wget https://developer.download.nvidia.com/compute/cuda/repos/$distro/$arch/cuda-keyring_1.0-1_all.deb
-dpkg -i cuda-keyring_1.0-1_all.deb
-apt-get update
-apt-get install -y cuda-compat-11-8
-
-
 # reset symlink and update library loading paths
 # **** set LD_LIBRARY_PATH as below in env var section of cluster config in DB cluster UI ****
 rm /usr/local/cuda
 ln -s /usr/local/cuda-11.8 /usr/local/cuda
-export LD_LIBRARY_PATH=/usr/local/cuda/compat:/usr/local/cuda/lib64
-ldconfig
 
 # upgrade pip
 /databricks/python/bin/pip install --upgrade pip


### PR DESCRIPTION
Databricks AWS recently updated gpu kernel driver versions.
Forward compatibility no longer needed and can cause problems in some runtimes.

Databricks Azure still has older drivers, so leaving needed lines in comments for notebook examples.