### PR TITLE
Extend cuML parameter testing and cleanup

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -342,31 +342,31 @@ class RandomForestClassifier(
     Parameters
     ----------
 
-    featuresCol: str or List[str]
+    featuresCol: str or List[str] (default = "features")
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.
-    labelCol:
+    labelCol: str (default = "label")
         The label column name.
-    predictionCol:
+    predictionCol: str (default = "prediction")
         The prediction column name.
-    probabilityCol:
+    probabilityCol: str (default = "probability")
         The column name for predicted class conditional probabilities.
-    rawPredictionCol:
+    rawPredictionCol: str (default = "rawPrediction")
         The column name for class raw predictions - this is currently set equal to probabilityCol values.
-    maxDepth:
+    maxDepth: int (default = 5)
         Maximum tree depth. Must be greater than 0.
-    maxBins:
+    maxBins: int (default = 32)
         Maximum number of bins used by the split algorithm per feature.
-    minInstancesPerNode:
+    minInstancesPerNode: int (default = 1)
         The minimum number of samples (rows) in each leaf node.
-    impurity: str = "gini",
+    impurity: str (default = "gini")
         The criterion used to split nodes.\n
             * ``'gini'`` for gini impurity
             * ``'entropy'`` for information gain (entropy)
-    numTrees:
+    numTrees: int (default = 20)
         Total number of trees in the forest.
-    featureSubsetStrategy:
+    featureSubsetStrategy: str (default = "auto")
         Ratio of number of features (columns) to consider per node split.\n
         The supported options:\n
             ``'auto'``:  If numTrees == 1, set to 'all', If numTrees > 1 (forest), set to 'sqrt'\n
@@ -376,9 +376,9 @@ class RandomForestClassifier(
             ``'log2'``: log2(number of features)\n
             ``'n'``: when n is in the range (0, 1.0], use n * number of features. When n
             is in the range (1, number of features), use n features.
-    seed:
+    seed: int (default = None)
         Seed for the random number generator.
-    bootstrap:
+    bootstrap: bool (default = True)
         Control bootstrapping.\n
             * If ``True``, each tree in the forest is built on a bootstrapped
               sample with replacement.
@@ -396,11 +396,11 @@ class RandomForestClassifier(
             * ``4 or False`` - Enables all messages up to and including information messages.
             * ``5 or True`` - Enables all messages up to and including debug messages.
             * ``6`` - Enables all messages up to and including trace messages.
-    n_streams:
+    n_streams: int (default = 1)
         Number of parallel streams used for forest building.
         Please note that there is a bug running spark-rapids-ml on a node with multi-gpus
         when n_streams > 1. See https://github.com/rapidsai/cuml/issues/5402.
-    min_samples_split:
+    min_samples_split: int or float (default = 2)
         The minimum number of samples required to split an internal node.\n
          * If type ``int``, then ``min_samples_split`` represents the minimum
            number.
@@ -408,11 +408,11 @@ class RandomForestClassifier(
            and ``ceil(min_samples_split * n_rows)`` is the minimum number of
            samples for each split.    max_samples:
         Ratio of dataset rows used while fitting each tree.
-    max_leaves:
+    max_leaves: int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited, if -1.
-    min_impurity_decrease:
+    min_impurity_decrease: float (default = 0.0)
         Minimum decrease in impurity required for node to be split.
-    max_batch_size:
+    max_batch_size: int (default = 4096)
         Maximum number of nodes that can be processed in a given batch.
 
     Examples
@@ -838,26 +838,26 @@ class LogisticRegression(
 
     Parameters
     ----------
-    featuresCol: str or List[str]
+    featuresCol: str or List[str] (default = "features")
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.
-    labelCol:
+    labelCol: (default = "label")
         The label column name.
-    predictionCol:
+    predictionCol: (default = "prediction")
         The class prediction column name.
-    probabilityCol:
+    probabilityCol: (default = "probability")
         The probability prediction column name.
-    rawPredictionCol:
+    rawPredictionCol: (default = "rawPrediction")
         The column name for class raw predictions - this is currently set equal to probabilityCol values.
-    maxIter:
+    maxIter: (default = 100)
         The maximum number of iterations of the underlying L-BFGS algorithm.
-    regParam:
+    regParam: (default = 0.0)
         The regularization parameter.
-    elasticNetParam:
+    elasticNetParam: (default = 0.0)
         The ElasticNet mixing parameter, in range [0, 1]. For alpha = 0,
         the penalty is an L2 penalty. For alpha = 1, it is an L1 penalty.
-    tol:
+    tol: (default = 1e-6)
         The convergence tolerance.
     enable_sparse_data_optim: None or boolean, optional (default=None)
         If features column is VectorUDT type, Spark rapids ml relies on this parameter to decide whether to use dense array or sparse array in cuml.
@@ -865,9 +865,9 @@ class LogisticRegression(
         If False, always uses dense array. This is favorable if the majority of VectorUDT vectors are DenseVector.
         If True, always uses sparse array. This is favorable if the majority of the VectorUDT vectors are SparseVector.
         Note this is only supported in spark >= 3.4.
-    fitIntercept:
+    fitIntercept: (default = True)
         Whether to fit an intercept term.
-    standardization:
+    standardization: (default = True)
         Whether to standardize the training data before fit.
     num_workers:
         Number of cuML workers, where each cuML worker corresponds to one Spark task

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -179,17 +179,17 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
 
     Parameters
     ----------
-    k: int (default = 8)
+    k: int (default = 2)
         the number of centers. Set this parameter to enable KMeans to learn k centers from input vectors.
 
     initMode: str (default = "k-means||")
         the algorithm to select initial centroids. It can be "k-means||" or "random".
 
-    maxIter: int (default = 300)
+    maxIter: int (default = 20)
         the maximum iterations the algorithm will run to learn the k centers.
         More iterations help generate more accurate centers.
 
-    seed: int (default = 1)
+    seed: int (default = None)
         the random seed used by the algorithm to initialize a set of k random centers to start with.
 
     tol: float (default = 1e-4)
@@ -502,14 +502,7 @@ class KMeansModel(KMeansClass, _CumlModelWithPredictionCol, _KMeansCumlParams):
 class DBSCANClass(_CumlClass):
     @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
-        return {
-            "eps": "eps",
-            "min_samples": "min_samples",
-            "metric": "metric",
-            "algorithm": "algorithm",
-            "max_mbytes_per_batch": "max_mbytes_per_batch",
-            "calc_core_sample_indices": "calc_core_sample_indices",
-        }
+        return {}
 
     def _get_cuml_params_default(self) -> Dict[str, Any]:
         return {
@@ -519,7 +512,7 @@ class DBSCANClass(_CumlClass):
             "algorithm": "brute",
             "verbose": False,
             "max_mbytes_per_batch": None,
-            "calc_core_sample_indices": False,
+            "calc_core_sample_indices": True,
         }
 
     def _pyspark_class(self) -> Optional[ABCMeta]:
@@ -652,12 +645,12 @@ class DBSCAN(DBSCANClass, _CumlEstimator, _DBSCANCumlParams):
 
     Parameters
     ----------
-    featuresCol: str or List[str]
+    featuresCol: str or List[str] (default = "features")
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.
 
-    predictionCol: str
+    predictionCol: str (default = "prediction")
         the name of the column that stores cluster indices of input vectors. predictionCol should be set when users expect to apply the transform function of a learned model.
 
     num_workers:

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -502,7 +502,9 @@ class KMeansModel(KMeansClass, _CumlModelWithPredictionCol, _KMeansCumlParams):
 class DBSCANClass(_CumlClass):
     @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
-        return {}
+        return {
+            "calc_core_sample_indices": "calc_core_sample_indices",  # we override default to False
+        }
 
     def _get_cuml_params_default(self) -> Dict[str, Any]:
         return {
@@ -528,7 +530,7 @@ class _DBSCANCumlParams(_CumlParams, HasFeaturesCol, HasFeaturesCols, HasIDCol):
             metric="euclidean",
             algorithm="brute",
             max_mbytes_per_batch=None,
-            calc_core_sample_indices=True,
+            calc_core_sample_indices=False,
             idCol=alias.row_number,
         )
 
@@ -765,7 +767,7 @@ class DBSCAN(DBSCANClass, _CumlEstimator, _DBSCANCumlParams):
         metric: str = "euclidean",
         algorithm: str = "brute",
         max_mbytes_per_batch: Optional[int] = None,
-        calc_core_sample_indices: bool = True,
+        calc_core_sample_indices: bool = False,
         verbose: Union[int, bool] = False,
         **kwargs: Any,
     ) -> None:

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -679,7 +679,7 @@ class DBSCAN(DBSCANClass, _CumlEstimator, _DBSCANCumlParams):
         The internal unique id column name for label matching, will not reveal in the output.
         Need to be set to a name that does not conflict with an existing column name in the original input data.
 
-    Note: We currently do not support calculating and storing the indices of the core samples via the parameter calc_core_sample_indices=True. 
+    Note: We currently do not support calculating and storing the indices of the core samples via the parameter calc_core_sample_indices=True.
 
     Examples
     ----------
@@ -764,7 +764,7 @@ class DBSCAN(DBSCANClass, _CumlEstimator, _DBSCANCumlParams):
         self.max_records_per_batch = int(max_records_per_batch_str)
         self.BROADCAST_LIMIT = 8 << 30
         self.verbose = verbose
-        self.cuml_params["calc_core_sample_indices"] = False # currently not supported
+        self.cuml_params["calc_core_sample_indices"] = False  # currently not supported
 
     def setEps(self: P, value: float) -> P:
         return self._set_params(eps=value)

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -62,7 +62,7 @@ from .core import (
     param_alias,
 )
 from .metrics import EvalMetricInfo
-from .params import HasIDCol, P, _CumlClass, _CumlParams
+from .params import DictTypeConverters, HasIDCol, P, _CumlClass, _CumlParams
 from .utils import (
     _concat_and_free,
     _get_class_or_callable_name,
@@ -807,17 +807,6 @@ class ApproximateNearestNeighborsClass(_CumlClass):
 
     def _pyspark_class(self) -> Optional[ABCMeta]:
         return None
-
-
-class DictTypeConverters(TypeConverters):
-    @staticmethod
-    def _toDict(value: Any) -> Dict[str, Any]:
-        """
-        Convert a value to a Dict type for Param typeConverter, if possible.
-        """
-        if isinstance(value, Dict):
-            return {TypeConverters.toString(k): v for k, v in value.items()}
-        raise TypeError("Could not convert %s to Dict[str, Any]" % value)
 
 
 class _ApproximateNearestNeighborsParams(_NearestNeighborsCumlParams):

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -560,3 +560,15 @@ class _CumlParams(_CumlClass, Params):
         """
         value_map = self._get_cuml_mapping_value(k, v)
         self._cuml_params[k] = value_map
+
+
+class DictTypeConverters(TypeConverters):
+    @staticmethod
+    def _toDict(value: Any) -> Dict[str, Any]:
+        """
+        Convert a value to a Dict type for Param typeConverter, if possible.
+        Used to support Dict types with the Spark ML Param API.
+        """
+        if isinstance(value, Dict):
+            return {TypeConverters.toString(k): v for k, v in value.items()}
+        raise TypeError("Could not convert %s to Dict[str, Any]" % value)

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -146,7 +146,7 @@ class _CumlClass(object):
         - None, if a defined Spark Param should raise an error.
 
         For algorithms without a Spark equivalent, the mapping can be left empty, with the exception
-        of parameters for which we override the cuML default value with our own (e.g. see DBSCAN).
+        of parameters for which we override the cuML default value with our own: these should include an identity mapping, e.g. {"param": "param"}.
 
         Note: standard Spark column Params, e.g. inputCol, featureCol, etc, should not be listed
         in this mapping, since they are handled differently.

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -291,7 +291,6 @@ class _CumlParams(_CumlClass, Params):
         """
         Set the default values of cuML parameters to match their Spark equivalents.
         """
-        print("_initialize_cuml_params called !!!")
         # initialize cuml_params with defaults from cuML
         self._cuml_params = self._get_cuml_params_default()
 
@@ -300,7 +299,6 @@ class _CumlParams(_CumlClass, Params):
 
         for spark_param in param_map.keys():
             if self.hasDefault(spark_param):
-                print(f"_initialize_cuml_params: calling _set_cuml_param({spark_param}, {self.getOrDefault(spark_param)})")
                 self._set_cuml_param(spark_param, self.getOrDefault(spark_param))
 
     def _set_params(self: P, **kwargs: Any) -> P:
@@ -308,7 +306,6 @@ class _CumlParams(_CumlClass, Params):
         Set the kwargs as Spark ML Params and/or cuML parameters, while maintaining parameter
         and value mappings defined by the _CumlClass.
         """
-        print("_set_params called with param_map: ", self._param_mapping())
         param_map = self._param_mapping()
 
         # raise error if setting both sides of a param mapping
@@ -334,18 +331,10 @@ class _CumlParams(_CumlClass, Params):
                 elif isinstance(v, List):
                     self._set(**{"featuresCols": v})
             elif self.hasParam(k):
-                # Param is declared as a Spark Param
+                # Param is declared as a Spark ML Param
                 self._set(**{str(k): v})  # type: ignore
-                if k in self.cuml_params:
-                    # cuML param codeclared as Spark param (i.e., for algos w/out Spark equivalents)
-                    print(f"_set_params: hasParams({k}) and {k} in self.cuml_params both True. Setting self._cuml_params[{k}] = {v}")
-                    self._cuml_params[k] = v
-                else:
-                    # Standard Spark ML param; update corresponding cuML param if mapped
-                    print(f"_set_params: hasParams({k}) is True, but {k} not in self.cuml_params. Calling _set_cuml_param({k}, {v})")
-                    self._set_cuml_param(k, v, silent=False)
+                self._set_cuml_param(k, v, silent=False)
             elif k in self.cuml_params:
-                print(f"_set_params: {k} in self.cuml_params is True. Setting self._cuml_params[{k}] = {v}")
                 # cuml param
                 self._cuml_params[k] = v
                 for spark_param, cuml_param in param_map.items():
@@ -473,11 +462,9 @@ class _CumlParams(_CumlClass, Params):
         return num_workers
 
     def _get_cuml_param(self, spark_param: str, silent: bool = True) -> Optional[str]:
-        print(f"_get_cuml_param: param_map is {self._param_mapping()}")
         param_map = self._param_mapping()
 
         if spark_param in param_map:
-            print(f"_get_cuml_param: param_map contains {spark_param}")
             cuml_param = param_map[spark_param]
             if cuml_param is None:
                 if not silent:
@@ -499,6 +486,8 @@ class _CumlParams(_CumlClass, Params):
         self, spark_param: str, spark_value: Any, silent: bool = True
     ) -> None:
         """Set a cuml_params parameter for a given Spark Param and value.
+        The Spark Param may be a cuML param that is declared as a Spark param (e.g., for algos w/out Spark equivalents),
+        in which case we recover the cuML param and set it.
 
         Parameters
         ----------
@@ -514,16 +503,15 @@ class _CumlParams(_CumlClass, Params):
         ValueError
             If the Spark Param is explictly not supported.
         """
-        print(f"_set_cuml_param: calling _get_cuml_param({spark_param}, silent={silent})")
 
         cuml_param = self._get_cuml_param(spark_param, silent)
-
-        print(f"_set_cuml_param: _get_cuml_param returned {cuml_param}")
+        if cuml_param is None and spark_param in self.cuml_params:
+            # cuML param is codeclared as Spark param (e.g., for algos w/out Spark equivalents); recover it.
+            cuml_param = spark_param
 
         if cuml_param is not None:
             # if Spark Param is mapped to cuML parameter, set cuml_params
             try:
-                print(f"_set_cuml_param: calling _set_cuml_value({cuml_param}, {spark_value})\n")
                 self._set_cuml_value(cuml_param, spark_value)
             except ValueError:
                 # create more informative message

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -482,6 +482,9 @@ class _CumlParams(_CumlClass, Params):
                 cuml_param = None
 
             return cuml_param
+        elif spark_param in self.cuml_params:
+            # cuML param that is declared as a Spark param (e.g., for algos w/out Spark equivalents)
+            return spark_param
         else:
             return None
 
@@ -490,7 +493,7 @@ class _CumlParams(_CumlClass, Params):
     ) -> None:
         """Set a cuml_params parameter for a given Spark Param and value.
         The Spark Param may be a cuML param that is declared as a Spark param (e.g., for algos w/out Spark equivalents),
-        in which case we recover the cuML param and set it.
+        in which case the cuML param will be returned from _get_cuml_param.
 
         Parameters
         ----------
@@ -508,9 +511,6 @@ class _CumlParams(_CumlClass, Params):
         """
 
         cuml_param = self._get_cuml_param(spark_param, silent)
-        if cuml_param is None and spark_param in self.cuml_params:
-            # cuML param is codeclared as Spark param (e.g., for algos w/out Spark equivalents); recover it.
-            cuml_param = spark_param
 
         if cuml_param is not None:
             # if Spark Param is mapped to cuML parameter, set cuml_params

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -145,6 +145,9 @@ class _CumlClass(object):
         - empty string, if a defined Spark Param should just be silently ignored, or
         - None, if a defined Spark Param should raise an error.
 
+        For algorithms without a Spark equivalent, the mapping can be left empty, with the exception
+        of parameters for which we override the cuML default value with our own (e.g. see DBSCAN).
+
         Note: standard Spark column Params, e.g. inputCol, featureCol, etc, should not be listed
         in this mapping, since they are handled differently.
 

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -311,31 +311,31 @@ class LinearRegression(
     Parameters
     ----------
 
-    featuresCol: str or List[str]
+    featuresCol: str or List[str] (default = "features")
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.
-    labelCol:
+    labelCol: str (default = "label")
         The label column name.
-    predictionCol:
+    predictionCol: str (default = "prediction")
         The prediction column name.
-    maxIter:
+    maxIter: int (default = 100)
         Max number of iterations (>= 0).
-    regParam:
-        Regularization parameter (>= 0)
-    elasticNetParam:
+    regParam: float (default = 0.0)
+        Regularization parameter (>= 0).
+    elasticNetParam: float (default = 0.0)
         The ElasticNet mixing parameter, in range [0, 1]. For alpha = 0,
         the penalty is an L2 penalty. For alpha = 1, it is an L1 penalty.
-    tol:
+    tol: float (default = 1e-6)
         The convergence tolerance for iterative algorithms (>= 0).
-    fitIntercept:
-        whether to fit an intercept term.
-    standardization:
+    fitIntercept: bool (default = True)
+        Whether to fit an intercept term.
+    standardization: bool (default = True)
         Whether to standardize the training features before fitting the model.
-    solver:
+    solver: str (default = "auto")
         The solver algorithm for optimization. If this is not set or empty, default value is 'auto'.\n
         The supported options: 'auto', 'normal' and 'eig', all of them will be mapped to 'eig' in cuML.
-    loss:
+    loss: str (default = "squaredError")
         The loss function to be optimized.
         The supported options: 'squaredError'
     num_workers:
@@ -840,25 +840,25 @@ class RandomForestRegressor(
     Parameters
     ----------
 
-    featuresCol: str or List[str]
+    featuresCol: str or List[str] (default = "features")
         The feature column names, spark-rapids-ml supports vector, array and columnar as the input.\n
             * When the value is a string, the feature columns must be assembled into 1 column with vector or array type.
             * When the value is a list of strings, the feature columns must be numeric types.
-    labelCol:
+    labelCol: str (default = "label")
         The label column name.
-    predictionCol:
+    predictionCol: str (default = "prediction")
         The prediction column name.
-    maxDepth:
+    maxDepth: int (default = 5)
         Maximum tree depth. Must be greater than 0.
-    maxBins:
+    maxBins: int (default = 32)
         Maximum number of bins used by the split algorithm per feature.
-    minInstancesPerNode:
+    minInstancesPerNode: int (default = 1)
         The minimum number of samples (rows) in each leaf node.
-    impurity: str = "variance",
+    impurity: str (default = "variance")
         The criterion used to split nodes.
-    numTrees:
+    numTrees: int (default = 20)
         Total number of trees in the forest.
-    featureSubsetStrategy:
+    featureSubsetStrategy: str (default = "auto")
         Ratio of number of features (columns) to consider per node split.\n
         The supported options:\n
             ``'auto'``:  If numTrees == 1, set to 'all', If numTrees > 1 (forest), set to 'onethird'\n
@@ -868,9 +868,9 @@ class RandomForestRegressor(
             ``'log2'``: log2(number of features)\n
             ``'n'``: when n is in the range (0, 1.0], use n * number of features. When n
             is in the range (1, number of features), use n features.
-    seed:
+    seed: int (default = None)
         Seed for the random number generator.
-    bootstrap:
+    bootstrap: bool (default = True)
         Control bootstrapping.\n
             * If ``True``, each tree in the forest is built on a bootstrapped
               sample with replacement.
@@ -888,11 +888,11 @@ class RandomForestRegressor(
             * ``4 or False`` - Enables all messages up to and including information messages.
             * ``5 or True`` - Enables all messages up to and including debug messages.
             * ``6`` - Enables all messages up to and including trace messages.
-    n_streams:
+    n_streams: int (default = 1)
         Number of parallel streams used for forest building.
         Please note that there is a bug running spark-rapids-ml on a node with multi-gpus
         when n_streams > 1. See https://github.com/rapidsai/cuml/issues/5402.
-    min_samples_split:
+    min_samples_split: int or float (default = 2)
         The minimum number of samples required to split an internal node.\n
          * If type ``int``, then ``min_samples_split`` represents the minimum
            number.
@@ -900,11 +900,11 @@ class RandomForestRegressor(
            and ``ceil(min_samples_split * n_rows)`` is the minimum number of
            samples for each split.    max_samples:
         Ratio of dataset rows used while fitting each tree.
-    max_leaves:
+    max_leaves: int (default = -1)
         Maximum leaf nodes per tree. Soft constraint. Unlimited, if -1.
-    min_impurity_decrease:
+    min_impurity_decrease: float (default = 0.0)
         Minimum decrease in impurity required for node to be split.
-    max_batch_size:
+    max_batch_size: int (default = 4096)
         Maximum number of nodes that can be processed in a given batch.
 
 

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -55,8 +55,6 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from spark_rapids_ml.core import FitInputType, _CumlModel
-
 from .core import (
     CumlT,
     FitInputType,
@@ -73,7 +71,7 @@ from .core import (
     param_alias,
 )
 from .metrics import EvalMetricInfo
-from .params import HasFeaturesCols, P, _CumlClass, _CumlParams
+from .params import DictTypeConverters, HasFeaturesCols, P, _CumlClass, _CumlParams
 from .utils import (
     _ArrayOrder,
     _concat_and_free,
@@ -97,6 +95,7 @@ class UMAPClass(_CumlClass):
             "n_neighbors": 15,
             "n_components": 2,
             "metric": "euclidean",
+            "metric_kwds": None,
             "n_epochs": None,
             "learning_rate": 1.0,
             "init": "spectral",
@@ -112,6 +111,8 @@ class UMAPClass(_CumlClass):
             "precomputed_knn": None,
             "random_state": None,
             "verbose": False,
+            "build_algo": "auto",
+            "build_kwds": None,
         }
 
     def _pyspark_class(self) -> Optional[ABCMeta]:
@@ -127,6 +128,7 @@ class _UMAPCumlParams(
             n_neighbors=15,
             n_components=2,
             metric="euclidean",
+            metric_kwds=None,
             n_epochs=None,
             learning_rate=1.0,
             init="spectral",
@@ -141,6 +143,8 @@ class _UMAPCumlParams(
             b=None,
             precomputed_knn=None,
             random_state=None,
+            build_algo="auto",
+            build_kwds=None,
             sample_fraction=1.0,
             outputCol="embedding",
         )
@@ -171,10 +175,21 @@ class _UMAPCumlParams(
         "metric",
         (
             f"Distance metric to use. Supported distances are ['l1', 'cityblock', 'taxicab', 'manhattan', 'euclidean', 'l2',"
-            f" 'sqeuclidean', 'canberra', 'chebyshev', 'linf', 'cosine', 'correlation', 'hellinger', 'hamming', 'jaccard']."
-            f" Metrics that take arguments via the metric_kwds dictionary are not supported."
+            f" 'sqeuclidean', 'canberra', 'minkowski', 'chebyshev', 'linf', 'cosine', 'correlation', 'hellinger', 'hamming',"
+            f" 'jaccard'] Metrics that take arguments (such as minkowski) can have arguments passed via the metric_kwds dictionary."
+            f" Note: The 'jaccard' distance metric is only supported for sparse inputs."
         ),
         typeConverter=TypeConverters.toString,
+    )
+
+    metric_kwds = Param(
+        Params._dummy(),
+        "metric_kwds",
+        (
+            f"Additional keyword arguments for the metric function. If the metric function takes additional arguments, they"
+            f" should be passed in this dictionary."
+        ),
+        typeConverter=DictTypeConverters._toDict,
     )
 
     n_epochs = Param(
@@ -328,6 +343,27 @@ class _UMAPCumlParams(
         typeConverter=TypeConverters.toInt,
     )
 
+    build_algo = Param(
+        Params._dummy(),
+        "build_algo",
+        (
+            f"How to build the knn graph. Supported build algorithms are ['auto', 'brute_force_knn', 'nn_descent']. 'auto' chooses"
+            f" to run with brute force knn if number of data rows is smaller than or equal to 50K. Otherwise, runs with nn descent."
+        ),
+        typeConverter=TypeConverters.toString,
+    )
+
+    build_kwds = Param(
+        Params._dummy(),
+        "build_kwds",
+        (
+            f"Build algorithm argument {{'nnd_graph_degree': 64, 'nnd_intermediate_graph_degree': 128, 'nnd_max_iterations': 20,"
+            f" 'nnd_termination_threshold': 0.0001, 'nnd_return_distances': True, 'nnd_n_clusters': 1}} Note that nnd_n_clusters > 1"
+            f" will result in batch-building with NN Descent."
+        ),
+        typeConverter=DictTypeConverters._toDict,
+    )
+
     sample_fraction = Param(
         Params._dummy(),
         "sample_fraction",
@@ -374,6 +410,18 @@ class _UMAPCumlParams(
         Sets the value of `metric`.
         """
         return self._set_params(metric=value)
+
+    def getMetricKwds(self: P) -> Optional[Dict[str, Any]]:
+        """
+        Gets the value of `metric_kwds`.
+        """
+        return self.getOrDefault("metric_kwds")
+
+    def setMetricKwds(self: P, value: Dict[str, Any]) -> P:
+        """
+        Sets the value of `metric_kwds`.
+        """
+        return self._set_params(metric_kwds=value)
 
     def getNEpochs(self: P) -> int:
         """
@@ -543,6 +591,30 @@ class _UMAPCumlParams(
         """
         return self._set_params(random_state=value)
 
+    def getBuildAlgo(self: P) -> str:
+        """
+        Gets the value of `build_algo`.
+        """
+        return self.getOrDefault("build_algo")
+
+    def setBuildAlgo(self: P, value: str) -> P:
+        """
+        Sets the value of `build_algo`.
+        """
+        return self._set_params(build_algo=value)
+
+    def getBuildKwds(self: P) -> Optional[Dict[str, Any]]:
+        """
+        Gets the value of `build_kwds`.
+        """
+        return self.getOrDefault("build_kwds")
+
+    def setBuildKwds(self: P, value: Dict[str, Any]) -> P:
+        """
+        Sets the value of `build_kwds`.
+        """
+        return self._set_params(build_kwds=value)
+
     def getSampleFraction(self: P) -> float:
         """
         Gets the value of `sample_fraction`.
@@ -628,6 +700,10 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
         'hamming', 'jaccard']. Metrics that take arguments (such as minkowski) can have arguments passed via the
         metric_kwds dictionary.
 
+    metric_kwds : dict (optional, default=None)
+        Additional keyword arguments for the metric function. If the metric function takes additional arguments,
+        they should be passed in this dictionary.
+
     n_epochs : int (optional, default=None)
         The number of training epochs to be used in optimizing the low dimensional embedding. Larger values result
         in more accurate embeddings. If None is specified a value will be selected based on the size of the input dataset
@@ -706,6 +782,15 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
             * ``4 or False`` - Enables all messages up to and including information messages.
             * ``5 or True`` - Enables all messages up to and including debug messages.
             * ``6`` - Enables all messages up to and including trace messages.
+
+    build_algo : str (optional, default='auto')
+        How to build the knn graph. Supported build algorithms are ['auto', 'brute_force_knn', 'nn_descent']. 'auto' chooses
+        to run with brute force knn if number of data rows is smaller than or equal to 50K. Otherwise, runs with nn descent.
+
+    build_kwds : dict (optional, default=None)
+        Build algorithm argument {'nnd_graph_degree': 64, 'nnd_intermediate_graph_degree': 128, 'nnd_max_iterations': 20,
+        'nnd_termination_threshold': 0.0001, 'nnd_return_distances': True, 'nnd_n_clusters': 1} Note that nnd_n_clusters > 1
+        will result in batch-building with NN Descent.
 
     sample_fraction : float (optional, default=1.0)
         The fraction of the dataset to be used for fitting the model. Since fitting is done on a single node, very large
@@ -787,6 +872,7 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
         n_neighbors: Optional[float] = 15,
         n_components: Optional[int] = 15,
         metric: str = "euclidean",
+        metric_kwds: Optional[Dict[str, Any]] = None,
         n_epochs: Optional[int] = None,
         learning_rate: Optional[float] = 1.0,
         init: Optional[str] = "spectral",
@@ -801,12 +887,13 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
         b: Optional[float] = None,
         precomputed_knn: Optional[List[List[float]]] = None,
         random_state: Optional[int] = None,
+        build_algo: Optional[str] = "auto",
+        build_kwds: Optional[Dict[str, Any]] = None,
         sample_fraction: Optional[float] = 1.0,
         featuresCol: Optional[Union[str, List[str]]] = None,
         labelCol: Optional[str] = None,
         outputCol: Optional[str] = None,
         num_workers: Optional[int] = None,
-        verbose: Union[int, bool] = False,
         **kwargs: Any,
     ) -> None:
         super().__init__()

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -90,25 +90,7 @@ if TYPE_CHECKING:
 class UMAPClass(_CumlClass):
     @classmethod
     def _param_mapping(cls) -> Dict[str, Optional[str]]:
-        return {
-            "n_neighbors": "n_neighbors",
-            "n_components": "n_components",
-            "metric": "metric",
-            "n_epochs": "n_epochs",
-            "learning_rate": "learning_rate",
-            "init": "init",
-            "min_dist": "min_dist",
-            "spread": "spread",
-            "set_op_mix_ratio": "set_op_mix_ratio",
-            "local_connectivity": "local_connectivity",
-            "repulsion_strength": "repulsion_strength",
-            "negative_sample_rate": "negative_sample_rate",
-            "transform_queue_size": "transform_queue_size",
-            "a": "a",
-            "b": "b",
-            "precomputed_knn": "precomputed_knn",
-            "random_state": "random_state",
-        }
+        return {}
 
     def _get_cuml_params_default(self) -> Dict[str, Any]:
         return {

--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -64,8 +64,8 @@ def test_params(default_params: bool) -> None:
 
     # obtain n_neighbors, verbose, algorithm, algo_params, metric
     cuml_params = get_default_cuml_parameters(
-        [CumlNearestNeighbors],
-        [
+        cuml_classes=[CumlNearestNeighbors],
+        excludes=[
             "handle",
             "p",
             "metric_expanded",

--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -57,9 +57,9 @@ def cal_dist(v1: np.ndarray, v2: np.ndarray, metric: str) -> float:
 def test_params(default_params: bool) -> None:
     from cuml import NearestNeighbors as CumlNearestNeighbors
 
-    spark_params: Dict[str, Any] = {
-        "algorithm": "ivfflat",
-        "metric": "euclidean",
+    spark_params = {
+        param.name: value
+        for param, value in ApproximateNearestNeighbors().extractParamMap().items()
     }
 
     # obtain n_neighbors, verbose, algorithm, algo_params, metric
@@ -82,7 +82,7 @@ def test_params(default_params: bool) -> None:
     if default_params:
         knn = ApproximateNearestNeighbors()
     else:
-        knn = ApproximateNearestNeighbors(n_neighbors=7)
+        knn = ApproximateNearestNeighbors(k=7)
         cuml_params["n_neighbors"] = 7
         spark_params["k"] = 7
 

--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -26,6 +26,7 @@ from .test_nearest_neighbors import (
 )
 from .utils import (
     array_equal,
+    assert_params,
     create_pyspark_dataframe,
     get_default_cuml_parameters,
     idfn,
@@ -52,8 +53,14 @@ def cal_dist(v1: np.ndarray, v2: np.ndarray, metric: str) -> float:
         assert False, f"Does not recognize metric '{metric}'"
 
 
-def test_params() -> None:
+@pytest.mark.parametrize("default_params", [True, False])
+def test_params(default_params: bool) -> None:
     from cuml import NearestNeighbors as CumlNearestNeighbors
+
+    spark_params: Dict[str, Any] = {
+        "algorithm": "ivfflat",
+        "metric": "euclidean",
+    }
 
     # obtain n_neighbors, verbose, algorithm, algo_params, metric
     cuml_params = get_default_cuml_parameters(
@@ -67,15 +74,29 @@ def test_params() -> None:
         ],
     )
 
-    spark_params = ApproximateNearestNeighbors()._get_cuml_params_default()
     cuml_params["algorithm"] = "ivfflat"  # change cuml default 'auto' to 'ivfflat'
-    assert cuml_params == spark_params
+
+    # Ensure internal cuml defaults match actual cuml defaults
+    assert ApproximateNearestNeighbors()._get_cuml_params_default() == cuml_params
+
+    if default_params:
+        knn = ApproximateNearestNeighbors()
+    else:
+        knn = ApproximateNearestNeighbors(n_neighbors=7)
+        cuml_params["n_neighbors"] = 7
+        spark_params["k"] = 7
+
+    # Ensure both Spark API params and internal cuml_params are set correctly
+    assert_params(knn, spark_params, cuml_params)
+    assert knn.cuml_params == cuml_params
 
     # setter/getter
     from .test_common_estimator import _test_input_setter_getter
 
     _test_input_setter_getter(ApproximateNearestNeighbors)
 
+
+def test_search_index_params() -> None:
     # test cagra index params and search params
     cagra_index_param: Dict[str, Any] = {
         "intermediate_graph_degree": 80,

--- a/python/tests/test_dbscan.py
+++ b/python/tests/test_dbscan.py
@@ -84,7 +84,7 @@ def test_params(
             "min_samples": 4,
             "calc_core_sample_indices": True,
         }
-        dbscan = DBSCAN(**nondefault_params)
+        dbscan = DBSCAN(**nondefault_params)  # type: ignore
         cuml_params.update(nondefault_params)
         spark_params.update(nondefault_params)
 

--- a/python/tests/test_dbscan.py
+++ b/python/tests/test_dbscan.py
@@ -73,7 +73,9 @@ def test_params(
     # Ensure internal cuml defaults match actual cuml defaults
     assert DBSCAN()._get_cuml_params_default() == cuml_params
 
-    with pytest.raises(ValueError, match="Unsupported param 'calc_core_sample_indices'"):
+    with pytest.raises(
+        ValueError, match="Unsupported param 'calc_core_sample_indices'"
+    ):
         dbscan_dummy = DBSCAN(calc_core_sample_indices=True)
 
     if default_params:
@@ -87,8 +89,10 @@ def test_params(
         dbscan = DBSCAN(**nondefault_params)  # type: ignore
         cuml_params.update(nondefault_params)
         spark_params.update(nondefault_params)
-    
-    cuml_params["calc_core_sample_indices"] = False # we override this param to False internally
+
+    cuml_params["calc_core_sample_indices"] = (
+        False  # we override this param to False internally
+    )
 
     # Ensure both Spark API params and internal cuml_params are set correctly
     assert_params(dbscan, spark_params, cuml_params)

--- a/python/tests/test_dbscan.py
+++ b/python/tests/test_dbscan.py
@@ -54,11 +54,7 @@ def test_params(
     from cuml import DBSCAN as cumlDBSCAN
 
     spark_params = {
-        "eps": 0.5,
-        "min_samples": 5,
-        "metric": "euclidean",
-        "algorithm": "brute",
-        "max_mbytes_per_batch": None,
+        param.name: value for param, value in DBSCAN().extractParamMap().items()
     }
 
     cuml_params = get_default_cuml_parameters(

--- a/python/tests/test_dbscan.py
+++ b/python/tests/test_dbscan.py
@@ -57,7 +57,8 @@ def test_default_cuml_params() -> None:
 
 @pytest.mark.parametrize("default_params", [True, False])
 def test_params(
-    gpu_number: int, default_params: bool, tmp_path: str, caplog: LogCaptureFixture
+    default_params: bool,
+    tmp_path: str,
 ) -> None:
     from cuml import DBSCAN as cumlDBSCAN
 
@@ -69,6 +70,9 @@ def test_params(
         ],
     )
 
+    # Ensure internal cuml defaults match actual cuml defaults
+    assert DBSCAN()._get_cuml_params_default() == cuml_params
+
     if default_params:
         dbscan = DBSCAN()
     else:
@@ -79,7 +83,8 @@ def test_params(
             min_samples=4,
         )
 
-    assert_params(dbscan, {}, cuml_params)
+    # Ensure both Spark API params and internal cuml_params are set correctly
+    assert_params(instance=dbscan, spark_params={}, cuml_params=cuml_params)
     assert dbscan.cuml_params == cuml_params
 
     # Estimator persistence

--- a/python/tests/test_dbscan.py
+++ b/python/tests/test_dbscan.py
@@ -46,15 +46,6 @@ from .utils import (
 )
 
 
-def test_default_cuml_params() -> None:
-    from cuml import DBSCAN as CumlDBSCAN
-
-    cuml_params = get_default_cuml_parameters([CumlDBSCAN], ["handle", "output_type"])
-    cuml_params["calc_core_sample_indices"] = False
-    spark_params = DBSCAN()._get_cuml_params_default()
-    assert cuml_params == spark_params
-
-
 @pytest.mark.parametrize("default_params", [True, False])
 def test_params(
     default_params: bool,

--- a/python/tests/test_dbscan.py
+++ b/python/tests/test_dbscan.py
@@ -63,8 +63,8 @@ def test_params(
     from cuml import DBSCAN as cumlDBSCAN
 
     cuml_params = get_default_cuml_parameters(
-        [cumlDBSCAN],
-        [
+        cuml_classes=[cumlDBSCAN],
+        excludes=[
             "handle",
             "output_type",
         ],

--- a/python/tests/test_kmeans.py
+++ b/python/tests/test_kmeans.py
@@ -75,17 +75,22 @@ def test_params(default_params: bool) -> None:
     }
 
     cuml_params = get_default_cuml_parameters(
-        [CumlKMeans], ["handle", "output_type", "convert_dtype"]
+        cuml_classes=[CumlKMeans], excludes=["handle", "output_type", "convert_dtype"]
     )
 
     # Ensure internal cuml defaults match actual cuml defaults
     assert KMeans()._get_cuml_params_default() == cuml_params
 
-    cuml_params["n_clusters"] = 2  # cuml default gets overriden by spark default = 2
-    cuml_params["max_iter"] = 20  # cuml default gets overriden by spark default = 20
-    cuml_params["init"] = (
-        "k-means||"  # cuml default gets overriden by spark default = 'k-means||'
-    )
+    # Our algorithm overrides the following cuml parameters with their spark defaults:
+    spark_default_overrides = {
+        "n_clusters": 2,
+        "max_iter": 20,
+        "init": "k-means||",
+    }
+
+    for param, value in spark_default_overrides.items():
+        if param in cuml_params:
+            cuml_params[param] = value
 
     if default_params:
         kmeans = KMeans()

--- a/python/tests/test_linear_model.py
+++ b/python/tests/test_linear_model.py
@@ -117,19 +117,25 @@ def test_params(default_params: bool) -> None:
     }
 
     cuml_params = get_default_cuml_parameters(
-        [CumlLinearRegression, Ridge, CD], ["handle", "output_type"]
+        cuml_classes=[CumlLinearRegression, Ridge, CD],
+        excludes=["handle", "output_type"],
     )
 
     # Ensure internal cuml defaults match actual cuml defaults
     assert cuml_params == LinearRegression()._get_cuml_params_default()
 
-    cuml_params["alpha"] = 0.0  # cuml default gets overriden by spark default = 0.0
-    cuml_params["l1_ratio"] = 0.0  # cuml default gets overriden by spark default = 0.0
-    cuml_params["max_iter"] = 100  # cuml default gets overriden by spark default = 100
-    cuml_params["normalize"] = (
-        True  # cuml default gets overriden by spark default = True
-    )
-    cuml_params["tol"] = 1e-06  # cuml default gets overriden by spark default = 1e-06
+    # Our algorithm overrides the following cuml parameters with their spark defaults:
+    spark_default_overrides = {
+        "alpha": 0.0,
+        "l1_ratio": 0.0,
+        "max_iter": 100,
+        "normalize": True,
+        "tol": 1e-06,
+    }
+
+    for param, value in spark_default_overrides.items():
+        if param in cuml_params:
+            cuml_params[param] = value
 
     if default_params:
         lr = LinearRegression()

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -39,8 +39,8 @@ def test_params(default_params: bool, caplog: LogCaptureFixture) -> None:
     spark_params = {}
 
     cuml_params = get_default_cuml_parameters(
-        [CumlNearestNeighbors, NearestNeighborsMG],
-        [
+        cuml_classes=[CumlNearestNeighbors, NearestNeighborsMG],
+        excludes=[
             "handle",
             "algorithm",
             "metric",

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -36,7 +36,10 @@ def test_params(default_params: bool, caplog: LogCaptureFixture) -> None:
         NearestNeighborsMG,  # to include the batch_size parameter that exists in the MG class
     )
 
-    spark_params = {}
+    spark_params = {
+        param.name: value
+        for param, value in NearestNeighbors().extractParamMap().items()
+    }
 
     cuml_params = get_default_cuml_parameters(
         cuml_classes=[CumlNearestNeighbors, NearestNeighborsMG],
@@ -56,12 +59,12 @@ def test_params(default_params: bool, caplog: LogCaptureFixture) -> None:
     if default_params:
         knn = NearestNeighbors()
     else:
-        knn = NearestNeighbors(n_neighbors=7)
+        knn = NearestNeighbors(k=7)
         cuml_params["n_neighbors"] = 7
         spark_params["k"] = 7
 
     # Ensure both Spark API params and internal cuml_params are set correctly
-    assert_params(knn, cuml_params, spark_params)
+    assert_params(knn, spark_params, cuml_params)
     assert knn.cuml_params == cuml_params
 
     # float32_inputs warn, NearestNeighbors only accepts float32

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -18,6 +18,7 @@ from spark_rapids_ml.knn import (
 from .sparksession import CleanSparkSession
 from .utils import (
     array_equal,
+    assert_params,
     create_pyspark_dataframe,
     get_default_cuml_parameters,
     idfn,
@@ -28,11 +29,14 @@ NNEstimator = Union[NearestNeighbors, ApproximateNearestNeighbors]
 NNModel = Union[NearestNeighborsModel, ApproximateNearestNeighborsModel]
 
 
-def test_params(caplog: LogCaptureFixture) -> None:
+@pytest.mark.parametrize("default_params", [True, False])
+def test_params(default_params: bool, caplog: LogCaptureFixture) -> None:
     from cuml import NearestNeighbors as CumlNearestNeighbors
     from cuml.neighbors.nearest_neighbors_mg import (
         NearestNeighborsMG,  # to include the batch_size parameter that exists in the MG class
     )
+
+    spark_params = {}
 
     cuml_params = get_default_cuml_parameters(
         [CumlNearestNeighbors, NearestNeighborsMG],
@@ -47,8 +51,18 @@ def test_params(caplog: LogCaptureFixture) -> None:
             "output_type",
         ],
     )
-    spark_params = NearestNeighbors()._get_cuml_params_default()
-    assert cuml_params == spark_params
+    assert cuml_params == NearestNeighbors()._get_cuml_params_default()
+
+    if default_params:
+        knn = NearestNeighbors()
+    else:
+        knn = NearestNeighbors(n_neighbors=7)
+        cuml_params["n_neighbors"] = 7
+        spark_params["k"] = 7
+
+    # Ensure both Spark API params and internal cuml_params are set correctly
+    assert_params(knn, cuml_params, spark_params)
+    assert knn.cuml_params == cuml_params
 
     # float32_inputs warn, NearestNeighbors only accepts float32
     nn_float32 = NearestNeighbors(float32_inputs=False)

--- a/python/tests/test_pca.py
+++ b/python/tests/test_pca.py
@@ -59,8 +59,8 @@ def test_params(default_params: bool, caplog: LogCaptureFixture) -> None:
     spark_params = {}
 
     cuml_params = get_default_cuml_parameters(
-        [CumlPCA],
-        [
+        cuml_classes=[CumlPCA],
+        excludes=[
             "copy",
             "handle",
             "iterated_power",

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -260,6 +260,9 @@ def test_params(tmp_path: str, default_params: bool) -> None:
         ],
     )
 
+    # Ensure internal cuml defaults match actual cuml defaults
+    assert UMAP()._get_cuml_params_default() == cuml_params
+
     if default_params:
         umap = UMAP()
     else:
@@ -268,7 +271,8 @@ def test_params(tmp_path: str, default_params: bool) -> None:
         cuml_params["random_state"] = 42
         umap = UMAP(n_neighbors=12, learning_rate=0.9, random_state=42)
 
-    assert_params(umap, {}, cuml_params)
+    # Ensure both Spark API params and internal cuml_params are set correctly
+    assert_params(instance=umap, spark_params={}, cuml_params=cuml_params)
     assert umap.cuml_params == cuml_params
 
     # Estimator persistence

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -15,7 +15,7 @@
 #
 
 import math
-from typing import List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import cupy as cp
 import numpy as np
@@ -292,7 +292,7 @@ def test_params(tmp_path: str, default_params: bool) -> None:
             "learning_rate": 0.9,
             "random_state": 42,
         }
-        umap = UMAP(**nondefault_params)
+        umap = UMAP(**nondefault_params)  # type: ignore
         cuml_params.update(nondefault_params)
         spark_params.update(nondefault_params)
 

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -251,12 +251,9 @@ def test_params(tmp_path: str, default_params: bool) -> None:
     cuml_params = get_default_cuml_parameters(
         cuml_classes=[cumlUMAP],
         excludes=[
-            "build_algo",
-            "build_kwds",
             "callback",
             "handle",
             "hash_input",
-            "metric_kwds",
             "output_type",
             "target_metric",
             "target_n_neighbors",

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -245,8 +245,8 @@ def test_params(tmp_path: str, default_params: bool) -> None:
     from cuml import UMAP as cumlUMAP
 
     cuml_params = get_default_cuml_parameters(
-        [cumlUMAP],
-        [
+        cuml_classes=[cumlUMAP],
+        excludes=[
             "build_algo",
             "build_kwds",
             "callback",

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -245,24 +245,7 @@ def test_params(tmp_path: str, default_params: bool) -> None:
     from cuml import UMAP as cumlUMAP
 
     spark_params = {
-        "n_neighbors": 15,
-        "n_components": 2,
-        "metric": "euclidean",
-        "n_epochs": None,
-        "learning_rate": 1.0,
-        "init": "spectral",
-        "min_dist": 0.1,
-        "spread": 1.0,
-        "set_op_mix_ratio": 1.0,
-        "local_connectivity": 1.0,
-        "repulsion_strength": 1.0,
-        "negative_sample_rate": 5,
-        "transform_queue_size": 4.0,
-        "a": None,
-        "b": None,
-        "precomputed_knn": None,
-        "random_state": None,
-        "verbose": False,
+        param.name: value for param, value in UMAP().extractParamMap().items()
     }
 
     cuml_params = get_default_cuml_parameters(


### PR DESCRIPTION
## Changes
`params.py`:
- Added logic to `_get_cuml_param` to handle the case where a cuML param is declared as a Spark param for algos w/out Spark equivalents.
  - Removes the need for identity mappings for UMAP, DBSCAN, and future cuML-only algos (except for cases where we override cuML's default value, as noted in `_param_mapping` docstring).
- Moved `DictTypeConverters` in from knn so that UMAP/future algos can leverage this function for Dict-type params.

`test_*.py`:
- Ensured all tests cover these checks:
  1. `Algorithm()._get_cuml_params_default() == get_default_cuml_parameters([CumlAlgorithm])`: Ensures that our internal dictionary of default cuML parameters matches those from cuML's API. 
  2. `assert_params(algorithm, spark_params, cuml_params)` with `default_params=True`: Ensures that we are correctly setting the default params in both the Spark parameter API and the internal cuML parameter dictionary.
  3. `assert_params(algorithm, spark_params, cuml_params)` with `default_params=False`: As above, checking that we correctly update params when non-default parameters are passed in.
  4. `assert algorithm.cuml_params == cuml_params`: An extra check to ensure the internal cuML dictionary fully matches the expected parameters under default and non-default conditions (catches any extra params without an equivalent in the other dict that may not have been caught in (iii)). 

**umap**:
- Added support for new params `build_algo` and `build_kwds` (and old param `metric_kwds`, which had been missing).
- Added a test for build_algo=nn_descent. 

**dbscan**:
- Unexposed `calc_core_sample_indices` from the user, since we [do not support it](https://github.com/NVIDIA/spark-rapids-ml/pull/598#discussion_r1548762983). 
- Updated documentation accordingly and added test to ensure it cannot be set. 

**algorithm docstrings**:
- Updated docstrings with default parameter values for consistency, fixed minor bugs/typos.

## Note about missing parameters 
In almost all algorithms, the corresponding cuML algorithm contains parameters that we do not support.  
Some unsupported params were "newly found" in this PR; this code currently excludes these parameters from the tests, (e.g., see [test_logistic_regression](https://github.com/rishic3/spark-rapids-ml/blob/param-tests/python/tests/test_logistic_regression.py#L190), [test_random_forest](https://github.com/rishic3/spark-rapids-ml/blob/param-tests/python/tests/test_random_forest.py#L128)), so that it can be merged.  

We may want do a pass over these excluded parameters to check if:
- the parameter is correctly omitted because we don't support it in the Spark version, or
- the parameter was added recently to cuML and we would like to update our algorithms to support it. 

If needed, in the latter case we can address parameters that should be supported in separate PR(s).
