### PR TITLE
output raw prediction column

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -295,7 +295,6 @@ class _RandomForestClassifierClass(_RandomForestClass):
     @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
         mapping = super()._param_mapping()
-        mapping["rawPredictionCol"] = ""
         return mapping
 
 
@@ -337,8 +336,10 @@ class RandomForestClassifier(
         The label column name.
     predictionCol:
         The prediction column name.
-    probabilityCol
+    probabilityCol:
         The column name for predicted class conditional probabilities.
+    rawPredictionCol:
+        The column name for class raw predictions - this is currently set equal to probabilityCol values.
     maxDepth:
         Maximum tree depth. Must be greater than 0.
     maxBins:
@@ -452,6 +453,7 @@ class RandomForestClassifier(
         labelCol: str = "label",
         predictionCol: str = "prediction",
         probabilityCol: str = "probability",
+        rawPredictionCol: str = "rawPrediction",
         maxDepth: int = 5,
         maxBins: int = 32,
         minInstancesPerNode: int = 1,
@@ -652,7 +654,6 @@ class LogisticRegressionClass(_CumlClass):
             "lowerBoundsOnIntercepts": None,
             "upperBoundsOnIntercepts": None,
             "maxBlockSizeInMB": None,
-            "rawPredictionCol": "",
         }
 
     @classmethod
@@ -809,6 +810,8 @@ class LogisticRegression(
         The class prediction column name.
     probabilityCol:
         The probability prediction column name.
+    rawPredictionCol:
+        The column name for class raw predictions - this is currently set equal to probabilityCol values.
     maxIter:
         The maximum number of iterations of the underlying L-BFGS algorithm.
     regParam:
@@ -875,6 +878,7 @@ class LogisticRegression(
         labelCol: str = "label",
         predictionCol: str = "prediction",
         probabilityCol: str = "probability",
+        rawPredictionCol: str = "rawPrediction",
         maxIter: int = 100,
         regParam: float = 0.0,
         elasticNetParam: float = 0.0,

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -80,10 +80,12 @@ def test_toy_example(gpu_number: int) -> None:
         def assert_transform(model: LogisticRegressionModel) -> None:
             preds_df_local = model.transform(df).collect()
             preds = [row["prediction"] for row in preds_df_local]
-            assert preds == [1.0, 1.0, 0.0, 0.0]
             probs = [row["probs"] for row in preds_df_local]
+            raw_preds = [row["rawPrediction"] for row in preds_df_local]
+            assert preds == [1.0, 1.0, 0.0, 0.0]
             assert len(probs) == len(preds)
             assert [p[1] > 0.5 for p in probs] == [True, True, False, False]
+            assert [p[1] > 0 for p in raw_preds] == [True, True, False, False]
 
         assert_transform(lr_model)
 
@@ -466,16 +468,11 @@ def test_compat(
             tolerance,
         )
 
-        if isinstance(blor_model, SparkLogisticRegressionModel):
-            assert array_equal(
-                output.newRawPrediction.toArray(),
-                Vectors.dense([-2.4238, 2.4238]).toArray(),
-                tolerance,
-            )
-        else:
-            warnings.warn(
-                "transform of spark rapids ml currently does not support rawPredictionCol"
-            )
+        array_equal(
+            output.newRawPrediction.toArray(),
+            Vectors.dense([-2.4238, 2.4238]).toArray(),
+            tolerance,
+        )
 
         blor_path = tmp_path + "/log_reg"
         blor.save(blor_path)
@@ -823,51 +820,45 @@ def test_compat_multinomial(
             tolerance,
         )
 
-        if isinstance(mlor_model, SparkLogisticRegressionModel):
-            assert array_equal(
-                output_res[0].rawPrediction.toArray(),
-                [0.84395339, 1.87349042, -0.84395339, -1.87349042],
-                tolerance,
-            )
-            assert array_equal(
-                output_res[1].rawPrediction.toArray(),
-                [0.78209218, 2.84116623, -0.78209218, -2.84116623],
-                tolerance,
-            )
-            assert array_equal(
-                output_res[2].rawPrediction.toArray(),
-                [1.87349042, 0.84395339, -1.87349042, -0.84395339],
-                tolerance,
-            )
-            assert array_equal(
-                output_res[3].rawPrediction.toArray(),
-                [2.84116623, 0.78209218, -2.84116623, -0.78209218],
-                tolerance,
-            )
-            assert array_equal(
-                output_res[4].rawPrediction.toArray(),
-                [-0.84395339, -1.87349042, 0.84395339, 1.87349042],
-                tolerance,
-            )
-            assert array_equal(
-                output_res[5].rawPrediction.toArray(),
-                [-0.78209218, -2.84116623, 0.78209218, 2.84116623],
-            )
-            assert array_equal(
-                output_res[6].rawPrediction.toArray(),
-                [-1.87349042, -0.84395339, 1.87349042, 0.84395339],
-                tolerance,
-            )
-            assert array_equal(
-                output_res[7].rawPrediction.toArray(),
-                [-2.84116623, -0.78209218, 2.84116623, 0.78209218],
-                tolerance,
-            )
-
-        else:
-            warnings.warn(
-                "transform of spark rapids ml currently does not support rawPredictionCol"
-            )
+        assert array_equal(
+            output_res[0].rawPrediction.toArray(),
+            [0.84395339, 1.87349042, -0.84395339, -1.87349042],
+            tolerance,
+        )
+        assert array_equal(
+            output_res[1].rawPrediction.toArray(),
+            [0.78209218, 2.84116623, -0.78209218, -2.84116623],
+            tolerance,
+        )
+        assert array_equal(
+            output_res[2].rawPrediction.toArray(),
+            [1.87349042, 0.84395339, -1.87349042, -0.84395339],
+            tolerance,
+        )
+        assert array_equal(
+            output_res[3].rawPrediction.toArray(),
+            [2.84116623, 0.78209218, -2.84116623, -0.78209218],
+            tolerance,
+        )
+        assert array_equal(
+            output_res[4].rawPrediction.toArray(),
+            [-0.84395339, -1.87349042, 0.84395339, 1.87349042],
+            tolerance,
+        )
+        assert array_equal(
+            output_res[5].rawPrediction.toArray(),
+            [-0.78209218, -2.84116623, 0.78209218, 2.84116623],
+        )
+        assert array_equal(
+            output_res[6].rawPrediction.toArray(),
+            [-1.87349042, -0.84395339, 1.87349042, 0.84395339],
+            tolerance,
+        )
+        assert array_equal(
+            output_res[7].rawPrediction.toArray(),
+            [-2.84116623, -0.78209218, 2.84116623, 0.78209218],
+            tolerance,
+        )
 
         mlor_path = tmp_path + "/m_log_reg"
         mlor.save(mlor_path)

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -848,6 +848,7 @@ def test_compat_multinomial(
         assert array_equal(
             output_res[5].rawPrediction.toArray(),
             [-0.78209218, -2.84116623, 0.78209218, 2.84116623],
+            tolerance,
         )
         assert array_equal(
             output_res[6].rawPrediction.toArray(),


### PR DESCRIPTION
For logistic regression using api found by @lijinf2 https://docs.rapids.ai/api/cuml/stable/api/#cuml.LogisticRegression.decision_function which matches spark's actual raw prediction output.    probability and prediction columns derived using cupy from this column to avoid repeated inference computations.

For random forest, raw prediction col is set to a copy of probability col, for compatibility with Spark's BinaryClassificationEvaluator default columns.