### PR TITLE
[auto-merge] branch-24.04 to branch-24.06 [skip ci] [bot]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -44,8 +44,6 @@ jobs:
       GaryShen2008,\
       NvTimLiu,\
       YanxuanLiu,\
-      zhanga5,\
-      Er1cCheng,\
       ', format('{0},', github.actor)) && github.event.comment.body == 'build'
     steps:
       - name: Check if comment is issued by authorized person


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-24.04` to create a PR keeping `branch-24.06` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.