### PR TITLE
[LogisticRegression] Support standardization for dense vectors

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -1019,7 +1019,13 @@ class LogisticRegression(
                     init_parameters["fit_intercept"] is True
                     and len(intercept_array) > 1
                 ):
-                    intercept_mean = sum(intercept_array) / len(intercept_array)
+                    import cupy as cp
+
+                    intercept_mean = (
+                        np.mean(intercept_array)
+                        if isinstance(intercept_array, np.ndarray)
+                        else cp.mean(intercept_array)
+                    )
                     intercept_array -= intercept_mean
 
                 n_cols = logistic_regression.n_cols

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1531,7 +1531,7 @@ def test_compat_sparse_multinomial(
 #@pytest.mark.parametrize("fit_intercept", [True, False])
 @pytest.mark.parametrize("fit_intercept", [True])
 #@pytest.mark.parametrize("standardization", [True, False])
-@pytest.mark.parametrize("standardization", [False])
+@pytest.mark.parametrize("standardization", [True])
 @pytest.mark.slow
 def test_sparse_nlp20news(
     fit_intercept: bool,
@@ -1604,27 +1604,25 @@ def test_sparse_nlp20news(
 
         gpu_model = gpu_lr.fit(df_train)
 
-        exit()
+        #cpu_model = cpu_lr.fit(df_train)
+        #cpu_objective = cpu_model.summary.objectiveHistory[-1]
 
-        cpu_model = cpu_lr.fit(df_train)
-        cpu_objective = cpu_model.summary.objectiveHistory[-1]
+        #assert (
+        #    gpu_model.objective < cpu_objective
+        #    or abs(gpu_model.objective - cpu_objective) < tolerance
+        #)
 
-        assert (
-            gpu_model.objective < cpu_objective
-            or abs(gpu_model.objective - cpu_objective) < tolerance
-        )
+        #assert "CUDA managed memory enabled." in caplog.text
 
-        assert "CUDA managed memory enabled." in caplog.text
-
-        if standardization is True:
-            compare_model(
-                gpu_model,
-                cpu_model,
-                df_train,
-                unit_tol=tolerance,
-                total_tol=tolerance,
-                accuracy_and_probability_only=True,
-            )
+        #if standardization is True:
+        #    compare_model(
+        #        gpu_model,
+        #        cpu_model,
+        #        df_train,
+        #        unit_tol=tolerance,
+        #        total_tol=tolerance,
+        #        accuracy_and_probability_only=True,
+        #    )
 
 
 @pytest.mark.parametrize("fit_intercept", [True, False])
@@ -1755,8 +1753,7 @@ def test_compat_standardization(
         blor_model = blor.fit(bdf)
 
         if isinstance(blor, LogisticRegression):
-            warning_log = ("when standardization is True, spark rapids ml forces densifying sparse vectors to dense vectors for training. "
-                            "enable_sparse_data_optim is set to False")
+            warning_log = ("when standardization is True, spark rapids ml forces densifying sparse vectors to dense vectors for training.")
             assert warning_log in caplog.text
 
         blor_model.setFeaturesCol("features")
@@ -1890,7 +1887,8 @@ def test_standardization(
         assert mg_test_acc > mc_test_acc or abs(mg_test_acc - mc_test_acc) < tolerance
 
 
-@pytest.mark.parametrize("fit_intercept", [True, False])
+#@pytest.mark.parametrize("fit_intercept", [True, False])
+@pytest.mark.parametrize("fit_intercept", [True])
 @pytest.mark.parametrize(
     "reg_factors", [(0.0, 0.0)]
     #"reg_factors", [(0.0, 0.0), (0.1, 0.0), (0.1, 1.0), (0.1, 0.2)]
@@ -1973,8 +1971,7 @@ def test_standardization_sparse_example(
         cpu_lr = SparkLogisticRegression(**est_params)
 
         gpu_model = gpu_lr.fit(df)
-        warning_log = ("when standardization is True, spark rapids ml forces densifying sparse vectors to dense vectors for training. "
-                        "enable_sparse_data_optim is set to False")
+        warning_log = ("when standardization is True, spark rapids ml forces densifying sparse vectors to dense vectors for training.")
         assert warning_log in caplog.text
 
         cpu_model = cpu_lr.fit(df)

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1528,10 +1528,8 @@ def test_compat_sparse_multinomial(
             compare_model(gpu_model, cpu_model, mdf)
 
 
-#@pytest.mark.parametrize("fit_intercept", [True, False])
-@pytest.mark.parametrize("fit_intercept", [True])
-#@pytest.mark.parametrize("standardization", [True, False])
-@pytest.mark.parametrize("standardization", [True])
+@pytest.mark.parametrize("fit_intercept", [True, False])
+@pytest.mark.parametrize("standardization", [True, False])
 @pytest.mark.slow
 def test_sparse_nlp20news(
     fit_intercept: bool,
@@ -1563,7 +1561,7 @@ def test_sparse_nlp20news(
     y = twenty_train.target.tolist()
 
     conf = {
-        "spark.rapids.ml.uvm.enabled": True
+        # "spark.rapids.ml.uvm.enabled": True # Commenting this out can resolve a cudaMemSet error
     }  # enable memory management to run the test case on GPU with small memory (e.g. 2G)
     with CleanSparkSession(conf) as spark:
         data = [
@@ -1604,25 +1602,25 @@ def test_sparse_nlp20news(
 
         gpu_model = gpu_lr.fit(df_train)
 
-        #cpu_model = cpu_lr.fit(df_train)
-        #cpu_objective = cpu_model.summary.objectiveHistory[-1]
+        cpu_model = cpu_lr.fit(df_train)
+        cpu_objective = cpu_model.summary.objectiveHistory[-1]
 
-        #assert (
-        #    gpu_model.objective < cpu_objective
-        #    or abs(gpu_model.objective - cpu_objective) < tolerance
-        #)
+        assert (
+            gpu_model.objective < cpu_objective
+            or abs(gpu_model.objective - cpu_objective) < tolerance
+        )
 
-        #assert "CUDA managed memory enabled." in caplog.text
+        # assert "CUDA managed memory enabled." in caplog.text
 
-        #if standardization is True:
-        #    compare_model(
-        #        gpu_model,
-        #        cpu_model,
-        #        df_train,
-        #        unit_tol=tolerance,
-        #        total_tol=tolerance,
-        #        accuracy_and_probability_only=True,
-        #    )
+        if standardization is True:
+            compare_model(
+                gpu_model,
+                cpu_model,
+                df_train,
+                unit_tol=tolerance,
+                total_tol=tolerance,
+                accuracy_and_probability_only=True,
+            )
 
 
 @pytest.mark.parametrize("fit_intercept", [True, False])
@@ -1753,7 +1751,7 @@ def test_compat_standardization(
         blor_model = blor.fit(bdf)
 
         if isinstance(blor, LogisticRegression):
-            warning_log = ("when standardization is True, spark rapids ml forces densifying sparse vectors to dense vectors for training.")
+            warning_log = "when standardization is True, spark rapids ml forces densifying sparse vectors to dense vectors for training."
             assert warning_log in caplog.text
 
         blor_model.setFeaturesCol("features")
@@ -1971,7 +1969,7 @@ def test_standardization_sparse_example(
         cpu_lr = SparkLogisticRegression(**est_params)
 
         gpu_model = gpu_lr.fit(df)
-        warning_log = ("when standardization is True, spark rapids ml forces densifying sparse vectors to dense vectors for training.")
+        warning_log = "when standardization is True, spark rapids ml forces densifying sparse vectors to dense vectors for training."
         assert warning_log in caplog.text
 
         cpu_model = cpu_lr.fit(df)

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -1560,7 +1560,7 @@ def test_sparse_nlp20news(
     X = twenty_train.data
     y = twenty_train.target.tolist()
 
-    conf = {
+    conf: Dict[str, Any] = {
         # "spark.rapids.ml.uvm.enabled": True # Commenting this out can resolve a cudaMemSet error
     }  # enable memory management to run the test case on GPU with small memory (e.g. 2G)
     with CleanSparkSession(conf) as spark:
@@ -1885,11 +1885,9 @@ def test_standardization(
         assert mg_test_acc > mc_test_acc or abs(mg_test_acc - mc_test_acc) < tolerance
 
 
-#@pytest.mark.parametrize("fit_intercept", [True, False])
-@pytest.mark.parametrize("fit_intercept", [True])
+@pytest.mark.parametrize("fit_intercept", [True, False])
 @pytest.mark.parametrize(
-    "reg_factors", [(0.0, 0.0)]
-    #"reg_factors", [(0.0, 0.0), (0.1, 0.0), (0.1, 1.0), (0.1, 0.2)]
+    "reg_factors", [(0.0, 0.0), (0.1, 0.0), (0.1, 1.0), (0.1, 0.2)]
 )
 def test_standardization_sparse_example(
     fit_intercept: bool,


### PR DESCRIPTION
Sparse vectors will be densified to dense vectors if standardization is on. 

The PR removes uvm in the test of nlp20news dataset, because it is found the uvm leads to a cuda memset error in vars calculation. 