### PR TITLE
add estimator class parameters into constructor for PCA and KMeans

### DIFF
--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from pyspark import keyword_only
 from pyspark.ml.common import _py2java
 from pyspark.ml.feature import PCAModel as SparkPCAModel
 from pyspark.ml.feature import _PCAParams
@@ -118,6 +119,22 @@ class PCA(PCAClass, _CumlEstimator, _PCACumlParams):
         the name of the column that stores output vectors. outputCol should be set when users expect to
         store output vectors in a single column.
 
+    num_workers:
+        Number of cuML workers, where each cuML worker corresponds to one Spark task
+        running on one GPU. If not set, spark-rapids-ml tries to infer the number of
+        cuML workers (i.e. GPUs in cluster) from the Spark environment.
+
+    verbose:
+    Logging level.
+            * ``0`` - Disables all log messages.
+            * ``1`` - Enables only critical messages.
+            * ``2`` - Enables all messages up to and including errors.
+            * ``3`` - Enables all messages up to and including warnings.
+            * ``4 or False`` - Enables all messages up to and including information messages.
+            * ``5 or True`` - Enables all messages up to and including debug messages.
+            * ``6`` - Enables all messages up to and including trace messages.
+
+
 
     Examples
     --------
@@ -163,9 +180,19 @@ class PCA(PCAClass, _CumlEstimator, _PCACumlParams):
     >>> gpu_model = gpu_pca.fit(df)
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    @keyword_only
+    def __init__(
+        self,
+        *,
+        k: Optional[int] = None,
+        inputCol: Optional[Union[str, List[str]]] = None,
+        outputCol: Optional[str] = None,
+        num_workers: Optional[int] = None,
+        verbose: Union[int, bool] = False,
+        **kwargs: Any,
+    ) -> None:
         super().__init__()
-        self._set_params(**kwargs)
+        self._set_params(**self._input_kwargs)
 
     def setK(self, value: int) -> "PCA":
         """

--- a/python/tests/test_kmeans.py
+++ b/python/tests/test_kmeans.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from typing import List, Tuple, Type, TypeVar
+from typing import Any, Dict, List, Tuple, Type, TypeVar
 
 import numpy as np
 import pytest
@@ -86,7 +86,7 @@ def test_kmeans_params(
     assert_params(default_kmeans, default_spark_params, default_cuml_params)
 
     # Spark Params constructor
-    spark_params = {"k": 10, "maxIter": 100}
+    spark_params: Dict[str, Any] = {"k": 10, "maxIter": 100}
     spark_kmeans = KMeans(**spark_params)
     expected_spark_params = default_spark_params.copy()
     expected_spark_params.update(spark_params)
@@ -95,7 +95,7 @@ def test_kmeans_params(
     assert_params(spark_kmeans, expected_spark_params, expected_cuml_params)
 
     # cuml_params constructor
-    cuml_params = {
+    cuml_params: Dict[str, Any] = {
         "n_clusters": 10,
         "max_iter": 100,
         "tol": 1e-1,
@@ -120,7 +120,7 @@ def test_kmeans_params(
     assert_params(loaded_kmeans, expected_spark_params, expected_cuml_params)
 
     # conflicting params
-    conflicting_params = {
+    conflicting_params: Dict[str, Any] = {
         "k": 2,
         "n_clusters": 10,
     }

--- a/python/tests/test_pca.py
+++ b/python/tests/test_pca.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from typing import Tuple, Type, TypeVar
+from typing import Any, Dict, Tuple, Type, TypeVar
 
 import numpy as np
 import pytest
@@ -156,7 +156,7 @@ def test_pca_params(gpu_number: int, tmp_path: str, caplog: LogCaptureFixture) -
     assert_params(default_pca, default_spark_params, default_cuml_params)
 
     # Spark Params constructor
-    spark_params = {"k": 2}
+    spark_params: Dict[str, Any] = {"k": 2}
     spark_pca = PCA(**spark_params)
     expected_spark_params = default_spark_params.copy()
     expected_spark_params.update(spark_params)  # type: ignore
@@ -165,7 +165,7 @@ def test_pca_params(gpu_number: int, tmp_path: str, caplog: LogCaptureFixture) -
     assert_params(spark_pca, expected_spark_params, expected_cuml_params)
 
     # cuml_params constructor
-    cuml_params = {
+    cuml_params: Dict[str, Any] = {
         "n_components": 5,
         "num_workers": 5,
         "svd_solver": "jacobi",
@@ -187,7 +187,7 @@ def test_pca_params(gpu_number: int, tmp_path: str, caplog: LogCaptureFixture) -
     assert_params(custom_pca_loaded, expected_spark_params, expected_cuml_params)
 
     # Conflicting params
-    conflicting_params = {
+    conflicting_params: Dict[str, Any] = {
         "k": 1,
         "n_components": 2,
     }


### PR DESCRIPTION
The PR enables constructor arguments to appear in the API docs.