### PR TITLE
[auto-merge] branch-24.04 to branch-24.06 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: branch-24.04 # force to fetch from latest upstream instead of PR ref
 

--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ fromJson(needs.Authorization.outputs.args).repo }}
           ref: ${{ fromJson(needs.Authorization.outputs.args).ref }}
@@ -69,7 +69,7 @@ jobs:
 
       # repo specific steps
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 8

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -39,7 +39,7 @@ jobs:
       SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
       CLUSTER_NAME: github-spark-rapids-ml-${{github.run_number}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: run benchmark
         shell: bash

--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -23,7 +23,7 @@ jobs:
   signoff-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: sigoff-check job
         uses: ./.github/workflows/signoff-check


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-24.04` to create a PR keeping `branch-24.06` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.