### PR TITLE
Remove CUDA version definition in benchmark script [skip ci]

### DIFF
--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -27,7 +27,6 @@ on:
 
 jobs:
   Benchmark:
-    if: github.repository == 'NVIDIA/spark-rapids-ml'
     runs-on: ubuntu-latest
     env:
       PROJECT: rapids-spark

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   Benchmark:
+    if: github.repository == 'NVIDIA/spark-rapids-ml'
     runs-on: ubuntu-latest
     env:
       PROJECT: rapids-spark

--- a/python/benchmark/dataproc/start_cluster.sh
+++ b/python/benchmark/dataproc/start_cluster.sh
@@ -13,7 +13,7 @@ if [[ -z ${GCS_BUCKET} ]]; then
 fi
 
 BENCHMARK_HOME=${BENCHMARK_HOME:-${GCS_BUCKET}/benchmark}
-CUDA_VERSION=${CUDA_VERSION:-12.3.0}
+CUDA_VERSION=${CUDA_VERSION:-12.2}
 
 gpu_args=$(cat <<EOF
 --master-accelerator type=nvidia-tesla-t4,count=1

--- a/python/benchmark/dataproc/start_cluster.sh
+++ b/python/benchmark/dataproc/start_cluster.sh
@@ -13,7 +13,7 @@ if [[ -z ${GCS_BUCKET} ]]; then
 fi
 
 BENCHMARK_HOME=${BENCHMARK_HOME:-${GCS_BUCKET}/benchmark}
-CUDA_VERSION=${CUDA_VERSION:-12.2}
+CUDA_VERSION=${CUDA_VERSION:-12.2.2}
 
 gpu_args=$(cat <<EOF
 --master-accelerator type=nvidia-tesla-t4,count=1

--- a/python/benchmark/dataproc/start_cluster.sh
+++ b/python/benchmark/dataproc/start_cluster.sh
@@ -13,7 +13,7 @@ if [[ -z ${GCS_BUCKET} ]]; then
 fi
 
 BENCHMARK_HOME=${BENCHMARK_HOME:-${GCS_BUCKET}/benchmark}
-CUDA_VERSION=${CUDA_VERSION:-11.8}
+CUDA_VERSION=${CUDA_VERSION:-11.8.0}
 
 gpu_args=$(cat <<EOF
 --master-accelerator type=nvidia-tesla-t4,count=1

--- a/python/benchmark/dataproc/start_cluster.sh
+++ b/python/benchmark/dataproc/start_cluster.sh
@@ -13,7 +13,7 @@ if [[ -z ${GCS_BUCKET} ]]; then
 fi
 
 BENCHMARK_HOME=${BENCHMARK_HOME:-${GCS_BUCKET}/benchmark}
-CUDA_VERSION=${CUDA_VERSION:-11.8.0}
+CUDA_VERSION=${CUDA_VERSION:-12.3.0}
 
 gpu_args=$(cat <<EOF
 --master-accelerator type=nvidia-tesla-t4,count=1

--- a/python/benchmark/dataproc/start_cluster.sh
+++ b/python/benchmark/dataproc/start_cluster.sh
@@ -13,7 +13,6 @@ if [[ -z ${GCS_BUCKET} ]]; then
 fi
 
 BENCHMARK_HOME=${BENCHMARK_HOME:-${GCS_BUCKET}/benchmark}
-CUDA_VERSION=${CUDA_VERSION:-12.2.2}
 
 gpu_args=$(cat <<EOF
 --master-accelerator type=nvidia-tesla-t4,count=1
@@ -21,7 +20,6 @@ gpu_args=$(cat <<EOF
 --initialization-actions gs://${BENCHMARK_HOME}/spark-rapids.sh,gs://${BENCHMARK_HOME}/init_benchmark.sh
 --metadata gpu-driver-provider="NVIDIA"
 --metadata rapids-runtime=SPARK
---metadata cuda-version=${CUDA_VERSION}
 --metadata benchmark-home=${BENCHMARK_HOME}
 EOF
 )


### PR DESCRIPTION
Change default cuda version to 12.2.2, same as `spark-rapids-ml-benchmarking/benchmark/spark-rapids.sh`