### PR TITLE
[auto-merge] branch-24.08 to branch-24.10 [skip ci] [bot]

### DIFF
--- a/.github/workflows/gcs-benchmark.yml
+++ b/.github/workflows/gcs-benchmark.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ jobs:
     env:
       PROJECT: rapids-spark
       DATAPROC_REGION: us-central1
-      COMPUTE_REGION: ${{inputs.computer_region}}
+      COMPUTE_REGION: ${{ inputs.computer_region || 'us-central1' }}
       COMPUTE_ZONE: us-central1-a
       GCS_BUCKET: spark-rapids-ml-benchmarking
       KEY_FILE_CONTENT: ${{ secrets.GCLOUD_PRIVATE_KEY }}


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-24.08` to create a PR keeping `branch-24.10` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.