### PR TITLE
Replace withColumn with select for columnar dataframe

### DIFF
--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1286,6 +1286,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
             feature_type: Union[Type[FloatType], Type[DoubleType]] = FloatType
             if not self._float32_inputs and any_double_types:
                 feature_type = DoubleType
+
             for c in input_cols:
                 col_type = dataset.schema[c].dataType
                 if (
@@ -1295,9 +1296,6 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                 ):
                     if not isinstance(col_type, feature_type):
                         tmp_input_col = f"{c}_c3BhcmstcmFwaWRzLW1sCg=="
-                        dataset = dataset.withColumn(
-                            tmp_input_col, col(c).cast(feature_type())
-                        )
                         select_cols.append(tmp_input_col)
                         tmp_cols.append(tmp_input_col)
                     else:
@@ -1306,6 +1304,12 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                     raise ValueError(
                         "All columns must be integral types or float/double types."
                     )
+
+            taglen = len("_c3BhcmstcmFwaWRzLW1sCg==")
+            added_tmp_cols = [
+                col(c[:-taglen]).cast(feature_type()).alias(c) for c in tmp_cols
+            ]
+            dataset = dataset.select("*", *added_tmp_cols)
         else:
             # should never get here
             raise Exception("Unable to determine input column(s).")

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1308,7 +1308,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                         "All columns must be integral types or float/double types."
                     )
 
-            taglen = len(col_name_unique_tag)
+            taglen = len(col_name_unique_tag) + 1
             added_tmp_cols = [
                 col(c[:-taglen]).cast(feature_type()).alias(c) for c in tmp_cols
             ]

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -131,11 +131,15 @@ Alias = namedtuple(
         "row_number",
     ),
 )
+
+# Avoid same naming. `echo spark-rapids-ml | base64` = c3BhcmstcmFwaWRzLW1sCg==
+col_name_unique_tag = "c3BhcmstcmFwaWRzLW1sCg=="
+
 alias = Alias(
-    "vector_type_c3BhcmstcmFwaWRzLW1sCg==",
-    "vector_size_c3BhcmstcmFwaWRzLW1sCg==",
-    "vector_indices_c3BhcmstcmFwaWRzLW1sCg==",
-    "cuml_values_c3BhcmstcmFwaWRzLW1sCg==",
+    f"vector_type_{col_name_unique_tag}",
+    f"vector_size_{col_name_unique_tag}",
+    f"vector_indices_{col_name_unique_tag}",
+    f"cuml_values_{col_name_unique_tag}",
     "cuml_label",
     "unique_id",
 )
@@ -1250,7 +1254,6 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                         select_cols.append(col_name)
                         tmp_cols.append(col_name)
                 else:
-                    # Avoid same naming. `echo spark-rapids-ml | base64` = c3BhcmstcmFwaWRzLW1sCg==
                     dataset = dataset.withColumn(
                         alias.data,
                         vector_to_array(col(input_col), vector_element_type),
@@ -1295,7 +1298,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                     or isinstance(col_type, DoubleType)
                 ):
                     if not isinstance(col_type, feature_type):
-                        tmp_input_col = f"{c}_c3BhcmstcmFwaWRzLW1sCg=="
+                        tmp_input_col = f"{c}_{col_name_unique_tag}"
                         select_cols.append(tmp_input_col)
                         tmp_cols.append(tmp_input_col)
                     else:
@@ -1305,7 +1308,7 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                         "All columns must be integral types or float/double types."
                     )
 
-            taglen = len("_c3BhcmstcmFwaWRzLW1sCg==")
+            taglen = len(col_name_unique_tag)
             added_tmp_cols = [
                 col(c[:-taglen]).cast(feature_type()).alias(c) for c in tmp_cols
             ]
@@ -1581,8 +1584,7 @@ class _CumlModelWithColumns(_CumlModel):
 
             return dataset.withColumn(pred_name, pred_col).drop(*tmp_cols)
         else:
-            # Avoid same naming. `echo sparkcuml | base64` = c3BhcmtjdW1sCg==
-            pred_struct_col_name = "_prediction_struct_c3BhcmtjdW1sCg=="
+            pred_struct_col_name = f"_prediction_struct_{col_name_unique_tag}"
             dataset = dataset.withColumn(pred_struct_col_name, pred_col)
 
             # 1. Add prediction in the base class

--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -291,3 +291,27 @@ def test_ivfflat(
 
         assert knn_est._cuml_params["metric"] == combo[3]
         assert knn_model._cuml_params["metric"] == combo[3]
+
+
+@pytest.mark.parametrize(
+    "combo",
+    [
+        ("array", 2000, {"nlist": 10, "nprobe": 2}, "sqeuclidean"),
+        ("vector", 5000, {"nlist": 20, "nprobe": 4}, "l2"),
+        ("multi_cols", 2000, {"nlist": 10, "nprobe": 2}, "inner_product"),
+    ],
+)
+@pytest.mark.parametrize("data_shape", [(4000, 3000)], ids=idfn)
+@pytest.mark.parametrize("data_type", [np.float32])
+@pytest.mark.slow
+def test_ivfflat_wide_matrix(
+    combo: Tuple[str, int, Optional[Dict[str, Any]], str],
+    data_shape: Tuple[int, int],
+    data_type: np.dtype,
+) -> None:
+    import time
+
+    start = time.time()
+    test_ivfflat(combo=combo, data_shape=data_shape, data_type=data_type)
+    duration_sec = time.time() - start
+    assert duration_sec < 10 * 60


### PR DESCRIPTION
When withColumn is used inside a for loop to add new columns iteratively, it gets slower as the number of columns in the dataframe increases. 