### PR TITLE
more updates for 24.10 release

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -38,5 +38,5 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
 
 # install cuML
 ARG CUML_VER=24.10
-RUN conda install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER cuvs=$CUML_VER python=3.10 cuda-version=11.8 numpy~=1.0 \
+RUN conda install -y -c rapidsai -c conda-forge -c nvidia cuml=$CUML_VER cuvs=$CUML_VER python=3.10 cuda-version=11.8 numpy~=1.0 \
     && conda clean --all -f -y

--- a/docker/Dockerfile.pip
+++ b/docker/Dockerfile.pip
@@ -18,7 +18,7 @@ ARG CUDA_VERSION=11.8.0
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
 
 ARG PYSPARK_VERSION=3.3.1
-ARG RAPIDS_VERSION=24.8.0
+ARG RAPIDS_VERSION=24.10.0
 ARG ARCH=amd64
 #ARG ARCH=arm64
 # Install packages to build spark-rapids-ml
@@ -41,6 +41,7 @@ RUN pip install --no-cache-dir \
     cudf-cu11~=${RAPIDS_VERSION} \
     cuml-cu11~=${RAPIDS_VERSION} \
     cuvs-cu11~=${RAPIDS_VERSION} \
+    numpy~=1.0 \
     --extra-index-url=https://pypi.nvidia.com
 
 # install python dependencies

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -17,7 +17,7 @@
 ARG CUDA_VERSION=11.8.0
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04
 
-ARG CUML_VERSION=24.08
+ARG CUML_VERSION=24.10
 
 # Install packages to build spark-rapids-ml
 RUN apt update -y \
@@ -38,7 +38,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
 
 # install cuML
 
-RUN conda install -y -c rapidsai -c conda-forge -c nvidia python=3.9 cuda-version=11.8 cuml=$CUML_VERSION \
+RUN conda install -y -c rapidsai -c conda-forge -c nvidia python=3.10 cuda-version=11.8 cuml=$CUML_VERSION numpy~=1.0 \
     && conda clean --all -f -y
 
 # install python dependencies

--- a/docs/site/compatibility.md
+++ b/docs/site/compatibility.md
@@ -28,7 +28,7 @@ Note: Spark does not provide a k-Nearest Neighbors (k-NN) implementation, but it
 
 | Spark Rapids ML | CUDA  | Spark  | Python |
 | :-------------- | :---- | :----- | :----- |
-| 1.0.0           | 11.5+ | 3.2.1+ | 3.9+   |
+| 1.0.0           | 11.4+ | 3.3+   | 3.10+  |
 
 
 ## Single vs Double precision inputs

--- a/notebooks/databricks/init-pip-cuda-11.8.sh
+++ b/notebooks/databricks/init-pip-cuda-11.8.sh
@@ -4,7 +4,7 @@ SPARK_RAPIDS_ML_ZIP=/dbfs/path/to/zip/file
 # IMPORTANT: specify RAPIDS_VERSION fully 23.10.0 and not 23.10
 # also in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
 # while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.08.2 and not 23.8.2)
-RAPIDS_VERSION=24.8.0
+RAPIDS_VERSION=24.10.0
 SPARK_RAPIDS_VERSION=24.08.1
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda11.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar

--- a/notebooks/dataproc/README.md
+++ b/notebooks/dataproc/README.md
@@ -29,7 +29,7 @@ If you already have a Dataproc account, you can run the example notebooks on a D
 - Create a cluster with at least two single-gpu workers.  **Note**: in addition to the initialization script from above, this also uses the standard [initialization actions](https://github.com/GoogleCloudDataproc/initialization-actions) for installing the GPU drivers and RAPIDS:
   ```
   export CUDA_VERSION=11.8
-  export RAPIDS_VERSION=24.8.0
+  export RAPIDS_VERSION=24.10.0
 
   gcloud dataproc clusters create $USER-spark-rapids-ml \
   --image-version=2.1-ubuntu \

--- a/notebooks/dataproc/spark_rapids_ml.sh
+++ b/notebooks/dataproc/spark_rapids_ml.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RAPIDS_VERSION=24.8.0
+RAPIDS_VERSION=24.10.0
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"

--- a/python/README.md
+++ b/python/README.md
@@ -8,9 +8,9 @@ For simplicity, the following instructions just use Spark local mode, assuming a
 
 First, install RAPIDS cuML per [these instructions](https://rapids.ai/start.html).   Example for CUDA Toolkit 11.8:
 ```bash
-conda create -n rapids-24.08 \
+conda create -n rapids-24.10 \
     -c rapidsai -c conda-forge -c nvidia \
-    cuml=24.08 cuvs=24.08 python=3.9 cuda-version=11.8
+    cuml=24.10 cuvs=24.10 python=3.10 cuda-version=11.8
 ```
 
 **Note**: while testing, we recommend using conda or docker to simplify installation and isolate your environment while experimenting.  Once you have a working environment, you can then try installing directly, if necessary.
@@ -19,7 +19,7 @@ conda create -n rapids-24.08 \
 
 Once you have the conda environment, activate it and install the required packages.
 ```bash
-conda activate rapids-24.08
+conda activate rapids-24.10
 
 ## for development access to notebooks, tests, and benchmarks
 git clone --branch main https://github.com/NVIDIA/spark-rapids-ml.git

--- a/python/benchmark/databricks/init-pip-cuda-11.8.sh
+++ b/python/benchmark/databricks/init-pip-cuda-11.8.sh
@@ -5,7 +5,7 @@ BENCHMARK_ZIP=/dbfs/path/to/benchmark.zip
 # IMPORTANT: specify rapids fully 23.10.0 and not 23.10
 # also, in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
 # while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.08.2 and not 23.8.2)
-RAPIDS_VERSION=24.8.0
+RAPIDS_VERSION=24.10.0
 SPARK_RAPIDS_VERSION=24.08.1
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda11.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar

--- a/python/benchmark/dataproc/init_benchmark.sh
+++ b/python/benchmark/dataproc/init_benchmark.sh
@@ -8,7 +8,7 @@ function get_metadata_attribute() {
   /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
 }
 
-RAPIDS_VERSION=$(get_metadata_attribute rapids-version 24.8.0)
+RAPIDS_VERSION=$(get_metadata_attribute rapids-version 24.10.0)
 
 # patch existing packages
 mamba install "llvmlite<0.40,>=0.39.0dev0" "numba>=0.56.2"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,16 +9,26 @@ authors = [
 ]
 description = "Apache Spark integration with RAPIDS and cuML"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Environment :: GPU :: NVIDIA CUDA :: 11",
+    "Environment :: GPU :: NVIDIA CUDA :: 11.4",
     "Environment :: GPU :: NVIDIA CUDA :: 11.5",
+    "Environment :: GPU :: NVIDIA CUDA :: 11.6",
+    "Environment :: GPU :: NVIDIA CUDA :: 11.7",
+    "Environment :: GPU :: NVIDIA CUDA :: 11.8",
+    "Environment :: GPU :: NVIDIA CUDA :: 12",
+    "Environment :: GPU :: NVIDIA CUDA :: 12.0",
+    "Environment :: GPU :: NVIDIA CUDA :: 12.1",
+    "Environment :: GPU :: NVIDIA CUDA :: 12.2",
+    "Environment :: GPU :: NVIDIA CUDA :: 12.3",
+    "Environment :: GPU :: NVIDIA CUDA :: 12.4",
+    "Environment :: GPU :: NVIDIA CUDA :: 12.5",
 ]
 
 [project.scripts]


### PR DESCRIPTION
aws-emr update to 24.10 is more involved due to python 3.10 upgrade and will be done in a follow-on.