### PR TITLE
[auto-merge] branch-23.10 to branch-23.12 [skip ci] [bot]

### DIFF
--- a/ci/docs.sh
+++ b/ci/docs.sh
@@ -17,6 +17,7 @@
 
 if [[ $1 == "nightly" ]]; then
     TAG=$(git log -1 --format="%h")
+    BRANCH=$(git branch --show-current)
 else
     # get version tag
     TAG="v$VERSION"
@@ -51,7 +52,7 @@ repo_url=$(git config --get remote.origin.url)
 url=${repo_url#https://}
 github_account=${GITHUB_ACCOUNT:-nvauto}
 if [[ -n $dff ]]; then
-    git commit -m "${TAG}"
+    git commit -m "Update draft api docs to commit ${TAG} on ${BRANCH}"
     git push -f https://${github_account}:${GITHUB_TOKEN}@${url} gh-pages
 fi
 


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-23.10` to create a PR keeping `branch-23.12` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.