### PR TITLE
make tests compatible with spark 3.3 (#521)

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -49,6 +49,7 @@ pip install -r requirements_dev.txt && pip install -e .
 if [[ $type == "nightly" ]]; then
     pip uninstall pyspark -y
     pip install pyspark~=3.3.0
+    ./run_test.sh
     ./run_benchmark.sh $bench_args
     # if everything passed till now update draft release docs in gh-pages
     # need to invoke docs.sh from top level of repo

--- a/python/tests/test_kmeans.py
+++ b/python/tests/test_kmeans.py
@@ -17,9 +17,16 @@
 from typing import Any, Dict, List, Tuple, Type, TypeVar
 
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
-from pyspark.errors import IllegalArgumentException
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.clustering import KMeans as SparkKMeans
 from pyspark.ml.clustering import KMeansModel as SparkKMeansModel
 from pyspark.ml.functions import array_to_vector
@@ -335,7 +342,7 @@ def test_kmeans_spark_compat(
         if version.parse(pyspark.__version__) < version.parse("3.4.0"):
             kmeans = _KMeans(k=2)
         else:
-            kmeans = _KMeans(k=2, solver="auto", maxBlockSizeInMB=0)
+            kmeans = _KMeans(k=2, solver="auto", maxBlockSizeInMB=0)  # type: ignore # only spark >= 3.4 supports solver and maxblockSize
 
         kmeans.setSeed(1)
         kmeans.setMaxIter(10)

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -17,9 +17,16 @@ import warnings
 from typing import Any, Dict, List, Tuple, Type, TypeVar, cast
 
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
-from pyspark.errors import IllegalArgumentException
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.evaluation import RegressionEvaluator
 from pyspark.ml.feature import VectorAssembler
 from pyspark.ml.functions import array_to_vector

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -2,10 +2,16 @@ from typing import Any, Dict, List, Tuple, Type, TypeVar
 
 import cuml
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
 from packaging import version
-from pyspark.errors import IllegalArgumentException
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.classification import LogisticRegression as SparkLogisticRegression
 from pyspark.ml.classification import (
     LogisticRegressionModel as SparkLogisticRegressionModel,

--- a/python/tests/test_pca.py
+++ b/python/tests/test_pca.py
@@ -17,9 +17,16 @@
 from typing import Any, Dict, Tuple, Type, TypeVar
 
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
-from pyspark.errors import IllegalArgumentException
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.feature import PCA as SparkPCA
 from pyspark.ml.feature import PCAModel as SparkPCAModel
 from pyspark.ml.functions import array_to_vector

--- a/python/tests/test_random_forest.py
+++ b/python/tests/test_random_forest.py
@@ -18,10 +18,17 @@ import math
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
 
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
 from cuml import accuracy_score
-from pyspark.errors import IllegalArgumentException
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.classification import (
     RandomForestClassificationModel as SparkRFClassificationModel,
 )


### PR DESCRIPTION
* make tests compatible with spark 3.3 and add testing against 3.3. to nightly



* run only fast tests



---------

Auto-merge failed so doing manual.  @pxLi 