### PR TITLE
Keep docstring consistent on supporting vector, array, and columnar input formats

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -329,7 +329,7 @@ class RandomForestClassifier(
     Parameters
     ----------
 
-    featuresCol:
+    featuresCol: str or List[str]
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.
@@ -799,7 +799,7 @@ class LogisticRegression(
 
     Parameters
     ----------
-    featuresCol:
+    featuresCol: str or List[str]
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -104,7 +104,7 @@ class _KMeansCumlParams(_CumlParams, _KMeansParams, HasFeaturesCols):
 
     def setFeaturesCol(self: P, value: Union[str, List[str]]) -> P:
         """
-        Sets the value of :py:attr:`featuresCol` or :py:attr:`featuresCols`. Used when input vectors are stored in a single column.
+        Sets the value of :py:attr:`featuresCol` or :py:attr:`featuresCols`.
         """
         if isinstance(value, str):
             self._set_params(featuresCol=value)
@@ -149,11 +149,10 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
     tol: float (default = 1e-4)
         early stopping criterion if centers do not change much after an iteration.
 
-    featuresCol: str
-        the name of the column that contains input vectors. featuresCol should be set when input vectors are stored in a single column of a dataframe.
-
-    featuresCols: List[str]
-        the names of feature columns that form input vectors. featureCols should be set when input vectors are stored as multiple feature columns of a dataframe.
+    featuresCol: str or List[str]
+        The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
+            * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
+            * When the value is a list of strings, the feature columns must be numeric types.
 
     predictionCol: str
         the name of the column that stores cluster indices of input vectors. predictionCol should be set when users expect to apply the transform function of a learned model.

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -76,7 +76,7 @@ class _PCACumlParams(_CumlParams, _PCAParams, HasInputCols):
 
     def setInputCol(self: P, value: Union[str, List[str]]) -> P:
         """
-        Sets the value of :py:attr:`inputCol` or :py:attr:`inputCols`. Used when input vectors are stored in a single column.
+        Sets the value of :py:attr:`inputCol` or :py:attr:`inputCols`.
         """
         if isinstance(value, str):
             self._set_params(inputCol=value)
@@ -108,13 +108,11 @@ class PCA(PCAClass, _CumlEstimator, _PCACumlParams):
     ----------
     k: int
         the number of components, or equivalently the dimension that all vectors will be projected to.
-    inputCol: str
-        the name of the column that contains input vectors. inputCol should be set when input vectors
-        are stored in a single column of a dataframe.
 
-    inputCols: List[str]
-        the names of feature columns that form input vectors. inputCols should be set when input vectors
-        are stored as multiple feature columns of a dataframe.
+    inputCol: str or List[str]
+        The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
+            * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
+            * When the value is a list of strings, the feature columns must be numeric types.
 
     outputCol: str
         the name of the column that stores output vectors. outputCol should be set when users expect to
@@ -252,6 +250,9 @@ class PCAModel(PCAClass, _CumlModelWithColumns, _PCACumlParams):
     Spark PCA does not automatically remove the mean of the input data, so use the
     :py:class::`~pyspark.ml.feature.StandardScaler` to center the input data before
     invoking transform.
+
+    The input vectors can be stored in three different formats: a column of vector,
+    a column of array, or multiple scalar columns.
 
     Examples
     --------

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -100,7 +100,7 @@ class _NearestNeighborsCumlParams(_CumlParams, HasInputCol, HasLabelCol, HasInpu
 
     def setInputCol(self: P, value: Union[str, List[str]]) -> P:
         """
-        Sets the value of :py:attr:`inputCol` or :py:attr:`inputCols`. Used when input vectors are stored in a single column.
+        Sets the value of :py:attr:`inputCol` or :py:attr:`inputCols`.
         """
         if isinstance(value, str):
             self._set_params(inputCol=value)
@@ -163,13 +163,10 @@ class NearestNeighbors(
     k: int (default = 5)
         the default number nearest neighbors to retrieve for each query.
 
-    inputCol: str
-        the name of the column that contains input vectors. inputCol should be set when feature vectors
-        are stored in a single column of a dataframe.
-
-    inputCols: List[str]
-        the names of feature columns that form input vectors. inputCols should be set when input vectors
-        are stored as multiple feature columns of a dataframe.
+    inputCol: str or List[str]
+        The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
+            * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
+            * When the value is a list of strings, the feature columns must be numeric types.
 
     idCol: str
         the name of the column in a dataframe that uniquely identifies each vector. idCol should be set

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -301,7 +301,7 @@ class LinearRegression(
     Parameters
     ----------
 
-    featuresCol:
+    featuresCol: str or List[str]
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.
@@ -813,7 +813,7 @@ class RandomForestRegressor(
     Parameters
     ----------
 
-    featuresCol:
+    featuresCol: str or List[str]
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -710,13 +710,10 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
         datasets must be subsampled to fit within the node's memory and execute in a reasonable time. Smaller fractions
         will result in faster training, but may result in sub-optimal embeddings.
 
-    featuresCol: str
-        The name of the column that contains input vectors. featuresCol should be set when input vectors are stored
-        in a single column of a dataframe.
-
-    featuresCols: List[str]
-        The names of the columns that contain input vectors. featuresCols should be set when input vectors are stored
-        in multiple columns of a dataframe.
+    featuresCol: str or List[str]
+        The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
+            * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
+            * When the value is a list of strings, the feature columns must be numeric types.
 
     labelCol: str (optional)
         The name of the column that contains labels. If provided, supervised fitting will be performed, where labels


### PR DESCRIPTION
Removed featuresCols and inputCols in docstring as they have been included in featuresCol and inputCol.