### PR TITLE
Increase tolerance for testing ivfpq due to quantization and randomness

### DIFF
--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -332,7 +332,7 @@ def test_ann_algorithm(
             if algorithm == "ivfpq":
                 # returned distances can be slightly different when running ivfpq multiple times due to quantization and randomness
                 assert array_equal(
-                    r1_distances, r2_distances, unit_tol=tolerance, total_tol=tolerance
+                    r1_distances, r2_distances, unit_tol=tolerance, total_tol=1e-3
                 )
             else:
                 assert array_equal(r1_distances, r2_distances, tolerance)

--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -329,7 +329,13 @@ def test_ann_algorithm(
             assert r1[f"query_{id_col}"] == r2[f"query_{id_col}"]
             r1_distances = r1["distances"]
             r2_distances = r2["distances"]
-            assert array_equal(r1_distances, r2_distances, tolerance)
+            if algorithm == "ivfpq":
+                # returned distances can be slightly different when running ivfpq multiple times due to quantization and randomness
+                assert array_equal(
+                    r1_distances, r2_distances, unit_tol=tolerance, total_tol=tolerance
+                )
+            else:
+                assert array_equal(r1_distances, r2_distances, tolerance)
 
             assert len(r1["indices"]) == len(r2["indices"])
             assert len(r1["indices"]) == n_neighbors
@@ -433,7 +439,7 @@ def test_ivfpq(
     combo = (algorithm, feature_type, max_records_per_batch, algo_params, metric)
     expected_avg_recall = 0.1
     distances_are_exact = False
-    tolerance = 1e-3
+    tolerance = 2e-3  # tolerance increased to be more stable due to quantization and randomness in ivfpq
 
     test_ann_algorithm(
         combo=combo,

--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -439,7 +439,7 @@ def test_ivfpq(
     combo = (algorithm, feature_type, max_records_per_batch, algo_params, metric)
     expected_avg_recall = 0.1
     distances_are_exact = False
-    tolerance = 2e-3  # tolerance increased to be more stable due to quantization and randomness in ivfpq
+    tolerance = 5e-3  # tolerance increased to be more stable due to quantization and randomness in ivfpq
 
     test_ann_algorithm(
         combo=combo,


### PR DESCRIPTION
The test case occasionally fails, at asserting the returned distances are equal when running kneighbors and approxSimilarityJoin. 
In fact, this may not be the case for ivfpq because returned distances seem sensitive to codebook and randomness. 