### PR TITLE
release 23.12 [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-23.10
+    - branch-23.12
     types: [closed]
 
 jobs:
@@ -29,14 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: branch-23.10 # force to fetch from latest upstream instead of PR ref
+          ref: branch-23.12 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids-ml
-          HEAD: branch-23.10
-          BASE: branch-23.12
+          HEAD: branch-23.12
+          BASE: branch-24.02
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -38,5 +38,5 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
 
 # install cuML
 ARG CUML_VER=23.12
-RUN conda install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
+RUN conda install -y -c rapidsai -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
     && conda clean --all -f -y

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,6 +37,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     && conda config --set solver libmamba
 
 # install cuML
-ARG CUML_VER=23.10
-RUN conda install -y -c rapidsai -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
+ARG CUML_VER=23.12
+RUN conda install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
     && conda clean --all -f -y

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -49,6 +49,7 @@ pip install -r requirements_dev.txt && pip install -e .
 if [[ $type == "nightly" ]]; then
     pip uninstall pyspark -y
     pip install pyspark~=3.3.0
+    ./run_test.sh
     ./run_benchmark.sh $bench_args
     # if everything passed till now update draft release docs in gh-pages
     # need to invoke docs.sh from top level of repo

--- a/docker/Dockerfile.pip
+++ b/docker/Dockerfile.pip
@@ -18,7 +18,7 @@ ARG CUDA_VERSION=11.8.0
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
 
 ARG PYSPARK_VERSION=3.3.1
-ARG RAPIDS_VERSION=23.10.0
+ARG RAPIDS_VERSION=23.12.0
 ARG ARCH=amd64
 #ARG ARCH=arm64
 # Install packages to build spark-rapids-ml

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -17,7 +17,7 @@
 ARG CUDA_VERSION=11.8.0
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04
 
-ARG CUML_VERSION=23.10
+ARG CUML_VERSION=23.12
 
 # Install packages to build spark-rapids-ml
 RUN apt update -y \

--- a/docs/site/performance.md
+++ b/docs/site/performance.md
@@ -1,0 +1,44 @@
+---
+title: Performance Tuning
+nav_order: 6
+---
+# Performance Tuning
+
+* TOC
+{:toc}
+
+## Stage-level scheduling
+
+Starting from spark-rapids-ml `23.10.0`, stage-level scheduling is automatically enabled.
+Therefore, if you are using Spark **standalone** cluster version **`3.4.0`** or higher, we strongly recommend
+configuring the `"spark.task.resource.gpu.amount"` as a fractional value. This will
+enable running multiple tasks in parallel during the ETL phase to help the performance. An example configuration
+would be `"spark.task.resource.gpu.amount=1/spark.executor.cores"`. For example,
+
+``` bash
+spark-submit \
+  --master spark://<master-ip>:7077 \
+  --conf spark.executor.cores=12 \
+  --conf spark.task.cpus=1 \
+  --conf spark.executor.resource.gpu.amount=1 \
+  --conf spark.task.resource.gpu.amount=0.08 \
+  ...
+```
+
+The above spark-submit command specifies a request for 1 GPU and 12 CPUs per executor. So you can see,
+a total of 12 tasks per executor will be executed concurrently during the ETL phase. And the stage-level scheduling
+is then used internally to the library to automatically carry out the ML training phases using the required 1 gpu per task.
+
+However, if you are using a spark-rapids-ml version earlier than 23.10.0 or a Spark
+standalone cluster version below 3.4.0, you need to make sure there will be only 1 task running at any time per executor.
+You can set `spark.task.cpus` equal to `spark.executor.cores`, or `"spark.task.resource.gpu.amount"=1`. For example,
+
+``` bash
+spark-submit \
+  --master spark://<master-ip>:7077 \
+  --conf spark.executor.cores=12 \
+  --conf spark.task.cpus=1 \
+  --conf spark.executor.resource.gpu.amount=1 \
+  --conf spark.task.resource.gpu.amount=1 \
+  ...
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = 'spark-rapids-ml'
 copyright = '2023, NVIDIA'
 author = 'NVIDIA'
-release = '23.10.0'
+release = '23.12.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/jvm/README.md
+++ b/jvm/README.md
@@ -94,8 +94,8 @@ repository, usually in your `~/.m2/repository`.
 
 Add the artifact jar to the Spark, for example:
 ```bash
-ML_JAR="target/rapids-4-spark-ml_2.12-23.10.0-SNAPSHOT.jar"
-PLUGIN_JAR="~/.m2/repository/com/nvidia/rapids-4-spark_2.12/23.10.0/rapids-4-spark_2.12-23.10.0.jar"
+ML_JAR="target/rapids-4-spark-ml_2.12-23.12.0-SNAPSHOT.jar"
+PLUGIN_JAR="~/.m2/repository/com/nvidia/rapids-4-spark_2.12/23.12.0/rapids-4-spark_2.12-23.12.1.jar"
 
 $SPARK_HOME/bin/spark-shell --master $SPARK_MASTER \
  --driver-memory 20G \

--- a/jvm/README.md
+++ b/jvm/README.md
@@ -74,7 +74,7 @@ the _project root path_ with:
 cd jvm
 mvn clean package
 ```
-Then `rapids-4-spark-ml_2.12-23.10.0-SNAPSHOT.jar` will be generated under `target` folder.
+Then `rapids-4-spark-ml_2.12-23.12.0-SNAPSHOT.jar` will be generated under `target` folder.
 
 Users can also use the _release_ version spark-rapids plugin as the dependency if it's already been
 released in public maven repositories, see [rapids-4-spark maven repository](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark)

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.nvidia</groupId>
     <artifactId>rapids-4-spark-ml_2.12</artifactId>
-    <version>23.10.0-SNAPSHOT</version>
+    <version>23.12.0-SNAPSHOT</version>
     <name>RAPIDS Accelerator for Apache Spark ML</name>
     <description>The RAPIDS cuML library for Apache Spark</description>
     <inceptionYear>2021</inceptionYear>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark_2.12</artifactId>
-            <version>23.10.0</version>
+            <version>23.12.0</version>
         </dependency>
 
 

--- a/notebooks/aws-emr/init-bootstrap-action.sh
+++ b/notebooks/aws-emr/init-bootstrap-action.sh
@@ -8,7 +8,7 @@ sudo chmod a+rwx -R /sys/fs/cgroup/devices
 sudo yum install -y gcc openssl-devel bzip2-devel libffi-devel tar gzip wget make mysql-devel
 sudo bash -c "wget https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tgz && tar xzf Python-3.9.9.tgz && cd Python-3.9.9 && ./configure --enable-optimizations && make altinstall"
 
-RAPIDS_VERSION=23.10.0
+RAPIDS_VERSION=23.12.0
 
 # install scikit-learn 
 sudo /usr/local/bin/pip3.9 install scikit-learn

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -44,7 +44,7 @@ If you already have a Databricks account, you can run the example notebooks on a
       spark.task.resource.gpu.amount 1
       spark.databricks.delta.preview.enabled true
       spark.python.worker.reuse true
-      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-23.10.0.jar:/databricks/spark/python
+      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-23.12.1.jar:/databricks/spark/python
       spark.sql.execution.arrow.maxRecordsPerBatch 100000
       spark.rapids.memory.gpu.minAllocFraction 0.0001
       spark.plugins com.nvidia.spark.SQLPlugin

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -68,9 +68,5 @@ If you already have a Databricks account, you can run the example notebooks on a
       LIBCUDF_CUFILE_POLICY=OFF
       NCCL_DEBUG=INFO
       ```
-    - **Additional Environment variable for Azure Databricks**
-      ```
-      LD_LIBRARY_PATH=/usr/local/cuda/compat:/usr/local/cuda/lib64
-      ```
 - Start the configured cluster.
 - Select your workspace and upload the desired [notebook](../) via `Import` in the drop down menu for your workspace.

--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -4,8 +4,8 @@ SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/zip/file
 # IMPORTANT: specify RAPIDS_VERSION fully 23.10.0 and not 23.10
 # also in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
 # while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.08.2 and not 23.8.2)
-RAPIDS_VERSION=23.10.0
-SPARK_RAPIDS_VERSION=23.10.0
+RAPIDS_VERSION=23.12.0
+SPARK_RAPIDS_VERSION=23.12.1
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda11.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar
 

--- a/notebooks/dataproc/README.md
+++ b/notebooks/dataproc/README.md
@@ -29,7 +29,7 @@ If you already have a Dataproc account, you can run the example notebooks on a D
 - Create a cluster with at least two single-gpu workers.  **Note**: in addition to the initialization script from above, this also uses the standard [initialization actions](https://github.com/GoogleCloudDataproc/initialization-actions) for installing the GPU drivers and RAPIDS:
   ```
   export CUDA_VERSION=11.8
-  export RAPIDS_VERSION=23.10.0
+  export RAPIDS_VERSION=23.12.0
 
   gcloud dataproc clusters create $USER-spark-rapids-ml \
   --image-version=2.1-ubuntu \

--- a/notebooks/dataproc/spark_rapids_ml.sh
+++ b/notebooks/dataproc/spark_rapids_ml.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RAPIDS_VERSION=23.10.0
+RAPIDS_VERSION=23.12.0
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"

--- a/notebooks/umap.ipynb
+++ b/notebooks/umap.ipynb
@@ -652,7 +652,7 @@
     "import os\n",
     "import requests\n",
     "\n",
-    "SPARK_RAPIDS_VERSION = \"23.08.1\"\n",
+    "SPARK_RAPIDS_VERSION = \"23.12.1\"\n",
     "cuda_version = \"12\"\n",
     "rapids_jar = f\"rapids-4-spark_2.12-{SPARK_RAPIDS_VERSION}.jar\"\n",
     "\n",

--- a/python/README.md
+++ b/python/README.md
@@ -8,9 +8,9 @@ For simplicity, the following instructions just use Spark local mode, assuming a
 
 First, install RAPIDS cuML per [these instructions](https://rapids.ai/start.html).   Example for CUDA Toolkit 11.8:
 ```bash
-conda create -n rapids-23.10 \
+conda create -n rapids-23.12 \
     -c rapidsai -c conda-forge -c nvidia \
-    cuml=23.10 python=3.9 cuda-version=11.8
+    cuml=23.12 python=3.9 cuda-version=11.8
 ```
 
 **Note**: while testing, we recommend using conda or docker to simplify installation and isolate your environment while experimenting.  Once you have a working environment, you can then try installing directly, if necessary.
@@ -19,7 +19,7 @@ conda create -n rapids-23.10 \
 
 Once you have the conda environment, activate it and install the required packages.
 ```bash
-conda activate rapids-23.10
+conda activate rapids-23.12
 
 ## for development access to notebooks, tests, and benchmarks
 git clone --branch main https://github.com/NVIDIA/spark-rapids-ml.git

--- a/python/benchmark/databricks/gpu_cluster_spec.sh
+++ b/python/benchmark/databricks/gpu_cluster_spec.sh
@@ -9,7 +9,7 @@ cat <<EOF
         "spark.task.cpus": "1",
         "spark.databricks.delta.preview.enabled": "true",
         "spark.python.worker.reuse": "true",
-        "spark.executorEnv.PYTHONPATH": "/databricks/jars/rapids-4-spark_2.12-23.10.0.jar:/databricks/spark/python",
+        "spark.executorEnv.PYTHONPATH": "/databricks/jars/rapids-4-spark_2.12-23.12.1.jar:/databricks/spark/python",
         "spark.sql.files.minPartitionNum": "2",
         "spark.sql.execution.arrow.maxRecordsPerBatch": "10000",
         "spark.executor.cores": "8",

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -4,9 +4,9 @@ SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/spark-rapids-ml.zip
 BENCHMARK_ZIP=/dbfs/path/to/benchmark.zip
 # IMPORTANT: specify rapids fully 23.10.0 and not 23.10
 # also, in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
-# while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.08.2 and not 23.8.1)
-RAPIDS_VERSION=23.10.0
-SPARK_RAPIDS_VERSION=23.10.0
+# while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.08.2 and not 23.8.2)
+RAPIDS_VERSION=23.12.0
+SPARK_RAPIDS_VERSION=23.12.1
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda11.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar
 

--- a/python/benchmark/dataproc/init_benchmark.sh
+++ b/python/benchmark/dataproc/init_benchmark.sh
@@ -8,7 +8,7 @@ function get_metadata_attribute() {
   /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
 }
 
-RAPIDS_VERSION=$(get_metadata_attribute rapids-version 23.10.0)
+RAPIDS_VERSION=$(get_metadata_attribute rapids-version 23.12.0)
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"

--- a/python/benchmark/dataproc/start_cluster.sh
+++ b/python/benchmark/dataproc/start_cluster.sh
@@ -13,7 +13,6 @@ if [[ -z ${GCS_BUCKET} ]]; then
 fi
 
 BENCHMARK_HOME=${BENCHMARK_HOME:-${GCS_BUCKET}/benchmark}
-CUDA_VERSION=${CUDA_VERSION:-11.8}
 
 gpu_args=$(cat <<EOF
 --master-accelerator type=nvidia-tesla-t4,count=1
@@ -21,7 +20,6 @@ gpu_args=$(cat <<EOF
 --initialization-actions gs://${BENCHMARK_HOME}/spark-rapids.sh,gs://${BENCHMARK_HOME}/init_benchmark.sh
 --metadata gpu-driver-provider="NVIDIA"
 --metadata rapids-runtime=SPARK
---metadata cuda-version=${CUDA_VERSION}
 --metadata benchmark-home=${BENCHMARK_HOME}
 EOF
 )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spark-rapids-ml"
-version = "23.10.0"
+version = "23.12.0"
 authors = [
   { name="Jinfeng Li", email="jinfeng@nvidia.com" },
   { name="Bobby Wang", email="bobwang@nvidia.com" },

--- a/python/run_benchmark.sh
+++ b/python/run_benchmark.sh
@@ -99,7 +99,7 @@ EOF
 
 if [[ $cluster_type == "gpu_etl" ]]
 then
-SPARK_RAPIDS_VERSION=23.10.0
+SPARK_RAPIDS_VERSION=23.12.1
 rapids_jar=${rapids_jar:-rapids-4-spark_2.12-$SPARK_RAPIDS_VERSION.jar}
 if [ ! -f $rapids_jar ]; then
     echo "downloading spark rapids jar"

--- a/python/src/spark_rapids_ml/__init__.py
+++ b/python/src/spark_rapids_ml/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "23.10.0"
+__version__ = "23.12.0"

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -976,6 +976,33 @@ class LogisticRegression(
                     "dtype": logistic_regression.dtype.name,
                     "num_iters": logistic_regression.solver_model.num_iters,
                 }
+
+                # check if invalid label exists
+                for class_val in model["classes_"]:
+                    if class_val < 0:
+                        raise RuntimeError(
+                            f"Labels MUST be in [0, 2147483647), but got {class_val}"
+                        )
+                    elif not class_val.is_integer():
+                        raise RuntimeError(
+                            f"Labels MUST be Integers, but got {class_val}"
+                        )
+
+                if len(logistic_regression.classes_) == 1:
+                    class_val = logistic_regression.classes_[0]
+                    # TODO: match Spark to use max(class_list) to calculate the number of classes
+                    # Cuml currently uses unique(class_list)
+                    if class_val != 1.0 and class_val != 0.0:
+                        raise RuntimeError(
+                            "class value must be either 1. or 0. when dataset has one label"
+                        )
+
+                    if init_parameters["fit_intercept"] is True:
+                        model["coef_"] = [[0.0] * logistic_regression.n_cols]
+                        model["intercept_"] = [
+                            float("inf") if class_val == 1.0 else float("-inf")
+                        ]
+
                 del logistic_regression
                 return model
 
@@ -1027,6 +1054,17 @@ class LogisticRegression(
         )
 
     def _create_pyspark_model(self, result: Row) -> "LogisticRegressionModel":
+        logger = get_logger(self.__class__)
+        if len(result["classes_"]) == 1:
+            if self.getFitIntercept() is False:
+                logger.warning(
+                    "All labels belong to a single class and fitIntercept=false. It's a dangerous ground, so the algorithm may not converge."
+                )
+            else:
+                logger.warning(
+                    "All labels are the same value and fitIntercept=true, so the coefficients will be zeros. Training is not needed."
+                )
+
         return LogisticRegressionModel._from_row(result)
 
     def _set_cuml_reg_params(self) -> "LogisticRegression":

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -836,7 +836,7 @@ class LogisticRegression(
         the penalty is an L2 penalty. For alpha = 1, it is an L1 penalty.
     tol:
         The convergence tolerance.
-    enable_sparse_data: None or boolean, optional (default=None)
+    enable_sparse_data_optim: None or boolean, optional (default=None)
         If features column is VectorUDT type, Spark rapids ml relies on this parameter to decide whether to use dense array or sparse array in cuml.
         If None, use dense array if the first VectorUDT of a dataframe is DenseVector. Use sparse array if it is SparseVector.
         If False, always uses dense array. This is favorable if the majority of VectorUDT vectors are DenseVector.
@@ -905,7 +905,7 @@ class LogisticRegression(
         elasticNetParam: float = 0.0,
         tol: float = 1e-6,
         fitIntercept: bool = True,
-        enable_sparse_data: Optional[bool] = None,
+        enable_sparse_data_optim: Optional[bool] = None,
         num_workers: Optional[int] = None,
         verbose: Union[int, bool] = False,
         **kwargs: Any,

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -40,7 +40,7 @@ from pyspark import RDD, SparkConf, TaskContext
 from pyspark.ml import Estimator, Model
 from pyspark.ml.evaluation import Evaluator
 from pyspark.ml.functions import array_to_vector, vector_to_array
-from pyspark.ml.linalg import VectorUDT
+from pyspark.ml.linalg import DenseVector, SparseVector, VectorUDT
 from pyspark.ml.param.shared import (
     HasLabelCol,
     HasOutputCol,
@@ -68,6 +68,7 @@ from pyspark.sql.types import (
     Row,
     StructType,
 )
+from scipy.sparse import csr_matrix
 
 from .common.cuml_context import CumlContext
 from .metrics import EvalMetricInfo
@@ -115,8 +116,25 @@ _EvaluateFunc = Callable[
 ]
 
 # Global constant for defining column alias
-Alias = namedtuple("Alias", ("data", "label", "row_number"))
-alias = Alias("cuml_values", "cuml_label", "unique_id")
+Alias = namedtuple(
+    "Alias",
+    (
+        "featureVectorType",
+        "featureVectorSize",
+        "featureVectorIndices",
+        "data",
+        "label",
+        "row_number",
+    ),
+)
+alias = Alias(
+    "vector_type",
+    "vector_size",
+    "vector_indices",
+    "cuml_values",
+    "cuml_label",
+    "unique_id",
+)
 
 # Global prediction names
 Pred = namedtuple(
@@ -134,6 +152,85 @@ param_alias = ParamAlias(
 )
 
 CumlModel = TypeVar("CumlModel", bound="_CumlModel")
+
+from .utils import _get_unwrap_udt_fn
+
+
+# similar to the XGBOOST _get_unwrapped_vec_cols in https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/spark/core.py
+def _get_unwrapped_vec_cols(feature_col: Column) -> List[Column]:
+    unwrap_udt = _get_unwrap_udt_fn()
+    features_unwrapped_vec_col = unwrap_udt(feature_col)
+
+    # After a `pyspark.ml.linalg.VectorUDT` type column being unwrapped, it becomes
+    # a pyspark struct type column, the struct fields are:
+    #  - `type`: byte
+    #  - `size`: int
+    #  - `indices`: array<int>
+    #  - `values`: array<double>
+    # For sparse vector, `type` field is 0, `size` field means vector dimension,
+    # `indices` field is the array of active element indices, `values` field
+    # is the array of active element values.
+    # For dense vector, `type` field is 1, `size` and `indices` fields are None,
+    # `values` field is the array of the vector element values.
+    return [
+        features_unwrapped_vec_col.type.alias(alias.featureVectorType),
+        features_unwrapped_vec_col.size.alias(alias.featureVectorSize),
+        features_unwrapped_vec_col.indices.alias(alias.featureVectorIndices),
+        # Note: the value field is double array type, cast it to float32 array type
+        # for speedup following repartitioning.
+        features_unwrapped_vec_col.values.cast(ArrayType(FloatType())).alias(
+            alias.data
+        ),
+    ]
+
+
+# similar to the XGBOOST _read_csr_matrix_from_unwrapped_spark_vec in https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/spark/data.py
+def _read_csr_matrix_from_unwrapped_spark_vec(part: pd.DataFrame) -> csr_matrix:
+    # variables for constructing csr_matrix
+    csr_indices_list, csr_indptr_list, csr_values_list = [], [0], []
+
+    n_features = 0
+
+    # TBD: investigate if there is a more efficient 'vectorized' approach to doing this. Iterating in python can be slow
+    for vec_type, vec_size_, vec_indices, vec_values in zip(
+        part[alias.featureVectorType],
+        part[alias.featureVectorSize],
+        part[alias.featureVectorIndices],
+        part[alias.data],
+    ):
+        if vec_type == 0:
+            # sparse vector
+            vec_size = int(vec_size_)
+            csr_indices = vec_indices
+            csr_values = vec_values
+        else:
+            # dense vector
+            # Note: According to spark ML VectorUDT format,
+            # when type field is 1, the size field is also empty.
+            # we need to check the values field to get vector length.
+            vec_size = len(vec_values)
+            csr_indices = np.arange(vec_size, dtype=np.int32)
+            csr_values = vec_values
+
+        if n_features == 0:
+            n_features = vec_size
+        assert n_features == vec_size, "all vectors must be of the same dimension"
+
+        csr_indices_list.append(csr_indices)
+        csr_indptr_list.append(csr_indptr_list[-1] + len(csr_indices))
+        assert len(csr_indptr_list) == 1 + len(csr_indices_list)
+
+        csr_values_list.append(csr_values)
+
+    assert len(csr_indptr_list) == 1 + len(part)
+
+    csr_indptr_arr = np.array(csr_indptr_list)
+    csr_indices_arr = np.concatenate(csr_indices_list)
+    csr_values_arr = np.concatenate(csr_values_list)
+
+    return csr_matrix(
+        (csr_values_arr, csr_indices_arr, csr_indptr_arr), shape=(len(part), n_features)
+    )
 
 
 class _CumlEstimatorWriter(MLWriter):
@@ -359,6 +456,7 @@ class _CumlCaller(_CumlParams, _CumlCommon):
         if input_col is not None:
             # Single Column
             input_datatype = dataset.schema[input_col].dataType
+            first_record = dataset.first()
 
             if isinstance(input_datatype, ArrayType):
                 # Array type
@@ -379,17 +477,37 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                     # FloatType array
                     select_cols.append(col(input_col).alias(alias.data))
             elif isinstance(input_datatype, VectorUDT):
-                # Vector type
                 vector_element_type = "float32" if self._float32_inputs else "float64"
-                select_cols.append(
-                    vector_to_array(col(input_col), vector_element_type).alias(alias.data)  # type: ignore
+                first_vectorudt_type = (
+                    DenseVector
+                    if first_record is None
+                    or type(first_record[input_col]) is DenseVector
+                    else SparseVector
                 )
+                use_sparse = self.hasParam(
+                    "enable_sparse_data_optim"
+                ) and self.getOrDefault("enable_sparse_data_optim")
+
+                if use_sparse is True or (
+                    use_sparse is None and first_vectorudt_type is SparseVector
+                ):
+                    # Sparse Vector type
+                    select_cols += _get_unwrapped_vec_cols(col(input_col))
+                else:
+                    # Dense Vector type
+                    assert use_sparse is False or (
+                        use_sparse is None and first_vectorudt_type is DenseVector
+                    )
+                    select_cols.append(
+                        vector_to_array(col(input_col), vector_element_type).alias(alias.data)  # type: ignore
+                    )
+
                 if not self._float32_inputs:
                     feature_type = DoubleType
             else:
                 raise ValueError("Unsupported input type.")
 
-            dimension = len(dataset.first()[input_col])  # type: ignore
+            dimension = len(first_record[input_col])  # type: ignore
 
         elif input_cols is not None:
             # if self._float32_inputs is False and if any columns are double type, convert all to double type
@@ -552,11 +670,17 @@ class _CumlCaller(_CumlParams, _CumlCommon):
         array_order = self._fit_array_order()
 
         cuml_verbose = self.cuml_params.get("verbose", False)
+        use_sparse_array = (
+            alias.featureVectorType in dataset.schema.fieldNames()
+            and alias.featureVectorSize in dataset.schema.fieldNames()
+            and alias.featureVectorIndices in dataset.schema.fieldNames()
+        )  # use sparse array in cuml only if features vectorudt column was unwrapped
 
         (enable_nccl, require_ucx) = self._require_nccl_ucx()
 
         def _train_udf(pdf_iter: Iterator[pd.DataFrame]) -> pd.DataFrame:
             import cupy as cp
+            import cupyx
             from pyspark import BarrierTaskContext
 
             context = BarrierTaskContext.get()
@@ -583,16 +707,26 @@ class _CumlCaller(_CumlParams, _CumlCommon):
             logger.info("Loading data into python worker memory")
             inputs = []
             sizes = []
+
             for pdf in pdf_iter:
                 sizes.append(pdf.shape[0])
                 if multi_col_names:
                     features = np.array(pdf[multi_col_names], order=array_order)
+                elif use_sparse_array:
+                    # sparse vector
+                    features = _read_csr_matrix_from_unwrapped_spark_vec(pdf)
                 else:
+                    # dense vector
                     features = np.array(list(pdf[alias.data]), order=array_order)
+
                 # experiments indicate it is faster to convert to numpy array and then to cupy array than directly
                 # invoking cupy array on the list
                 if cuda_managed_mem_enabled:
-                    features = cp.array(features)
+                    features = (
+                        cp.array(features)
+                        if use_sparse_array is False
+                        else cupyx.scipy.sparse.csr_matrix(features)
+                    )
 
                 label = pdf[alias.label] if alias.label in pdf.columns else None
                 row_number = (

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -128,10 +128,10 @@ Alias = namedtuple(
     ),
 )
 alias = Alias(
-    "vector_type",
-    "vector_size",
-    "vector_indices",
-    "cuml_values",
+    "vector_type_c3BhcmstcmFwaWRzLW1sCg==",
+    "vector_size_c3BhcmstcmFwaWRzLW1sCg==",
+    "vector_indices_c3BhcmstcmFwaWRzLW1sCg==",
+    "cuml_values_c3BhcmstcmFwaWRzLW1sCg==",
     "cuml_label",
     "unique_id",
 )
@@ -182,6 +182,14 @@ def _get_unwrapped_vec_cols(feature_col: Column) -> List[Column]:
             alias.data
         ),
     ]
+
+
+def _use_sparse_in_cuml(dataset: DataFrame) -> bool:
+    return (
+        alias.featureVectorType in dataset.schema.fieldNames()
+        and alias.featureVectorSize in dataset.schema.fieldNames()
+        and alias.featureVectorIndices in dataset.schema.fieldNames()
+    )  # use sparse array in cuml only if features vectorudt column was unwrapped
 
 
 # similar to the XGBOOST _read_csr_matrix_from_unwrapped_spark_vec in https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/spark/data.py
@@ -670,11 +678,8 @@ class _CumlCaller(_CumlParams, _CumlCommon):
         array_order = self._fit_array_order()
 
         cuml_verbose = self.cuml_params.get("verbose", False)
-        use_sparse_array = (
-            alias.featureVectorType in dataset.schema.fieldNames()
-            and alias.featureVectorSize in dataset.schema.fieldNames()
-            and alias.featureVectorIndices in dataset.schema.fieldNames()
-        )  # use sparse array in cuml only if features vectorudt column was unwrapped
+
+        use_sparse_array = _use_sparse_in_cuml(dataset)
 
         (enable_nccl, require_ucx) = self._require_nccl_ucx()
 
@@ -1192,16 +1197,55 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
 
         if input_col is not None:
             input_col_type = dataset.schema[input_col].dataType
-            tmp_input_col = f"{alias.data}_c3BhcmstcmFwaWRzLW1sCg=="
             if isinstance(input_col_type, VectorUDT):
                 # Vector type
-                # Avoid same naming. `echo spark-rapids-ml | base64` = c3BhcmstcmFwaWRzLW1sCg==
                 vector_element_type = "float32" if self._float32_inputs else "float64"
-                dataset = dataset.withColumn(
-                    tmp_input_col, vector_to_array(col(input_col), vector_element_type)
-                )
-                select_cols.append(tmp_input_col)
-                tmp_cols.append(tmp_input_col)
+
+                if self.hasParam("enable_sparse_data_optim") is False:
+                    use_cuml_sparse = False
+                elif self.getOrDefault("enable_sparse_data_optim") is None:
+                    first_record = dataset.first()
+                    first_vectorudt_type = (
+                        DenseVector
+                        if first_record is None
+                        or type(first_record[input_col]) is DenseVector
+                        else SparseVector
+                    )
+                    use_cuml_sparse = first_vectorudt_type is SparseVector
+                else:
+                    use_cuml_sparse = self.getOrDefault("enable_sparse_data_optim")
+
+                if use_cuml_sparse:
+                    type_col, size_col, indices_col, data_col = _get_unwrapped_vec_cols(
+                        col(input_col)
+                    )
+
+                    dataset = dataset.withColumn(alias.featureVectorType, type_col)
+
+                    dataset = dataset.withColumn(alias.featureVectorSize, size_col)
+
+                    dataset = dataset.withColumn(
+                        alias.featureVectorIndices, indices_col
+                    )
+
+                    dataset = dataset.withColumn(alias.data, data_col.alias(alias.data))
+
+                    for col_name in [
+                        alias.featureVectorType,
+                        alias.featureVectorSize,
+                        alias.featureVectorIndices,
+                        alias.data,
+                    ]:
+                        select_cols.append(col_name)
+                        tmp_cols.append(col_name)
+                else:
+                    # Avoid same naming. `echo spark-rapids-ml | base64` = c3BhcmstcmFwaWRzLW1sCg==
+                    dataset = dataset.withColumn(
+                        alias.data,
+                        vector_to_array(col(input_col), vector_element_type),
+                    )
+                    select_cols.append(alias.data)
+                    tmp_cols.append(alias.data)
             elif isinstance(input_col_type, ArrayType):
                 if (
                     isinstance(input_col_type.elementType, DoubleType)
@@ -1213,10 +1257,10 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                     and self._float32_inputs
                 ):
                     dataset = dataset.withColumn(
-                        tmp_input_col, col(input_col).cast(ArrayType(FloatType()))
+                        alias.data, col(input_col).cast(ArrayType(FloatType()))
                     )
-                    select_cols.append(tmp_input_col)
-                    tmp_cols.append(tmp_input_col)
+                    select_cols.append(alias.data)
+                    tmp_cols.append(alias.data)
                 else:
                     # FloatType array
                     select_cols.append(input_col)
@@ -1281,6 +1325,8 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
 
         array_order = self._transform_array_order()
 
+        use_sparse_array = _use_sparse_in_cuml(dataset)
+
         def _transform_udf(pdf_iter: Iterator[pd.DataFrame]) -> pd.DataFrame:
             from pyspark import TaskContext
 
@@ -1298,7 +1344,12 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
             for pdf in pdf_iter:
                 for index, cuml_object in enumerate(cuml_objects):
                     # Transform the dataset
-                    if input_is_multi_cols:
+                    if use_sparse_array:
+                        features = _read_csr_matrix_from_unwrapped_spark_vec(
+                            pdf[select_cols]
+                        )
+                        data = cuml_transform_func(cuml_object, features)
+                    elif input_is_multi_cols:
                         data = cuml_transform_func(cuml_object, pdf[select_cols])
                     else:
                         nparray = np.array(list(pdf[select_cols[0]]), order=array_order)
@@ -1425,6 +1476,8 @@ class _CumlModelWithColumns(_CumlModel):
 
         array_order = self._transform_array_order()
 
+        use_sparse_array = _use_sparse_in_cuml(dataset)
+
         @pandas_udf(self._out_schema(dataset.schema))  # type: ignore
         def predict_udf(iterator: Iterator[pd.DataFrame]) -> Iterator[pd.Series]:
             from pyspark import TaskContext
@@ -1436,7 +1489,9 @@ class _CumlModelWithColumns(_CumlModel):
                 cuml_objects[0] if isinstance(cuml_objects, list) else cuml_objects
             )
             for pdf in iterator:
-                if not input_is_multi_cols:
+                if use_sparse_array:
+                    data = _read_csr_matrix_from_unwrapped_spark_vec(pdf[select_cols])
+                elif not input_is_multi_cols:
                     data = np.array(list(pdf[select_cols[0]]), order=array_order)
                 else:
                     data = pdf[select_cols]

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -39,6 +39,31 @@ if TYPE_CHECKING:
 P = TypeVar("P", bound="_CumlParams")
 
 
+class HasEnableSparseDataOptim(Params):
+
+    """
+    This is a Params based class inherited from XGBOOST: https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/spark/params.py.
+    It holds the variable to store the boolean config for enabling sparse data optimization.
+    """
+
+    enable_sparse_data_optim = Param(
+        Params._dummy(),
+        "enable_sparse_data_optim",
+        "This param activates sparse data optimization for VectorUDT features column. "
+        "If the param is not included in an Estimator class, "
+        "Spark rapids ml always converts VectorUDT features column into dense arrays when calling cuml backend. "
+        "If included, Spark rapids ml will determine whether to create sparse arrays based on the param value: "
+        "(1) If None, create dense arrays if the first VectorUDT of a dataframe is DenseVector. Create sparse arrays if it is SparseVector."
+        "(2) If False, create dense arrays. This is favorable if the majority of vectors are DenseVector."
+        "(3) If True, create sparse arrays. This is favorable if the majority of the VectorUDT vectors are SparseVector.",
+        typeConverter=TypeConverters.toBoolean,
+    )
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._setDefault(enable_sparse_data_optim=None)
+
+
 class HasFeaturesCols(Params):
     """
     Mixin for param featuresCols: features column names for multi-column input.

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -22,9 +22,13 @@ if TYPE_CHECKING:
     import cudf
     import cupy as cp
 
+import cupyx
 import numpy as np
+import pandas as pd
+import scipy
 from pyspark import BarrierTaskContext, SparkConf, SparkContext, TaskContext
-from pyspark.sql import SparkSession
+from pyspark.sql import Column, SparkSession
+from pyspark.sql.types import ArrayType, FloatType
 
 _ArrayOrder = Literal["C", "F"]
 
@@ -197,26 +201,41 @@ class PartitionDescriptor:
 
 
 def _concat_and_free(
-    array_list: Union[List["cp.ndarray"], List[np.ndarray]], order: _ArrayOrder = "F"
-) -> Union["cp.ndarray", np.ndarray]:
+    array_list: Union[
+        List["cp.ndarray"],
+        List[np.ndarray],
+        List[scipy.sparse.csr_matrix],
+        List["cupyx.scipy.sparse.csr_matrix"],
+    ],
+    order: _ArrayOrder = "F",
+) -> Union[
+    "cp.ndarray", np.ndarray, scipy.sparse.csr_matrix, "cupyx.scipy.sparse.csr_matrix"
+]:
     """
     concatenates a list of compatible numpy arrays into a 'order' ordered output array,
     in a memory efficient way.
     Note: frees list elements so do not reuse after calling.
+
+    if the type of input arrays is scipy or cupyx csr_matrix, 'order' parameter will not be used.
     """
-    import cupy as cp
-
-    array_module = cp if isinstance(array_list[0], cp.ndarray) else np
-
-    rows = sum(arr.shape[0] for arr in array_list)
-    if len(array_list[0].shape) > 1:
-        cols = array_list[0].shape[1]
-        concat_shape: Tuple[int, ...] = (rows, cols)
+    if isinstance(array_list[0], scipy.sparse.csr_matrix):
+        concated = scipy.sparse.vstack(array_list)
+    elif isinstance(array_list[0], cupyx.scipy.sparse.csr_matrix):
+        concated = cupyx.scipy.sparse.vstack(array_list)
     else:
-        concat_shape = (rows,)
-    d_type = array_list[0].dtype
-    concated = array_module.empty(shape=concat_shape, order=order, dtype=d_type)
-    array_module.concatenate(array_list, out=concated)
+        import cupy as cp
+
+        array_module = cp if isinstance(array_list[0], cp.ndarray) else np
+
+        rows = sum(arr.shape[0] for arr in array_list)
+        if len(array_list[0].shape) > 1:
+            cols = array_list[0].shape[1]
+            concat_shape: Tuple[int, ...] = (rows, cols)
+        else:
+            concat_shape = (rows,)
+        d_type = array_list[0].dtype
+        concated = array_module.empty(shape=concat_shape, order=order, dtype=d_type)
+        array_module.concatenate(array_list, out=concated)
     del array_list[:]
     return concated
 
@@ -444,3 +463,23 @@ def translate_trees(sc: SparkContext, impurity: str, model: Dict[str, Any]):  # 
         )
     elif "leaf_value" in model:
         return _create_leaf_node(sc, impurity, model)
+
+
+# to the XGBOOST _get_unwrap_udt_fn in https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/spark/core.py
+def _get_unwrap_udt_fn() -> Callable[[Union[Column, str]], Column]:
+    try:
+        from pyspark.sql.functions import unwrap_udt  # type: ignore
+
+        return unwrap_udt
+    except ImportError:
+        pass
+
+    try:
+        from pyspark.databricks.sql.functions import unwrap_udt as databricks_unwrap_udt
+
+        return databricks_unwrap_udt
+    except ImportError as exc:
+        raise RuntimeError(
+            "Cannot import pyspark `unwrap_udt` function. Please install pyspark>=3.4 "
+            "or run on Databricks Runtime."
+        ) from exc

--- a/python/tests/test_kmeans.py
+++ b/python/tests/test_kmeans.py
@@ -152,7 +152,11 @@ def test_kmeans_basic(gpu_number: int, tmp_path: str) -> None:
             .map(lambda row: (row,))
             .toDF(["features"])
         )
-        kmeans = KMeans(num_workers=gpu_number, n_clusters=2).setFeaturesCol("features")
+        kmeans = (
+            KMeans(num_workers=gpu_number, n_clusters=2)
+            .setFeaturesCol("features")
+            .setSeed(0)
+        )
 
         def assert_kmeans_model(model: KMeansModel) -> None:
             assert len(model.cluster_centers_) == 2

--- a/python/tests/test_kmeans.py
+++ b/python/tests/test_kmeans.py
@@ -17,9 +17,16 @@
 from typing import Any, Dict, List, Tuple, Type, TypeVar
 
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
-from pyspark.errors import IllegalArgumentException
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.clustering import KMeans as SparkKMeans
 from pyspark.ml.clustering import KMeansModel as SparkKMeansModel
 from pyspark.ml.functions import array_to_vector
@@ -335,7 +342,7 @@ def test_kmeans_spark_compat(
         if version.parse(pyspark.__version__) < version.parse("3.4.0"):
             kmeans = _KMeans(k=2)
         else:
-            kmeans = _KMeans(k=2, solver="auto", maxBlockSizeInMB=0)
+            kmeans = _KMeans(k=2, solver="auto", maxBlockSizeInMB=0)  # type: ignore # only spark >= 3.4 supports solver and maxblockSize
 
         kmeans.setSeed(1)
         kmeans.setMaxIter(10)

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -17,9 +17,16 @@ import warnings
 from typing import Any, Dict, List, Tuple, Type, TypeVar, cast
 
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
-from pyspark.errors import IllegalArgumentException
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.evaluation import RegressionEvaluator
 from pyspark.ml.feature import VectorAssembler
 from pyspark.ml.functions import array_to_vector

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -28,6 +28,7 @@ from pyspark.ml.tuning import CrossValidator as SparkCrossValidator
 from pyspark.ml.tuning import CrossValidatorModel, ParamGridBuilder
 from pyspark.sql import DataFrame, Row
 from pyspark.sql.functions import array, col
+from pyspark.sql.types import FloatType
 
 if version.parse(cuml.__version__) < version.parse("23.08.00"):
     raise ValueError(
@@ -37,6 +38,7 @@ if version.parse(cuml.__version__) < version.parse("23.08.00"):
 import warnings
 
 from spark_rapids_ml.classification import LogisticRegression, LogisticRegressionModel
+from spark_rapids_ml.core import _use_sparse_in_cuml, alias
 from spark_rapids_ml.tuning import CrossValidator
 
 from .sparksession import CleanSparkSession
@@ -48,6 +50,46 @@ from .utils import (
     idfn,
     make_classification_dataset,
 )
+
+
+def check_sparse_estimator_preprocess(
+    lr: LogisticRegression, df: DataFrame, dimension: int
+) -> None:
+    (select_cols, multi_col_names, dimension, feature_type) = lr._pre_process_data(df)
+    internal_df = df.select(*select_cols)
+    field_names = internal_df.schema.fieldNames()
+    assert field_names == [
+        alias.featureVectorType,
+        alias.featureVectorSize,
+        alias.featureVectorIndices,
+        alias.data,
+        alias.label,
+    ]
+    assert multi_col_names is None
+    assert dimension == dimension
+    assert feature_type == FloatType
+    assert _use_sparse_in_cuml(internal_df) is True
+
+
+def check_sparse_model_preprocess(
+    model: LogisticRegressionModel, df: DataFrame
+) -> None:
+    (internal_df, select_cols, input_is_multi_cols, tmp_cols) = model._pre_process_data(
+        df
+    )
+    df_field_names = df.schema.fieldNames()
+    internal_df_field_names = internal_df.schema.fieldNames()
+    unwrapped_col_names = [
+        alias.featureVectorType,
+        alias.featureVectorSize,
+        alias.featureVectorIndices,
+        alias.data,
+    ]
+    assert internal_df_field_names == df_field_names + unwrapped_col_names
+    assert select_cols == unwrapped_col_names
+    assert tmp_cols == select_cols
+    assert input_is_multi_cols is False
+    assert _use_sparse_in_cuml(internal_df) is True
 
 
 def test_toy_example(gpu_number: int) -> None:
@@ -1013,7 +1055,11 @@ def test_crossvalidator_logistic_regression(
     feature_type: str,
     data_type: np.dtype,
     data_shape: Tuple[int, int],
+    convert_to_sparse: bool = False,
 ) -> None:
+    if convert_to_sparse:
+        assert feature_type == feature_types.vector
+
     # Train a toy model
 
     n_classes = 2 if metric_name == "areaUnderROC" else 10
@@ -1034,9 +1080,26 @@ def test_crossvalidator_logistic_regression(
         )
         assert label_col is not None
 
-        lr = LogisticRegression()
+        if convert_to_sparse:
+            assert type(features_col) is str
+
+            from pyspark.sql.functions import udf
+
+            def to_sparse_func(v: Union[SparseVector, DenseVector]) -> SparseVector:
+                if isinstance(v, DenseVector):
+                    return SparseVector(len(v), range(len(v)), v.toArray())
+                else:
+                    return v
+
+            udf_to_sparse = udf(to_sparse_func, VectorUDT())
+            df = df.withColumn(features_col, udf_to_sparse(features_col))
+
+        lr = LogisticRegression(enable_sparse_data_optim=convert_to_sparse)
         lr.setFeaturesCol(features_col)
         lr.setLabelCol(label_col)
+
+        if convert_to_sparse is True:
+            check_sparse_estimator_preprocess(lr, df, data_shape[1])
 
         evaluator = (
             BinaryClassificationEvaluator()
@@ -1380,7 +1443,10 @@ def test_compat_sparse_binomial(
                 gpu_lr.fit(bdf)
             return
 
+        check_sparse_estimator_preprocess(gpu_lr, bdf, dimension=3)
+
         gpu_model = gpu_lr.fit(bdf)
+        check_sparse_model_preprocess(gpu_model, bdf)
 
         cpu_lr = SparkLogisticRegression(**params)
         cpu_model = cpu_lr.fit(bdf)
@@ -1571,4 +1637,21 @@ def test_quick_sparse(
         reg_param=reg_param,
         elasticNet_param=elasticNet_param,
         convert_to_sparse=convert_to_sparse,
+    )
+
+
+@pytest.mark.parametrize("metric_name", ["accuracy", "logLoss", "areaUnderROC"])
+@pytest.mark.parametrize("data_type", [np.float32])
+@pytest.mark.parametrize("data_shape", [(100, 8)], ids=idfn)
+def test_sparse_crossvalidator_logistic_regression(
+    metric_name: str,
+    data_type: np.dtype,
+    data_shape: Tuple[int, int],
+) -> None:
+    test_crossvalidator_logistic_regression(
+        metric_name=metric_name,
+        feature_type=feature_types.vector,
+        data_type=data_type,
+        data_shape=data_shape,
+        convert_to_sparse=True,
     )

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1060,6 +1060,14 @@ def test_crossvalidator_logistic_regression(
     if convert_to_sparse:
         assert feature_type == feature_types.vector
 
+        if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+            import logging
+
+            err_msg = "pyspark < 3.4 is detected. Cannot import pyspark `unwrap_udt` function. "
+            "The test case will be skipped. Please install pyspark>=3.4."
+            logging.info(err_msg)
+        return
+
     # Train a toy model
 
     n_classes = 2 if metric_name == "areaUnderROC" else 10

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -2,10 +2,16 @@ from typing import Any, Dict, List, Tuple, Type, TypeVar
 
 import cuml
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
 from packaging import version
-from pyspark.errors import IllegalArgumentException
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.classification import LogisticRegression as SparkLogisticRegression
 from pyspark.ml.classification import (
     LogisticRegressionModel as SparkLogisticRegressionModel,

--- a/python/tests/test_pca.py
+++ b/python/tests/test_pca.py
@@ -17,9 +17,16 @@
 from typing import Any, Dict, Tuple, Type, TypeVar
 
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
-from pyspark.errors import IllegalArgumentException
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.feature import PCA as SparkPCA
 from pyspark.ml.feature import PCAModel as SparkPCAModel
 from pyspark.ml.functions import array_to_vector

--- a/python/tests/test_random_forest.py
+++ b/python/tests/test_random_forest.py
@@ -18,10 +18,17 @@ import math
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
 
 import numpy as np
+import pyspark
 import pytest
 from _pytest.logging import LogCaptureFixture
 from cuml import accuracy_score
-from pyspark.errors import IllegalArgumentException
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+    from pyspark.sql.utils import IllegalArgumentException  # type: ignore
+else:
+    from pyspark.errors import IllegalArgumentException  # type: ignore
+
 from pyspark.ml.classification import (
     RandomForestClassificationModel as SparkRFClassificationModel,
 )


### PR DESCRIPTION
Merge to main for 23.12 release

Release notes as follows:

- Match Spark's logistic regression fit behavior when data set has only one label value.
- Support sparse vector based computations through cuML layer in logistic regression fit, transform, and cross validation.
- Update dataproc benchmark script.
- Update Azure Databricks instructions.
- Update RAPIDS dependencies to 23.12.

NOTE: this PR must be merged as `create a merge commit`