### PR TITLE
Update cuml version to 24.02 in ci/Dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,6 +37,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     && conda config --set solver libmamba
 
 # install cuML
-ARG CUML_VER=23.12
+ARG CUML_VER=24.02
 RUN conda install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
     && conda clean --all -f -y

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,6 +37,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     && conda config --set solver libmamba
 
 # install cuML
-ARG CUML_VER=24.02
-RUN conda install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
+ARG CUML_VER=23.12
+RUN conda install -y -c rapidsai -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
     && conda clean --all -f -y


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/spark-rapids-ml/issues/533

```
PackagesNotFoundError: - cuml=23.12* in the channel rapidsai-nightly
```

On branch-24.02, Build Docker image failed as below due to referring to ARG CUML_VER=23.12, with file : ci/Dockerfile

Only 24.02 cuml packages available in the rapids-nightly conda channel : https://anaconda.org/rapidsai-nightly/cuml/files

Change ARG CUML_VER=23.12 to ARG CUML_VER=24.02 to PASS the docker build