### PR TITLE
updated version of PR 440 to add spark parameter validation 

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -892,14 +892,6 @@ class LogisticRegression(
         verbose: Union[int, bool] = False,
         **kwargs: Any,
     ):
-        # verify the parameters by spark LR in the jvm space
-        from pyspark.ml.classification import (
-            LogisticRegression as SparkLogisticRegression,
-        )
-
-        lr = SparkLogisticRegression(maxIter=maxIter, regParam=regParam, tol=tol)
-        lr._transfer_params_to_java()
-
         if not self._input_kwargs.get("float32_inputs", True):
             get_logger(self.__class__).warning(
                 "This estimator does not support double precision inputs. Setting float32_inputs to False will be ignored."

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -892,6 +892,14 @@ class LogisticRegression(
         verbose: Union[int, bool] = False,
         **kwargs: Any,
     ):
+        # verify the parameters by spark LR in the jvm space
+        from pyspark.ml.classification import (
+            LogisticRegression as SparkLogisticRegression,
+        )
+
+        lr = SparkLogisticRegression(maxIter=maxIter, regParam=regParam, tol=tol)
+        lr._transfer_params_to_java()
+
         if not self._input_kwargs.get("float32_inputs", True):
             get_logger(self.__class__).warning(
                 "This estimator does not support double precision inputs. Setting float32_inputs to False will be ignored."

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from abc import ABCMeta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -27,6 +28,7 @@ from typing import (
     cast,
 )
 
+import pyspark
 from pyspark.ml.common import _py2java
 from pyspark.ml.evaluation import Evaluator, MulticlassClassificationEvaluator
 
@@ -297,6 +299,9 @@ class _RandomForestClassifierClass(_RandomForestClass):
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
         mapping = super()._param_mapping()
         return mapping
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return pyspark.ml.classification.RandomForestClassifier
 
 
 class RandomForestClassifier(
@@ -664,7 +669,7 @@ class LogisticRegressionClass(_CumlClass):
     def _param_value_mapping(
         cls,
     ) -> Dict[str, Callable[[Any], Union[None, str, float, int]]]:
-        return {"C": lambda x: 1 / x if x != 0.0 else 0.0}
+        return {"C": lambda x: 1 / x if x > 0.0 else (0.0 if x == 0.0 else None)}
 
     def _get_cuml_params_default(self) -> Dict[str, Any]:
         return {
@@ -703,6 +708,9 @@ class LogisticRegressionClass(_CumlClass):
             l1_ratio = elasticNet_param
 
         return (penalty, C, l1_ratio)
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return pyspark.ml.classification.LogisticRegression
 
 
 class _LogisticRegressionCumlParams(

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -14,10 +14,12 @@
 # limitations under the License.
 #
 
+from abc import ABCMeta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
+import pyspark
 from pyspark import keyword_only
 from pyspark.ml.clustering import KMeansModel as SparkKMeansModel
 from pyspark.ml.clustering import _KMeansParams
@@ -82,6 +84,9 @@ class KMeansClass(_CumlClass):
             "oversampling_factor": 2.0,
             "max_samples_per_batch": 32768,
         }
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return pyspark.ml.clustering.KMeans
 
 
 class _KMeansCumlParams(_CumlParams, _KMeansParams, HasFeaturesCols):

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -56,6 +56,7 @@ from pyspark.ml.util import (
     MLWritable,
     MLWriter,
 )
+from pyspark.ml.wrapper import JavaParams
 from pyspark.sql import Column, DataFrame
 from pyspark.sql.functions import col, struct
 from pyspark.sql.pandas.functions import pandas_udf
@@ -419,6 +420,42 @@ class _CumlCaller(_CumlParams, _CumlCommon):
         """
         return (True, False)
 
+    def _validate_parameters(self) -> None:
+        cls_name = self.__class__.__name__
+
+        pyspark_est: Optional[JavaParams] = None
+
+        # Is there a better way for the dynamic imports?
+        if "LogisticRegression" in cls_name:
+            from pyspark.ml.classification import LogisticRegression
+
+            pyspark_est = LogisticRegression()
+        elif "RandomForestClassifier" in cls_name:
+            from pyspark.ml.classification import RandomForestClassifier
+
+            pyspark_est = RandomForestClassifier()
+        elif "RandomForestRegressor" in cls_name:
+            from pyspark.ml.regression import RandomForestRegressor
+
+            pyspark_est = RandomForestRegressor()
+
+        elif "LinearRegression" in cls_name:
+            from pyspark.ml.regression import LinearRegression
+
+            pyspark_est = LinearRegression()
+
+        elif "PCA" in cls_name:
+            from pyspark.ml.feature import PCA
+
+            pyspark_est = PCA()
+
+        if pyspark_est is not None:
+            self._copyValues(pyspark_est)
+            # validate the parameters
+            pyspark_est._transfer_params_to_java()
+
+            del pyspark_est
+
     @abstractmethod
     def _get_cuml_fit_func(
         self,
@@ -468,6 +505,7 @@ class _CumlCaller(_CumlParams, _CumlCommon):
         :class:`Transformer`
             fitted model
         """
+        self._validate_parameters()
 
         cls = self.__class__
 

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -438,17 +438,18 @@ class _CumlCaller(_CumlParams, _CumlCommon):
             from pyspark.ml.regression import RandomForestRegressor
 
             pyspark_est = RandomForestRegressor()
-
         elif "LinearRegression" in cls_name:
             from pyspark.ml.regression import LinearRegression
 
             pyspark_est = LinearRegression()
-
         elif "PCA" in cls_name:
             from pyspark.ml.feature import PCA
 
             pyspark_est = PCA()
+        elif "KMeans" in cls_name:
+            from pyspark.ml.clustering import KMeans
 
+            pyspark_est = KMeans()
         if pyspark_est is not None:
             # Both pyspark and cuml may have a parameter with the same name,
             # but cuml might have additional optional values that can be set.
@@ -456,17 +457,19 @@ class _CumlCaller(_CumlParams, _CumlCommon):
             # it would result in an exception.
             # To avoid this issue, we skip transferring these parameters
             # since the mapped parameters have been validated in _get_cuml_mapping_value.
-            cuml_params = self._param_value_mapping().keys()
-            param_mapping = self._param_mapping()
+            cuml_est = self.copy()
+            cuml_params = cuml_est._param_value_mapping().keys()
+            param_mapping = cuml_est._param_mapping()
             pyspark_params = [k for k, v in param_mapping.items() if v in cuml_params]
             for p in pyspark_params:
-                self.clear(self.getParam(p))
+                cuml_est.clear(cuml_est.getParam(p))
 
-            self._copyValues(pyspark_est)
+            cuml_est._copyValues(pyspark_est)
             # validate the parameters
             pyspark_est._transfer_params_to_java()
 
             del pyspark_est
+            del cuml_est
 
     @abstractmethod
     def _get_cuml_fit_func(

--- a/python/src/spark_rapids_ml/feature.py
+++ b/python/src/spark_rapids_ml/feature.py
@@ -15,10 +15,12 @@
 #
 
 import itertools
+from abc import ABCMeta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+import pyspark
 from pyspark import keyword_only
 from pyspark.ml.common import _py2java
 from pyspark.ml.feature import PCAModel as SparkPCAModel
@@ -68,6 +70,9 @@ class PCAClass(_CumlClass):
             "verbose": False,
             "whiten": False,
         }
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return pyspark.ml.feature.PCA
 
 
 class _PCACumlParams(_CumlParams, _PCAParams, HasInputCols):

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -15,6 +15,7 @@
 #
 
 import asyncio
+from abc import ABCMeta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -66,6 +67,9 @@ class NearestNeighborsClass(_CumlClass):
 
     def _get_cuml_params_default(self) -> Dict[str, Any]:
         return {"n_neighbors": 5, "verbose": False, "batch_size": 2000000}
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return None
 
 
 class _NearestNeighborsCumlParams(_CumlParams, HasInputCol, HasLabelCol, HasInputCols):

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -429,7 +429,13 @@ class _CumlParams(_CumlClass, Params):
 
         if cuml_param is not None:
             # if Spark Param is mapped to cuML parameter, set cuml_params
-            self._set_cuml_value(cuml_param, spark_value)
+            try:
+                self._set_cuml_value(cuml_param, spark_value)
+            except ValueError:
+                # create more informative message
+                raise ValueError(
+                    f"{cuml_param} or {spark_param} given invalid value {spark_value}"
+                )
 
     def _get_cuml_mapping_value(self, k: str, v: Any) -> Any:
         value_map = self._param_value_mapping()

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -433,10 +433,12 @@ class _CumlParams(_CumlClass, Params):
                 self._set_cuml_value(cuml_param, spark_value)
             except ValueError:
                 # create more informative message
-                param_ref_str = cuml_param + " or " + spark_param if cuml_param != spark_param else spark_param
-                raise ValueError(
-                    f"{param_ref_str} given invalid value {spark_value}"
+                param_ref_str = (
+                    cuml_param + " or " + spark_param
+                    if cuml_param != spark_param
+                    else spark_param
                 )
+                raise ValueError(f"{param_ref_str} given invalid value {spark_value}")
 
     def _get_cuml_mapping_value(self, k: str, v: Any) -> Any:
         value_map = self._param_value_mapping()

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -433,8 +433,9 @@ class _CumlParams(_CumlClass, Params):
                 self._set_cuml_value(cuml_param, spark_value)
             except ValueError:
                 # create more informative message
+                param_ref_str = cuml_param + " or " + spark_param if cuml_param != spark_param else spark_param
                 raise ValueError(
-                    f"{cuml_param} or {spark_param} given invalid value {spark_value}"
+                    f"{param_ref_str} given invalid value {spark_value}"
                 )
 
     def _get_cuml_mapping_value(self, k: str, v: Any) -> Any:

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from abc import ABCMeta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -28,6 +29,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pyspark
 from pyspark import Row, TaskContext, keyword_only
 from pyspark.ml.common import _py2java
 from pyspark.ml.evaluation import Evaluator, RegressionEvaluator
@@ -217,6 +219,9 @@ class LinearRegressionClass(_CumlClass):
             "tol": 0.001,
             "shuffle": True,
         }
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return pyspark.ml.regression.LinearRegression
 
 
 class _LinearRegressionCumlParams(
@@ -782,6 +787,9 @@ class _RandomForestRegressorClass(_RandomForestClass):
             x, None
         )
         return mapping
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return pyspark.ml.regression.RandomForestRegressor
 
 
 class RandomForestRegressor(

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -16,6 +16,7 @@
 
 import json
 import os
+from abc import ABCMeta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -112,6 +113,9 @@ class UMAPClass(_CumlClass):
             "random_state": None,
             "verbose": False,
         }
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return None
 
 
 class _UMAPCumlParams(

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+from abc import ABCMeta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -233,6 +234,9 @@ class SparkRapidsMLDummy(
         assert result.model_attribute_a == 1024
         assert result.model_attribute_b == "hello dummy"
         return SparkRapidsMLDummyModel._from_row(result)
+
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return None
 
 
 class SparkRapidsMLDummyModel(

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -670,3 +670,6 @@ def test_parameters_validation() -> None:
             IllegalArgumentException, match="regParam given invalid value -1.0"
         ):
             LinearRegression().setRegParam(-1.0).fit(df)
+
+        # shouldn't throw an exception for setting cuml values
+        LinearRegression(loss="squared_loss")._validate_parameters()

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -168,7 +168,7 @@ def test_linear_regression_params(
     # Unsupported value
     spark_params = {"solver": "l-bfgs"}
     with pytest.raises(
-        ValueError, match="Value 'l-bfgs' for 'solver' param is unsupported"
+        ValueError, match="solver given invalid value l-bfgs"
     ):
         unsupported_lr = LinearRegression(**spark_params)
 

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -167,9 +167,7 @@ def test_linear_regression_params(
 
     # Unsupported value
     spark_params = {"solver": "l-bfgs"}
-    with pytest.raises(
-        ValueError, match="solver given invalid value l-bfgs"
-    ):
+    with pytest.raises(ValueError, match="solver given invalid value l-bfgs"):
         unsupported_lr = LinearRegression(**spark_params)
 
     # make sure no warning when enabling float64 inputs

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Tuple, Type, TypeVar, cast
 import numpy as np
 import pytest
 from _pytest.logging import LogCaptureFixture
+from pyspark.errors import IllegalArgumentException
 from pyspark.ml.evaluation import RegressionEvaluator
 from pyspark.ml.feature import VectorAssembler
 from pyspark.ml.functions import array_to_vector
@@ -647,3 +648,25 @@ def test_crossvalidator_linear_regression(
         spark_cv_model = spark_cv.fit(df)
 
         assert array_equal(model.avgMetrics, spark_cv_model.avgMetrics)
+
+
+def test_parameters_validation() -> None:
+    data = [
+        ([1.0, 2.0], 1.0),
+        ([3.0, 1.0], 0.0),
+    ]
+
+    with CleanSparkSession() as spark:
+        features_col = "features"
+        label_col = "label"
+        schema = features_col + " array<float>, " + label_col + " float"
+        df = spark.createDataFrame(data, schema=schema)
+        with pytest.raises(
+            IllegalArgumentException, match="maxIter given invalid value -1"
+        ):
+            LinearRegression(maxIter=-1).fit(df)
+
+        with pytest.raises(
+            IllegalArgumentException, match="regParam given invalid value -1.0"
+        ):
+            LinearRegression().setRegParam(-1.0).fit(df)

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1047,7 +1047,7 @@ def test_crossvalidator_logistic_regression(
         )
         spark_cv_model = spark_cv.fit(df)
 
-        assert array_equal(model.avgMetrics, spark_cv_model.avgMetrics, tolerance=0.0005)
+        assert array_equal(model.avgMetrics, spark_cv_model.avgMetrics, 0.0005)
 
 
 def test_parameters_validation() -> None:

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -658,7 +658,7 @@ def test_compat_multinomial(
                 regParam=0.1,
                 elasticNetParam=0.2,
                 fitIntercept=fit_intercept,
-                family="multimonial",
+                family="multinomial",
             )
 
         assert mlor.getRegParam() == 0.1

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from _pytest.logging import LogCaptureFixture
 from packaging import version
+from pyspark.errors import IllegalArgumentException
 from pyspark.ml.classification import LogisticRegression as SparkLogisticRegression
 from pyspark.ml.classification import (
     LogisticRegressionModel as SparkLogisticRegressionModel,
@@ -1047,3 +1048,15 @@ def test_crossvalidator_logistic_regression(
         spark_cv_model = spark_cv.fit(df)
 
         assert array_equal(model.avgMetrics, spark_cv_model.avgMetrics)
+
+
+def test_parameters_verification() -> None:
+    with pytest.raises(
+        IllegalArgumentException, match="maxIter given invalid value -1"
+    ):
+        LogisticRegression(maxIter=-1)
+
+    with pytest.raises(
+        IllegalArgumentException, match="regParam given invalid value -1.0"
+    ):
+        LogisticRegression(regParam=-1.0)

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1050,13 +1050,23 @@ def test_crossvalidator_logistic_regression(
         assert array_equal(model.avgMetrics, spark_cv_model.avgMetrics)
 
 
-def test_parameters_verification() -> None:
-    with pytest.raises(
-        IllegalArgumentException, match="maxIter given invalid value -1"
-    ):
-        LogisticRegression(maxIter=-1)
+def test_parameters_validation() -> None:
+    data = [
+        ([1.0, 2.0], 1.0),
+        ([3.0, 1.0], 0.0),
+    ]
 
-    with pytest.raises(
-        IllegalArgumentException, match="regParam given invalid value -1.0"
-    ):
-        LogisticRegression(regParam=-1.0)
+    with CleanSparkSession() as spark:
+        features_col = "features"
+        label_col = "label"
+        schema = features_col + " array<float>, " + label_col + " float"
+        df = spark.createDataFrame(data, schema=schema)
+        with pytest.raises(
+            IllegalArgumentException, match="maxIter given invalid value -1"
+        ):
+            LogisticRegression(maxIter=-1).fit(df)
+
+        with pytest.raises(
+            IllegalArgumentException, match="regParam given invalid value -1.0"
+        ):
+            LogisticRegression().setRegParam(-1.0).fit(df)

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1047,7 +1047,7 @@ def test_crossvalidator_logistic_regression(
         )
         spark_cv_model = spark_cv.fit(df)
 
-        assert array_equal(model.avgMetrics, spark_cv_model.avgMetrics)
+        assert array_equal(model.avgMetrics, spark_cv_model.avgMetrics, tolerance=0.0005)
 
 
 def test_parameters_validation() -> None:

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1066,7 +1066,7 @@ def test_parameters_validation() -> None:
         ):
             LogisticRegression(maxIter=-1).fit(df)
 
-        with pytest.raises(
-            IllegalArgumentException, match="regParam given invalid value -1.0"
-        ):
+        # regParam is mapped to different value in LogisticRegression which should be in
+        # charge of validating it.
+        with pytest.raises(ValueError, match="C or regParam given invalid value -1.0"):
             LogisticRegression().setRegParam(-1.0).fit(df)

--- a/python/tests/test_random_forest.py
+++ b/python/tests/test_random_forest.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 from _pytest.logging import LogCaptureFixture
 from cuml import accuracy_score
+from pyspark.errors import IllegalArgumentException
 from pyspark.ml.classification import (
     RandomForestClassificationModel as SparkRFClassificationModel,
 )
@@ -904,3 +905,25 @@ def test_crossvalidator_random_forest(
         spark_cv_model = spark_cv.fit(df)
 
         assert array_equal(model.avgMetrics, spark_cv_model.avgMetrics)
+
+
+def test_parameters_validation() -> None:
+    data = [
+        ([1.0, 2.0], 1.0),
+        ([3.0, 1.0], 0.0),
+    ]
+
+    with CleanSparkSession() as spark:
+        features_col = "features"
+        label_col = "label"
+        schema = features_col + " array<float>, " + label_col + " float"
+        df = spark.createDataFrame(data, schema=schema)
+        with pytest.raises(
+            IllegalArgumentException, match="maxDepth given invalid value -1"
+        ):
+            RandomForestClassifier(maxDepth=-1).fit(df)
+
+        with pytest.raises(
+            IllegalArgumentException, match="maxBins given invalid value -1"
+        ):
+            RandomForestRegressor().setMaxBins(-1).fit(df)


### PR DESCRIPTION
rebased onto latest branch-23.10 changes and addressing comments
one issue is the setting of spark params based on cuml params.  However, all current such cases have compatible values or are removed from validation.