### PR TITLE
Fix nightly test failure by specifying the absolute tolerance 

### DIFF
--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -280,7 +280,7 @@ def test_ivfflat(
                 if i1 != i2:
                     query_vec = X[r1[f"query_{id_col}"]]
                     assert cal_dist(query_vec, X[i1], metric) == pytest.approx(
-                        cal_dist(query_vec, X[i2], metric)
+                        cal_dist(query_vec, X[i2], metric), abs=tolerance
                     )
 
         assert len(reconstructed_collect) == len(knn_df_collect)


### PR DESCRIPTION
default relative tolerance 1.0e-6 is too small for small values. e.g.: 

Obtained: 0.05323904405853512
Expected: 0.053238988191376575 ± 5.3e-08

