### PR TITLE
[LogisticRegression] Padding zeros to bypass the out-of-bound memory access of the raft stats (sum, mean, stddev) kernels

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -979,6 +979,9 @@ class LogisticRegression(
             if self.getStandardization() is True and is_sparse is True:
                 concated = concated.toarray()
 
+            # Padding zero columns so that the total number of columns is a multiple of 32.
+            # The purpose is to avoid out-of-bound memory access of some RAFT 24.02 cuda kernels (e.g. sum).
+            # This is a temporary workaround and is expected to be removed in 24.04
             num_pad_zero_cols = 0
             if self.getStandardization() is True and concated.shape[1] % 32 != 0:
                 num_pad_zero_cols = 32 - concated.shape[1] % 32

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -981,7 +981,7 @@ class LogisticRegression(
 
             num_pad_zero_cols = 0
             if self.getStandardization() is True and concated.shape[1] % 32 != 0:
-                num_pad_zero_cols = concated.shape[1] % 32
+                num_pad_zero_cols = 32 - concated.shape[1] % 32
                 nrows = concated.shape[0]
                 import cupy as cp
 
@@ -1002,6 +1002,8 @@ class LogisticRegression(
                 else:
                     assert is_sparse is True
                     concated._shape = (nrows, concated.shape[1] + num_pad_zero_cols)
+
+                assert concated.shape[1] % 32 == 0
 
             pdesc = PartitionDescriptor.build(
                 [concated.shape[0]],

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -520,7 +520,7 @@ def test_compat(
             else [-2.42377087, 2.42377087]
         )
         assert array_equal(blor_model.coefficients.toArray(), coef_gnd, tolerance)
-        assert blor_model.intercept == pytest.approx(0, abs=1e-6)
+        assert blor_model.intercept == pytest.approx(0, abs=1e-4)
 
         assert isinstance(blor_model.coefficientMatrix, DenseMatrix)
         assert array_equal(


### PR DESCRIPTION
This PR is a workaround to bypass gpu memory out-of-bound access of raft 24.02. 
