### PR TITLE
add place holder for draft release docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,3 +52,4 @@ exclude:
 
 include:
   - _static
+  - _sphinx*

--- a/api/index.md
+++ b/api/index.md
@@ -4,4 +4,6 @@ nav_order: 5
 ---
 # API Documentation
 
-- [Python API](python)
+- Python API 
+  - [Stable Release](python)
+  - [Draft](python-draft)


### PR DESCRIPTION
and fixing error involving a sphinx generated .js file starting with underscore when running jekyll locally.