### PR TITLE
updates for 24.06 rapids compatibility

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,6 +37,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     && conda config --set solver libmamba
 
 # install cuML
-ARG CUML_VER=24.04
+ARG CUML_VER=24.06
 RUN conda install -y -c rapidsai -c conda-forge -c nvidia cuml=$CUML_VER python=3.9 cuda-version=11.8 \
     && conda clean --all -f -y

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = 'spark-rapids-ml'
 copyright = '2024, NVIDIA'
 author = 'NVIDIA'
-release = '24.04.0'
+release = '24.06.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/jvm/README.md
+++ b/jvm/README.md
@@ -74,7 +74,7 @@ the _project root path_ with:
 cd jvm
 mvn clean package
 ```
-Then `rapids-4-spark-ml_2.12-24.02.0-SNAPSHOT.jar` will be generated under `target` folder.
+Then `rapids-4-spark-ml_2.12-24.04.1-SNAPSHOT.jar` will be generated under `target` folder.
 
 Users can also use the _release_ version spark-rapids plugin as the dependency if it's already been
 released in public maven repositories, see [rapids-4-spark maven repository](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark)
@@ -94,8 +94,8 @@ repository, usually in your `~/.m2/repository`.
 
 Add the artifact jar to the Spark, for example:
 ```bash
-ML_JAR="target/rapids-4-spark-ml_2.12-24.02.0-SNAPSHOT.jar"
-PLUGIN_JAR="~/.m2/repository/com/nvidia/rapids-4-spark_2.12/24.02.0/rapids-4-spark_2.12-24.02.0.jar"
+ML_JAR="target/rapids-4-spark-ml_2.12-24.04.1-SNAPSHOT.jar"
+PLUGIN_JAR="~/.m2/repository/com/nvidia/rapids-4-spark_2.12/24.04.1/rapids-4-spark_2.12-24.04.1.jar"
 
 $SPARK_HOME/bin/spark-shell --master $SPARK_MASTER \
  --driver-memory 20G \

--- a/notebooks/aws-emr/init-bootstrap-action.sh
+++ b/notebooks/aws-emr/init-bootstrap-action.sh
@@ -8,7 +8,7 @@ sudo chmod a+rwx -R /sys/fs/cgroup/devices
 sudo yum install -y gcc openssl-devel bzip2-devel libffi-devel tar gzip wget make mysql-devel
 sudo bash -c "wget https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tgz && tar xzf Python-3.9.9.tgz && cd Python-3.9.9 && ./configure --enable-optimizations && make altinstall"
 
-RAPIDS_VERSION=24.4.0
+RAPIDS_VERSION=24.6.0
 
 # install scikit-learn 
 sudo /usr/local/bin/pip3.9 install scikit-learn

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -51,7 +51,7 @@ If you already have a Databricks account, you can run the example notebooks on a
       spark.task.resource.gpu.amount 1
       spark.databricks.delta.preview.enabled true
       spark.python.worker.reuse true
-      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-24.02.0.jar:/databricks/spark/python
+      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-24.04.1.jar:/databricks/spark/python
       spark.sql.execution.arrow.maxRecordsPerBatch 100000
       spark.rapids.memory.gpu.minAllocFraction 0.0001
       spark.plugins com.nvidia.spark.SQLPlugin

--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -4,8 +4,8 @@ SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/zip/file
 # IMPORTANT: specify RAPIDS_VERSION fully 23.10.0 and not 23.10
 # also in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
 # while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.08.2 and not 23.8.2)
-RAPIDS_VERSION=24.4.0
-SPARK_RAPIDS_VERSION=24.02.0
+RAPIDS_VERSION=24.6.0
+SPARK_RAPIDS_VERSION=24.04.1
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda11.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar
 

--- a/notebooks/dataproc/README.md
+++ b/notebooks/dataproc/README.md
@@ -29,7 +29,7 @@ If you already have a Dataproc account, you can run the example notebooks on a D
 - Create a cluster with at least two single-gpu workers.  **Note**: in addition to the initialization script from above, this also uses the standard [initialization actions](https://github.com/GoogleCloudDataproc/initialization-actions) for installing the GPU drivers and RAPIDS:
   ```
   export CUDA_VERSION=11.8
-  export RAPIDS_VERSION=24.4.0
+  export RAPIDS_VERSION=24.6.0
 
   gcloud dataproc clusters create $USER-spark-rapids-ml \
   --image-version=2.1-ubuntu \

--- a/notebooks/dataproc/spark_rapids_ml.sh
+++ b/notebooks/dataproc/spark_rapids_ml.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RAPIDS_VERSION=24.4.0
+RAPIDS_VERSION=24.6.0
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"

--- a/python/README.md
+++ b/python/README.md
@@ -8,9 +8,9 @@ For simplicity, the following instructions just use Spark local mode, assuming a
 
 First, install RAPIDS cuML per [these instructions](https://rapids.ai/start.html).   Example for CUDA Toolkit 11.8:
 ```bash
-conda create -n rapids-24.04 \
+conda create -n rapids-24.06 \
     -c rapidsai -c conda-forge -c nvidia \
-    cuml=24.04 python=3.9 cuda-version=11.8
+    cuml=24.06 python=3.9 cuda-version=11.8
 ```
 
 **Note**: while testing, we recommend using conda or docker to simplify installation and isolate your environment while experimenting.  Once you have a working environment, you can then try installing directly, if necessary.
@@ -19,7 +19,7 @@ conda create -n rapids-24.04 \
 
 Once you have the conda environment, activate it and install the required packages.
 ```bash
-conda activate rapids-24.04
+conda activate rapids-24.06
 
 ## for development access to notebooks, tests, and benchmarks
 git clone --branch main https://github.com/NVIDIA/spark-rapids-ml.git

--- a/python/benchmark/databricks/gpu_cluster_spec.sh
+++ b/python/benchmark/databricks/gpu_cluster_spec.sh
@@ -9,7 +9,7 @@ cat <<EOF
         "spark.task.cpus": "1",
         "spark.databricks.delta.preview.enabled": "true",
         "spark.python.worker.reuse": "true",
-        "spark.executorEnv.PYTHONPATH": "/databricks/jars/rapids-4-spark_2.12-24.02.0.jar:/databricks/spark/python",
+        "spark.executorEnv.PYTHONPATH": "/databricks/jars/rapids-4-spark_2.12-24.04.1.jar:/databricks/spark/python",
         "spark.sql.files.minPartitionNum": "2",
         "spark.sql.execution.arrow.maxRecordsPerBatch": "10000",
         "spark.executor.cores": "8",

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -5,8 +5,8 @@ BENCHMARK_ZIP=/dbfs/path/to/benchmark.zip
 # IMPORTANT: specify rapids fully 23.10.0 and not 23.10
 # also, in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
 # while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.08.2 and not 23.8.2)
-RAPIDS_VERSION=24.4.0
-SPARK_RAPIDS_VERSION=24.02.0
+RAPIDS_VERSION=24.6.0
+SPARK_RAPIDS_VERSION=24.04.1
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda11.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar
 

--- a/python/benchmark/databricks/setup.sh
+++ b/python/benchmark/databricks/setup.sh
@@ -49,6 +49,13 @@ databricks workspace mkdirs ${INIT_SCRIPT_DIR} --profile ${DB_PROFILE} ${DB_OVER
 for init_script in init-pip-cuda-11.8.sh init-cpu.sh
 do
 # NOTE: on linux delete the .bu after -i
+    if base64 --help | grep '\-w'; then
+        # linux
+        base64_cmd="base64 -w 0"
+    else
+        # mac os
+        base64_cmd="base64 -i"
+    fi
     sed -e "s#/path/to/spark-rapids-ml\.zip#${SPARK_RAPIDS_ML_ZIP}#g" -e "s#/path/to/benchmark\.zip#${BENCHMARK_ZIP}#g" $init_script > ${init_script}.updated && \
-    databricks workspace import --format AUTO --content $(base64 -i ${init_script}.updated) ${INIT_SCRIPT_DIR}/${init_script} --profile ${DB_PROFILE} ${DB_OVERWRITE}
+    databricks workspace import --format AUTO --content $(${base64_cmd} ${init_script}.updated) ${INIT_SCRIPT_DIR}/${init_script} --profile ${DB_PROFILE} ${DB_OVERWRITE}
 done

--- a/python/benchmark/dataproc/init_benchmark.sh
+++ b/python/benchmark/dataproc/init_benchmark.sh
@@ -8,7 +8,7 @@ function get_metadata_attribute() {
   /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
 }
 
-RAPIDS_VERSION=$(get_metadata_attribute rapids-version 24.4.0)
+RAPIDS_VERSION=$(get_metadata_attribute rapids-version 24.6.0)
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"

--- a/python/run_benchmark.sh
+++ b/python/run_benchmark.sh
@@ -106,7 +106,7 @@ EOF
 
 if [[ $cluster_type == "gpu_etl" ]]
 then
-SPARK_RAPIDS_VERSION=24.02.0
+SPARK_RAPIDS_VERSION=24.04.1
 rapids_jar=${rapids_jar:-rapids-4-spark_2.12-$SPARK_RAPIDS_VERSION.jar}
 if [ ! -f $rapids_jar ]; then
     echo "downloading spark rapids jar"

--- a/python/src/spark_rapids_ml/__init__.py
+++ b/python/src/spark_rapids_ml/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "24.04.0"
+__version__ = "24.06.0"
 
 import pandas as pd
 import pyspark

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -707,11 +707,11 @@ class LogisticRegressionClass(_CumlClass):
     @classmethod
     def _reg_params_value_mapping(
         cls, reg_param: float, elasticNet_param: float
-    ) -> Tuple[str, float, float]:
-        # Note cuml ignores l1_ratio when penalty is "none", "l2", and "l1"
+    ) -> Tuple[Optional[str], float, float]:
+        # Note cuml ignores l1_ratio when penalty is None, "l2", and "l1"
         # Spark Rapids ML sets it to elasticNet_param to be compatible with Spark
         if reg_param == 0.0:
-            penalty = "none"
+            penalty = None
             C = 0.0
             l1_ratio = elasticNet_param
         elif elasticNet_param == 0.0:
@@ -1041,7 +1041,7 @@ class LogisticRegression(
                     init_parameters["standardization"] = False
 
                 if init_parameters["C"] == 0.0:
-                    init_parameters["penalty"] = "none"
+                    init_parameters["penalty"] = None
 
                 elif init_parameters["l1_ratio"] == 0.0:
                     init_parameters["penalty"] = "l2"

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -96,7 +96,7 @@ class KMeansClass(_CumlClass):
         def tol_value_mapper(x: float) -> float:
             if x == 0.0:
                 logger = get_logger(cls)
-                logger.warn(
+                logger.warning(
                     "tol=0 is not supported in cuml yet. "
                     + "It will be mapped to smallest positive float, i.e. numpy.finfo('float32').tiny."
                 )

--- a/python/src/spark_rapids_ml/common/cuml_context.py
+++ b/python/src/spark_rapids_ml/common/cuml_context.py
@@ -138,6 +138,7 @@ class CumlContext:
             inject_comms_on_handle(
                 self._handle,
                 self._nccl_comm,
+                False,  # is_ucxx - TODO: migrate to ucxx from ucp
                 self._ucx.get_worker(),  # type: ignore
                 self._ucx_eps,
                 self._nranks,

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -128,7 +128,7 @@ class _RandomForestClass(_CumlClass):
             "n_streams": 4,
             "n_estimators": 100,
             "max_depth": 16,
-            "max_features": "auto",
+            "max_features": "sqrt",  # for classification, should be 1.0 for regressor, cuml is a little broken here
             "n_bins": 128,
             "bootstrap": True,
             "verbose": False,

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -177,9 +177,9 @@ def test_params(tmp_path: str, caplog: LogCaptureFixture) -> None:
         "standardization": True,
     }
 
-    default_cuml_params = {
+    default_cuml_params: Dict[str, Any] = {
         "max_iter": 100,
-        "penalty": "none",
+        "penalty": None,
         "C": 0.0,
         "l1_ratio": 0.0,
         "tol": 1e-6,
@@ -1050,7 +1050,7 @@ def test_quick(
     sg = CUMLSG(penalty=penalty, C=C, l1_ratio=l1_ratio)
     l1_strength, l2_strength = sg._get_qn_params()
     if reg_param == 0.0:
-        assert penalty == "none"
+        assert penalty == None
         assert l1_strength == 0.0
         assert l2_strength == 0.0
     elif elasticNet_param == 0.0:


### PR DESCRIPTION
mostly version updates +

- changes for some method signature changes for ucx
- change penalty param type change for LR
- default bagging sample rate change
- minor refactor approx knn test to avoid deprecation warning in pytest (tests shouldn't return anything).
