### PR TITLE
work around to support pyspark 3.3 with rapids 24.04

### DIFF
--- a/python/src/spark_rapids_ml/__init__.py
+++ b/python/src/spark_rapids_ml/__init__.py
@@ -14,3 +14,15 @@
 # limitations under the License.
 #
 __version__ = "24.04.0"
+
+import pandas as pd
+import pyspark
+
+# patch pandas 2.0+ for backward compatibility with psypark < 3.4
+from packaging import version
+
+if version.parse(pyspark.__version__) < version.parse("3.4.0") and version.parse(
+    pd.__version__
+) >= version.parse("2.0.0"):
+    pd.DataFrame.iteritems = pd.DataFrame.items
+    pd.Series.iteritems = pd.Series.items


### PR DESCRIPTION
pyspark 3.3.x uses pandas iteritems method on dfs which has been removed in pandas 2.0.0 .    

This at least allows our 3.3 tests to pass.