### PR TITLE
Fix bug: add default value to computer region of GCS Benchmark test [skip ci]

### DIFF
--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -24,7 +24,7 @@ on:
         description: 'COMPUTER REGION'
   schedule:
     # - cron: "0 13 * * 1"  
-    - cron: "*/5 * * * *"  
+    - cron: "* * * * *"  
 
 jobs:
   Benchmark:

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   Benchmark:
-    if: github.repository == 'NVIDIA/spark-rapids-ml'
+    if: github.repository == 'YanxuanLiu/spark-rapids-ml'
     runs-on: ubuntu-latest
     env:
       PROJECT: rapids-spark

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -23,7 +23,8 @@ on:
         default: 'us-central1'
         description: 'COMPUTER REGION'
   schedule:
-    - cron: "0 13 * * 1"    
+    # - cron: "0 13 * * 1"  
+    - cron: "*/10 * * * *"  
 
 jobs:
   Benchmark:

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -23,12 +23,11 @@ on:
         default: 'us-central1'
         description: 'COMPUTER REGION'
   schedule:
-    # - cron: "0 13 * * 1"  
-    - cron: "* * * * *"  
+    - cron: "0 13 * * 1"  
 
 jobs:
   Benchmark:
-    if: github.repository == 'YanxuanLiu/spark-rapids-ml'
+    if: github.repository == 'NVIDIA/spark-rapids-ml'
     runs-on: ubuntu-latest
     env:
       PROJECT: rapids-spark

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -23,7 +23,7 @@ on:
         default: 'us-central1'
         description: 'COMPUTER REGION'
   schedule:
-    - cron: "0 13 * * 1"  
+    - cron: "0 13 * * 1"    
 
 jobs:
   Benchmark:

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -24,7 +24,7 @@ on:
         description: 'COMPUTER REGION'
   schedule:
     # - cron: "0 13 * * 1"  
-    - cron: "*/10 * * * *"  
+    - cron: "*/5 * * * *"  
 
 jobs:
   Benchmark:

--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -32,7 +32,7 @@ jobs:
     env:
       PROJECT: rapids-spark
       DATAPROC_REGION: us-central1
-      COMPUTE_REGION: ${{inputs.computer_region}}
+      COMPUTE_REGION: ${{ inputs.computer_region || 'us-central1' }}
       COMPUTE_ZONE: us-central1-a
       GCS_BUCKET: spark-rapids-ml-benchmarking
       KEY_FILE_CONTENT: ${{ secrets.GCLOUD_PRIVATE_KEY }}


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids-ml/issues/719

Add a default value 'us-central1' to `COMPUTER_REGION`

test build: https://github.com/YanxuanLiu/spark-rapids-ml/actions/runs/10557503255/job/29245140616