### PR TITLE
Spawn multiple pytest workers to speedup CI

### DIFF
--- a/python/requirements_dev.txt
+++ b/python/requirements_dev.txt
@@ -7,5 +7,6 @@ numpydoc
 pydata-sphinx-theme
 pylint
 pytest
+pytest-xdist
 sphinx<6.0
 twine>=4.0.0

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -20,7 +20,7 @@ spark-rapids-submit --master local[1] tests_no_import_change/test_no_import_chan
 spark-submit --master local[1] tests_no_import_change/test_no_import_change.py 0.2
 
 echo "use --runslow to run all tests"
-pytest "$@" -n 3 benchmark/test_gen_data.py
-PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 3 --durations=10 tests
-#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 3 --durations=10 tests
+pytest "$@" -n 2 benchmark/test_gen_data.py
+PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 2 --durations=10 tests
+#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 2 --durations=10 tests
 #PYTHONPATH=`pwd`/benchmark pytest -ra "$@" --durations=10 tests_large

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -20,7 +20,7 @@ spark-rapids-submit --master local[1] tests_no_import_change/test_no_import_chan
 spark-submit --master local[1] tests_no_import_change/test_no_import_change.py 0.2
 
 echo "use --runslow to run all tests"
-pytest "$@" -n 8 benchmark/test_gen_data.py
-PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 8 --durations=10 tests
-#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 8 --durations=10 tests
+pytest "$@" -n 3 benchmark/test_gen_data.py
+PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 3 --durations=10 tests
+#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 3 --durations=10 tests
 #PYTHONPATH=`pwd`/benchmark pytest -ra "$@" --durations=10 tests_large

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -20,7 +20,7 @@ spark-rapids-submit --master local[1] tests_no_import_change/test_no_import_chan
 spark-submit --master local[1] tests_no_import_change/test_no_import_change.py 0.2
 
 echo "use --runslow to run all tests"
-pytest "$@" -n 4 benchmark/test_gen_data.py
-PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 4 --durations=10 tests
-#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 4 --durations=10 tests
+pytest "$@" -n 8 benchmark/test_gen_data.py
+PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 8 --durations=10 tests
+#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 8 --durations=10 tests
 #PYTHONPATH=`pwd`/benchmark pytest -ra "$@" --durations=10 tests_large

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -19,8 +19,26 @@ spark-rapids-submit --master local[1] tests_no_import_change/test_no_import_chan
 # runs on cpu with spark-submit
 spark-submit --master local[1] tests_no_import_change/test_no_import_change.py 0.2
 
+
+# calculate pytest parallelism by following https://github.com/NVIDIA/spark-rapids/blob/branch-24.12/integration_tests/run_pyspark_from_build.sh
+MAX_PARALLEL=3
+NVIDIA_SMI_ARGS="" 
+if [ ${CUDA_VISIBLE_DEVICES} ]; then
+        NVIDIA_SMI_ARGS="${NVIDIA_SMI_ARGS} -i ${CUDA_VISIBLE_DEVICES}" 
+fi
+GPU_MEM_PARALLEL=`nvidia-smi ${NVIDIA_SMI_ARGS} --query-gpu=memory.free --format=csv,noheader | awk 'NR == 1 { MIN = $1 } { if ($1 < MIN) { MIN = $1 } } END { print int((MIN - 2 * 1024) / ((3 * 1024) + 750)) }'`
+CPU_CORES=`nproc`
+TMP_PARALLEL=$(( $GPU_MEM_PARALLEL > $CPU_CORES ? $CPU_CORES : $GPU_MEM_PARALLEL ))
+TMP_PARALLEL=$(( $TMP_PARALLEL > $MAX_PARALLEL ? $MAX_PARALLEL : $TMP_PARALLEL ))
+if  (( $TMP_PARALLEL <= 1 )); then
+        TEST_PARALLEL=1
+    else
+        TEST_PARALLEL=$TMP_PARALLEL
+fi
+echo "Test functions in benchmark/test_gen_data.py and tests/ directory will be executed in parallel with ${TEST_PARALLEL} pytest workers" 
+
 echo "use --runslow to run all tests"
-pytest "$@" -n 3 benchmark/test_gen_data.py
-PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 3 --durations=10 tests
-#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 3 --durations=10 tests
+pytest "$@" -n ${MAX_PARALLEL} benchmark/test_gen_data.py
+PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n ${MAX_PARALLEL} --durations=10 tests
+#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n ${MAX_PARALLEL} --durations=10 tests
 #PYTHONPATH=`pwd`/benchmark pytest -ra "$@" --durations=10 tests_large

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -20,7 +20,7 @@ spark-rapids-submit --master local[1] tests_no_import_change/test_no_import_chan
 spark-submit --master local[1] tests_no_import_change/test_no_import_change.py 0.2
 
 echo "use --runslow to run all tests"
-pytest "$@" benchmark/test_gen_data.py
-PYTHONPATH=`pwd`/benchmark pytest -ra "$@" --durations=10 tests
-#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow --durations=10 tests
+pytest "$@" -n 4 benchmark/test_gen_data.py
+PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 4 --durations=10 tests
+#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 4 --durations=10 tests
 #PYTHONPATH=`pwd`/benchmark pytest -ra "$@" --durations=10 tests_large

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -19,26 +19,8 @@ spark-rapids-submit --master local[1] tests_no_import_change/test_no_import_chan
 # runs on cpu with spark-submit
 spark-submit --master local[1] tests_no_import_change/test_no_import_change.py 0.2
 
-# calculate pytest parallelism by following https://github.com/NVIDIA/spark-rapids/blob/branch-24.12/integration_tests/run_pyspark_from_build.sh
-NVIDIA_SMI_ARGS="" 
-if [ ${CUDA_VISIBLE_DEVICES} ]; then
-    NVIDIA_SMI_ARGS="${NVIDIA_SMI_ARGS} -i ${CUDA_VISIBLE_DEVICES}" 
-fi
-GPU_MEM_PARALLEL=`nvidia-smi ${NVIDIA_SMI_ARGS} --query-gpu=memory.free --format=csv,noheader | awk 'NR == 1 { MIN = $1 } { if ($1 < MIN) { MIN = $1 } } END { print int((MIN - 2 * 1024) / ((1.5 * 1024) + 750)) }'`
-CPU_CORES=`nproc`
-HOST_MEM_PARALLEL=`cat /proc/meminfo | grep MemAvailable | awk '{print int($2 / (8 * 1024 * 1024))}'`
-TMP_PARALLEL=$(( $GPU_MEM_PARALLEL > $CPU_CORES ? $CPU_CORES : $GPU_MEM_PARALLEL ))
-TMP_PARALLEL=$(( $TMP_PARALLEL > $HOST_MEM_PARALLEL ? $HOST_MEM_PARALLEL : $TMP_PARALLEL ))
-TEST_PARALLEL=${TMP_PARALLEL}
-if  (( $TMP_PARALLEL <= 1 )); then
-    TEST_PARALLEL=1
-else
-TEST_PARALLEL=$TMP_PARALLEL
-fi
-echo "Test functions in benchmark/test_gen_data.py and tests/ directory will be executed in parallel with ${TEST_PARALLEL} pytest workers"
-
 echo "use --runslow to run all tests"
-pytest "$@" -n ${TEST_PARALLEL} benchmark/test_gen_data.py
-PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n ${TEST_PARALLEL} --durations=10 tests
-#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n ${TEST_PARALLEL} --durations=10 tests
+pytest "$@" -n 3 benchmark/test_gen_data.py
+PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n 3 --durations=10 tests
+#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n 3 --durations=10 tests
 #PYTHONPATH=`pwd`/benchmark pytest -ra "$@" --durations=10 tests_large

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -19,14 +19,19 @@ spark-rapids-submit --master local[1] tests_no_import_change/test_no_import_chan
 # runs on cpu with spark-submit
 spark-submit --master local[1] tests_no_import_change/test_no_import_change.py 0.2
 
-# calculate pytest parallelism following https://github.com/NVIDIA/spark-rapids/blob/branch-24.12/integration_tests/run_pyspark_from_build.sh
-GPU_MEM_PARALLEL=`nvidia-smi --query-gpu=memory.free --format=csv,noheader | awk '{if (MAX < $1){ MAX = $1}} END {print int((MAX - 2 * 1024) / ((1.5 * 1024) + 750))}'`
+# calculate pytest parallelism by following https://github.com/NVIDIA/spark-rapids/blob/branch-24.12/integration_tests/run_pyspark_from_build.sh
+GPU_MEM_PARALLEL=`nvidia-smi --query-gpu=memory.free --format=csv,noheader | awk 'NR == 1 { MIN = $1 } { if ($1 < MIN) { MIN = $1 } } END { print int((MIN - 2 * 1024) / ((1.5 * 1024) + 750)) }'`
 CPU_CORES=`nproc`
 HOST_MEM_PARALLEL=`cat /proc/meminfo | grep MemAvailable | awk '{print int($2 / (8 * 1024 * 1024))}'`
 TMP_PARALLEL=$(( $GPU_MEM_PARALLEL > $CPU_CORES ? $CPU_CORES : $GPU_MEM_PARALLEL ))
 TMP_PARALLEL=$(( $TMP_PARALLEL > $HOST_MEM_PARALLEL ? $HOST_MEM_PARALLEL : $TMP_PARALLEL ))
 TEST_PARALLEL=${TMP_PARALLEL}
-echo "${TEST_PARALLEL} pytest workers will be used to execute test functions in benchmark/test_gen_data.py and tests/ directory in parallel"
+if  (( $TMP_PARALLEL <= 1 )); then
+    TEST_PARALLEL=1
+else
+TEST_PARALLEL=$TMP_PARALLEL
+fi
+echo "Test functions in benchmark/test_gen_data.py and tests/ directory will be executed in parallel with ${TEST_PARALLEL} pytest workers"
 
 echo "use --runslow to run all tests"
 pytest "$@" -n ${TEST_PARALLEL} benchmark/test_gen_data.py

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -38,7 +38,7 @@ fi
 echo "Test functions in benchmark/test_gen_data.py and tests/ directory will be executed in parallel with ${TEST_PARALLEL} pytest workers" 
 
 echo "use --runslow to run all tests"
-pytest "$@" -n ${MAX_PARALLEL} benchmark/test_gen_data.py
-PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n ${MAX_PARALLEL} --durations=10 tests
-#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n ${MAX_PARALLEL} --durations=10 tests
+pytest "$@" -n ${TEST_PARALLEL} benchmark/test_gen_data.py
+PYTHONPATH=`pwd`/benchmark pytest -ra "$@" -n ${TEST_PARALLEL} --durations=10 tests
+#PYTHONPATH=`pwd`/benchmark pytest -ra --runslow -n ${TEST_PARALLEL} --durations=10 tests
 #PYTHONPATH=`pwd`/benchmark pytest -ra "$@" --durations=10 tests_large

--- a/python/run_test.sh
+++ b/python/run_test.sh
@@ -20,7 +20,11 @@ spark-rapids-submit --master local[1] tests_no_import_change/test_no_import_chan
 spark-submit --master local[1] tests_no_import_change/test_no_import_change.py 0.2
 
 # calculate pytest parallelism by following https://github.com/NVIDIA/spark-rapids/blob/branch-24.12/integration_tests/run_pyspark_from_build.sh
-GPU_MEM_PARALLEL=`nvidia-smi --query-gpu=memory.free --format=csv,noheader | awk 'NR == 1 { MIN = $1 } { if ($1 < MIN) { MIN = $1 } } END { print int((MIN - 2 * 1024) / ((1.5 * 1024) + 750)) }'`
+NVIDIA_SMI_ARGS="" 
+if [ ${CUDA_VISIBLE_DEVICES} ]; then
+    NVIDIA_SMI_ARGS="${NVIDIA_SMI_ARGS} -i ${CUDA_VISIBLE_DEVICES}" 
+fi
+GPU_MEM_PARALLEL=`nvidia-smi ${NVIDIA_SMI_ARGS} --query-gpu=memory.free --format=csv,noheader | awk 'NR == 1 { MIN = $1 } { if ($1 < MIN) { MIN = $1 } } END { print int((MIN - 2 * 1024) / ((1.5 * 1024) + 750)) }'`
 CPU_CORES=`nproc`
 HOST_MEM_PARALLEL=`cat /proc/meminfo | grep MemAvailable | awk '{print int($2 / (8 * 1024 * 1024))}'`
 TMP_PARALLEL=$(( $GPU_MEM_PARALLEL > $CPU_CORES ? $CPU_CORES : $GPU_MEM_PARALLEL ))


### PR DESCRIPTION
with pytest -n 4 on a V100 32GB GPU,
run_tests.sh got passed in 20 mins.
run_tests.sh --runslow got passed in 40 mins.
peak CPU memory usage was around 2GB.
