### PR TITLE
skip testing sparse vector cross validator for spark < 3.4

### DIFF
--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1060,6 +1060,14 @@ def test_crossvalidator_logistic_regression(
     if convert_to_sparse:
         assert feature_type == feature_types.vector
 
+        if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+            import logging
+
+            err_msg = "pyspark < 3.4 is detected. Cannot import pyspark `unwrap_udt` function. "
+            "The test case will be skipped. Please install pyspark>=3.4."
+            logging.info(err_msg)
+        return
+
     # Train a toy model
 
     n_classes = 2 if metric_name == "areaUnderROC" else 10


### PR DESCRIPTION
sparse vectors component uses a function that is only available in spark >=3.4, while nightly ci will test spark 3.3