### PR TITLE
Fix cuml parameter setting issues in UMAP/DBSCAN

### DIFF
--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -836,7 +836,7 @@ class DBSCAN(DBSCANClass, _CumlEstimator, _DBSCANCumlParams):
 
         model._num_workers = self.num_workers
         self._copyValues(model)
-        self._copy_cuml_params(model)
+        self._copy_cuml_params(model)  # type: ignore
 
         return model
 

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -502,7 +502,14 @@ class KMeansModel(KMeansClass, _CumlModelWithPredictionCol, _KMeansCumlParams):
 class DBSCANClass(_CumlClass):
     @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
-        return {}
+        return {
+            "eps": "eps",
+            "min_samples": "min_samples",
+            "metric": "metric",
+            "algorithm": "algorithm",
+            "max_mbytes_per_batch": "max_mbytes_per_batch",
+            "calc_core_sample_indices": "calc_core_sample_indices",
+        }
 
     def _get_cuml_params_default(self) -> Dict[str, Any]:
         return {
@@ -829,6 +836,7 @@ class DBSCAN(DBSCANClass, _CumlEstimator, _DBSCANCumlParams):
 
         model._num_workers = self.num_workers
         self._copyValues(model)
+        self._copy_cuml_params(model)
 
         return model
 
@@ -970,13 +978,7 @@ class DBSCANModel(
             dbscan = CumlDBSCANMG(
                 handle=params[param_alias.handle],
                 output_type="cudf",
-                eps=self.getOrDefault("eps"),
-                min_samples=self.getOrDefault("min_samples"),
-                metric=self.getOrDefault("metric"),
-                algorithm=self.getOrDefault("algorithm"),
-                max_mbytes_per_batch=self.getOrDefault("max_mbytes_per_batch"),
-                calc_core_sample_indices=self.getOrDefault("calc_core_sample_indices"),
-                verbose=self.verbose,
+                **params[param_alias.cuml_init],
             )
             dbscan.n_cols = params[param_alias.num_cols]
             dbscan.dtype = np.dtype(dtype)

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -145,6 +145,9 @@ class _CumlClass(object):
         - empty string, if a defined Spark Param should just be silently ignored, or
         - None, if a defined Spark Param should raise an error.
 
+        If the class has no Spark ML equivalent, the cuML parameter names should be mapped to themselves,
+        i.e., `{"cuml_param": "cuml_param"}`.
+
         Note: standard Spark column Params, e.g. inputCol, featureCol, etc, should not be listed
         in this mapping, since they are handled differently.
 

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -90,7 +90,25 @@ if TYPE_CHECKING:
 class UMAPClass(_CumlClass):
     @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
-        return {}
+        return {
+            "n_neighbors": "n_neighbors",
+            "n_components": "n_components",
+            "metric": "metric",
+            "n_epochs": "n_epochs",
+            "learning_rate": "learning_rate",
+            "init": "init",
+            "min_dist": "min_dist",
+            "spread": "spread",
+            "set_op_mix_ratio": "set_op_mix_ratio",
+            "local_connectivity": "local_connectivity",
+            "repulsion_strength": "repulsion_strength",
+            "negative_sample_rate": "negative_sample_rate",
+            "transform_queue_size": "transform_queue_size",
+            "a": "a",
+            "b": "b",
+            "precomputed_knn": "precomputed_knn",
+            "random_state": "random_state",
+        }
 
     def _get_cuml_params_default(self) -> Dict[str, Any]:
         return {
@@ -171,9 +189,8 @@ class _UMAPCumlParams(
         "metric",
         (
             f"Distance metric to use. Supported distances are ['l1', 'cityblock', 'taxicab', 'manhattan', 'euclidean', 'l2',"
-            f" 'sqeuclidean', 'canberra', 'minkowski', 'chebyshev', 'linf', 'cosine', 'correlation', 'hellinger', 'hamming',"
-            f" 'jaccard']. Metrics that take arguments (such as minkowski) can have arguments passed via the metric_kwds"
-            f" dictionary."
+            f" 'sqeuclidean', 'canberra', 'chebyshev', 'linf', 'cosine', 'correlation', 'hellinger', 'hamming', 'jaccard']."
+            f" Metrics that take arguments via the metric_kwds dictionary are not supported."
         ),
         typeConverter=TypeConverters.toString,
     )
@@ -340,7 +357,7 @@ class _UMAPCumlParams(
         typeConverter=TypeConverters.toFloat,
     )
 
-    def getNNeighbors(self) -> float:
+    def getNNeighbors(self: P) -> float:
         """
         Gets the value of `n_neighbors`.
         """
@@ -352,7 +369,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(n_neighbors=value)
 
-    def getNComponents(self) -> int:
+    def getNComponents(self: P) -> int:
         """
         Gets the value of `n_components`.
         """
@@ -364,7 +381,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(n_components=value)
 
-    def getMetric(self) -> str:
+    def getMetric(self: P) -> str:
         """
         Gets the value of `metric`.
         """
@@ -376,7 +393,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(metric=value)
 
-    def getNEpochs(self) -> int:
+    def getNEpochs(self: P) -> int:
         """
         Gets the value of `n_epochs`.
         """
@@ -388,7 +405,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(n_epochs=value)
 
-    def getLearningRate(self) -> float:
+    def getLearningRate(self: P) -> float:
         """
         Gets the value of `learning_rate`.
         """
@@ -400,7 +417,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(learning_rate=value)
 
-    def getInit(self) -> str:
+    def getInit(self: P) -> str:
         """
         Gets the value of `init`.
         """
@@ -412,7 +429,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(init=value)
 
-    def getMinDist(self) -> float:
+    def getMinDist(self: P) -> float:
         """
         Gets the value of `min_dist`.
         """
@@ -424,7 +441,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(min_dist=value)
 
-    def getSpread(self) -> float:
+    def getSpread(self: P) -> float:
         """
         Gets the value of `spread`.
         """
@@ -436,7 +453,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(spread=value)
 
-    def getSetOpMixRatio(self) -> float:
+    def getSetOpMixRatio(self: P) -> float:
         """
         Gets the value of `set_op_mix_ratio`.
         """
@@ -448,7 +465,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(set_op_mix_ratio=value)
 
-    def getLocalConnectivity(self) -> float:
+    def getLocalConnectivity(self: P) -> float:
         """
         Gets the value of `local_connectivity`.
         """
@@ -460,7 +477,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(local_connectivity=value)
 
-    def getRepulsionStrength(self) -> float:
+    def getRepulsionStrength(self: P) -> float:
         """
         Gets the value of `repulsion_strength`.
         """
@@ -472,7 +489,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(repulsion_strength=value)
 
-    def getNegativeSampleRate(self) -> int:
+    def getNegativeSampleRate(self: P) -> int:
         """
         Gets the value of `negative_sample_rate`.
         """
@@ -484,7 +501,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(negative_sample_rate=value)
 
-    def getTransformQueueSize(self) -> float:
+    def getTransformQueueSize(self: P) -> float:
         """
         Gets the value of `transform_queue_size`.
         """
@@ -496,7 +513,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(transform_queue_size=value)
 
-    def getA(self) -> float:
+    def getA(self: P) -> float:
         """
         Gets the value of `a`.
         """
@@ -508,7 +525,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(a=value)
 
-    def getB(self) -> float:
+    def getB(self: P) -> float:
         """
         Gets the value of `b`.
         """
@@ -520,7 +537,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(b=value)
 
-    def getPrecomputedKNN(self) -> List[List[float]]:
+    def getPrecomputedKNN(self: P) -> List[List[float]]:
         """
         Gets the value of `precomputed_knn`.
         """
@@ -532,7 +549,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(precomputed_knn=value)
 
-    def getRandomState(self) -> int:
+    def getRandomState(self: P) -> int:
         """
         Gets the value of `random_state`.
         """
@@ -544,7 +561,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(random_state=value)
 
-    def getSampleFraction(self) -> float:
+    def getSampleFraction(self: P) -> float:
         """
         Gets the value of `sample_fraction`.
         """
@@ -556,7 +573,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(sample_fraction=value)
 
-    def getFeaturesCol(self) -> Union[str, List[str]]:  # type: ignore
+    def getFeaturesCol(self: P) -> Union[str, List[str]]:  # type: ignore
         """
         Gets the value of :py:attr:`featuresCol` or :py:attr:`featuresCols`
         """
@@ -590,7 +607,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(labelCol=value)
 
-    def getOutputCol(self) -> str:
+    def getOutputCol(self: P) -> str:
         """
         Gets the value of :py:attr:`outputCol`. Contains the embeddings of the input data.
         """

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -573,7 +573,7 @@ class _UMAPCumlParams(
         """
         return self._set_params(sample_fraction=value)
 
-    def getFeaturesCol(self: P) -> Union[str, List[str]]:  # type: ignore
+    def getFeaturesCol(self) -> Union[str, List[str]]:  # type: ignore
         """
         Gets the value of :py:attr:`featuresCol` or :py:attr:`featuresCols`
         """

--- a/python/tests/test_dbscan.py
+++ b/python/tests/test_dbscan.py
@@ -56,15 +56,17 @@ def test_default_cuml_params() -> None:
 
 
 @pytest.mark.parametrize("default_params", [True, False])
-def test_params(gpu_number: int, default_params: bool, tmp_path: str, caplog: LogCaptureFixture) -> None:
+def test_params(
+    gpu_number: int, default_params: bool, tmp_path: str, caplog: LogCaptureFixture
+) -> None:
     from cuml import DBSCAN as cumlDBSCAN
-    
+
     cuml_params = get_default_cuml_parameters(
         [cumlDBSCAN],
         [
             "handle",
             "output_type",
-        ]
+        ],
     )
 
     if default_params:

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -31,8 +31,8 @@ from .sparksession import CleanSparkSession
 from .utils import (
     assert_params,
     create_pyspark_dataframe,
-    get_default_cuml_parameters,
     cuml_supported_data_types,
+    get_default_cuml_parameters,
     pyspark_supported_feature_types,
 )
 
@@ -257,7 +257,7 @@ def test_params(tmp_path: str, default_params: bool) -> None:
             "target_metric",
             "target_n_neighbors",
             "target_weight",
-        ]
+        ],
     )
 
     if default_params:

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -31,6 +31,7 @@ from .sparksession import CleanSparkSession
 from .utils import (
     assert_params,
     create_pyspark_dataframe,
+    get_default_cuml_parameters,
     cuml_supported_data_types,
     pyspark_supported_feature_types,
 )
@@ -239,37 +240,44 @@ def test_spark_umap_fast(
     assert umap_float32._float32_inputs
 
 
-def test_params(tmp_path: str) -> None:
-    # Default constructor
-    default_cuml_params = {
-        "n_neighbors": 15,
-        "n_components": 2,
-        "metric": "euclidean",
-        "n_epochs": None,
-        "learning_rate": 1.0,
-        "init": "spectral",
-        "min_dist": 0.1,
-        "spread": 1.0,
-        "set_op_mix_ratio": 1.0,
-        "local_connectivity": 1.0,
-        "repulsion_strength": 1.0,
-        "negative_sample_rate": 5,
-        "transform_queue_size": 4.0,
-        "a": None,
-        "b": None,
-        "precomputed_knn": None,
-        "random_state": None,
-        "verbose": False,
-    }
-    default_umap = UMAP()
-    assert_params(default_umap, {}, default_cuml_params)
+@pytest.mark.parametrize("default_params", [True, False])
+def test_params(tmp_path: str, default_params: bool) -> None:
+    from cuml import UMAP as cumlUMAP
+
+    cuml_params = get_default_cuml_parameters(
+        [cumlUMAP],
+        [
+            "build_algo",
+            "build_kwds",
+            "callback",
+            "handle",
+            "hash_input",
+            "metric_kwds",
+            "output_type",
+            "target_metric",
+            "target_n_neighbors",
+            "target_weight",
+        ]
+    )
+
+    if default_params:
+        umap = UMAP()
+    else:
+        cuml_params["n_neighbors"] = 12
+        cuml_params["learning_rate"] = 0.9
+        cuml_params["random_state"] = 42
+        umap = UMAP(n_neighbors=12, learning_rate=0.9, random_state=42)
+
+    assert_params(umap, {}, cuml_params)
+    assert umap.cuml_params == cuml_params
 
     # Estimator persistence
     path = tmp_path + "/umap_tests"
     estimator_path = f"{path}/umap"
-    default_umap.write().overwrite().save(estimator_path)
+    umap.write().overwrite().save(estimator_path)
     loaded_umap = UMAP.load(estimator_path)
-    assert_params(loaded_umap, {}, default_cuml_params)
+    assert_params(loaded_umap, {}, cuml_params)
+    assert umap.cuml_params == cuml_params
     assert loaded_umap._float32_inputs
 
     # setter/getter
@@ -371,6 +379,7 @@ def test_umap_sample_fraction(gpu_number: int) -> None:
 
     n_rows = 5000
     sample_fraction = 0.5
+    random_state = 42
 
     X, _ = make_blobs(
         n_rows,
@@ -385,15 +394,16 @@ def test_umap_sample_fraction(gpu_number: int) -> None:
         pyspark_type = "float"
         feature_cols = [f"c{i}" for i in range(X.shape[1])]
         schema = [f"{c} {pyspark_type}" for c in feature_cols]
-        df = spark.createDataFrame(X.tolist(), ",".join(schema))
+        df = spark.createDataFrame(X.tolist(), ",".join(schema)).coalesce(1)
         df = df.withColumn("features", array(*feature_cols)).drop(*feature_cols)
 
         umap = (
-            UMAP(num_workers=gpu_number, random_state=42)
+            UMAP(num_workers=gpu_number, random_state=random_state)
             .setFeaturesCol("features")
             .setSampleFraction(sample_fraction)
         )
         assert umap.getSampleFraction() == sample_fraction
+        assert umap.getRandomState() == random_state
 
         umap_model = umap.fit(df)
 
@@ -404,6 +414,7 @@ def test_umap_sample_fraction(gpu_number: int) -> None:
             threshold = 2 * np.sqrt(
                 n_rows * sample_fraction * (1 - sample_fraction)
             )  # 2 std devs
+
             assert np.abs(n_rows * sample_fraction - embedding.shape[0]) <= threshold
             assert np.abs(n_rows * sample_fraction - raw_data.shape[0]) <= threshold
             assert model.dtype == "float32"


### PR DESCRIPTION
Fixed an issue where cuml parameters in UMAP were not being set due to a silent failure in `_set_param`, where these parameters could not be found in the `_param_mapping`. Mapping these params to themselves fixes this issue, as it is [done in KNN](https://github.com/NVIDIA/spark-rapids-ml/blob/branch-24.10/python/src/spark_rapids_ml/knn.py#L790). 

DBSCAN had the same issue where cuml parameters were never set, but got away with this by [using the Spark API to retrieve parameters](https://github.com/NVIDIA/spark-rapids-ml/blob/branch-24.10/python/src/spark_rapids_ml/clustering.py#L970) and avoiding the use of `cuml_params` dict entirely. 

## Changes:
- Updated both DBSCAN and UMAP to include identity mappings for cuml parameters in `_param_mapping`.
- Updated DBSCAN to use the `cuml_params` dictionary for initialization to be consistent with the other algorithms.
- Updated the `_param_mapping` description to avoid future confusion for cuml algorithms without a PySpark equivalent.
- Added tests for DBSCAN and UMAP to check that cuml parameters are properly set using both the Spark param API and the `cuml_params` attribute, and test under non-default cuml parameter settings. 

This PR also resolves Issue #749, as `random_state` is now properly set, making dataframe sampling deterministic. 