### PR TITLE
Fix "No object to concat" Bug and support Some corner cases

### DIFF
--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1398,7 +1398,8 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
                         yield pdf
                 else:
                     pdfs = [pdf for pdf in pdf_iter]
-                    yield pd.concat(pdfs, ignore_index=True)
+                    if (len(pdfs)) > 0:
+                        yield pd.concat(pdfs, ignore_index=True)
 
             processed_pdf_iter = process_pdf_iter(pdf_iter)
             has_row_number = None

--- a/python/src/spark_rapids_ml/knn.py
+++ b/python/src/spark_rapids_ml/knn.py
@@ -1470,14 +1470,15 @@ class ApproximateNearestNeighborsModel(
                 assert len(item.columns) == 1
                 item = np.array(list(item[item.columns[0]]), order="C")
 
-            if len(item) == 0:
-                return pd.DataFrame(
+            if len(item) == 0 or len(bcast_qfeatures.value) == 0:
+                res = pd.DataFrame(
                     {
-                        f"query_{id_col_name}": [],
-                        "indices": [],
-                        "distances": [],
+                        f"query_{id_col_name}": pd.Series(dtype="int64"),
+                        "indices": pd.Series(dtype="object"),
+                        "distances": pd.Series(dtype="object"),
                     }
                 )
+                return res
 
             import cupy as cp
             from pyspark import TaskContext

--- a/python/tests/test_approximate_nearest_neighbors.py
+++ b/python/tests/test_approximate_nearest_neighbors.py
@@ -151,6 +151,20 @@ def test_example(
         assert obj._cuml_params["algo_params"] == algoParams
 
 
+@pytest.mark.slow
+def test_empty_dataframe() -> None:
+    gpu_knn = ApproximateNearestNeighbors()
+    gpu_knn = gpu_knn.setInputCol("features").setK(1)
+    with CleanSparkSession() as spark:
+        schema = f"features array<float>, metadata string"
+        item_df = spark.createDataFrame([], schema)
+        gpu_model = gpu_knn.fit(item_df)
+
+        query_df = spark.createDataFrame([], schema="features array<float>")
+        (_, _, knn_df_empty) = gpu_model.kneighbors(query_df)
+        knn_df_empty.show()
+
+
 def test_example_cosine() -> None:
     gpu_number = 1
     X = [

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -129,6 +129,7 @@ def func_test_example_no_id(
         (item_df_withid, query_df_withid, knn_df) = gpu_model.kneighbors(query_df)
         item_df_withid.show()
         query_df_withid.show()
+        knn_df = knn_df.cache()
         knn_df.show()
 
         # check knn results
@@ -180,6 +181,7 @@ def func_test_example_no_id(
         else:
             knnjoin_df = gpu_model.approxSimilarityJoin(query_df, distCol="distCol")
 
+        knnjoin_df = knnjoin_df.cache()
         knnjoin_df.show()
 
         assert len(knnjoin_df.dtypes) == 3
@@ -274,6 +276,9 @@ def func_test_example_no_id(
         (_, _, knn_df_empty) = gpu_model.kneighbors(df_empty)
         knn_df_empty.show()
 
+        knn_df.unpersist()
+        knnjoin_df.unpersist()
+
         return gpu_knn, gpu_model
 
 
@@ -323,6 +328,8 @@ def func_test_example_with_id(
         item_df_withid, query_df_withid, knn_df = gpu_model.kneighbors(query_df)
         item_df_withid.show()
         query_df_withid.show()
+
+        knn_df = knn_df.cache()
         knn_df.show()
 
         distances_df = knn_df.select("distances")
@@ -346,6 +353,7 @@ def func_test_example_with_id(
         else:
             knnjoin_df = gpu_model.approxSimilarityJoin(query_df, distCol="distCol")
 
+        knnjoin_df = knnjoin_df.cache()
         knnjoin_df.show()
 
         assert len(knnjoin_df.dtypes) == 3
@@ -374,6 +382,8 @@ def func_test_example_with_id(
         (_, _, knn_df_empty) = gpu_model.kneighbors(df_empty)
         knn_df_empty.show()
 
+        knn_df.unpersist()
+        knnjoin_df.unpersist()
         return (gpu_knn, gpu_model)
 
 

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -4,7 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 from _pytest.logging import LogCaptureFixture
+from pyspark.ml.linalg import VectorUDT
 from pyspark.sql import DataFrame
+from pyspark.sql.types import LongType, StructField, StructType
 from sklearn.datasets import make_blobs
 
 from spark_rapids_ml.core import alias
@@ -267,6 +269,11 @@ def func_test_example_no_id(
         (_, _, knn_df_v2) = gpu_model_v2.kneighbors(query_df)
         assert knn_df_v2.collect() == knn_df.collect()
 
+        # test kneighbors on empty dataframe
+        df_empty = spark.createDataFrame([], schema="features array<float>")
+        (_, _, knn_df_empty) = gpu_model.kneighbors(df_empty)
+        knn_df_empty.show()
+
         return gpu_knn, gpu_model
 
 
@@ -361,6 +368,11 @@ def func_test_example_with_id(
         assert_indices_equal(reconstructed_knn_indices)
         reconstructed_query_ids = [r.query_id for r in reconstructed_rows]
         assert reconstructed_query_ids == [201, 202, 203, 204, 205]
+
+        # test kneighbors on empty dataframe without id column
+        df_empty = spark.createDataFrame([], schema="features array<float>")
+        (_, _, knn_df_empty) = gpu_model.kneighbors(df_empty)
+        knn_df_empty.show()
 
         return (gpu_knn, gpu_model)
 

--- a/python/tests/test_nearest_neighbors.py
+++ b/python/tests/test_nearest_neighbors.py
@@ -126,6 +126,12 @@ def func_test_example_no_id(
         with pytest.raises(NotImplementedError):
             gpu_model.save(tmp_path + "/knn_model")
 
+        # test kneighbors on empty query dataframe
+        df_empty = spark.createDataFrame([], schema="features array<float>")
+        (_, _, knn_df_empty) = gpu_model.kneighbors(df_empty)
+        knn_df_empty.show()
+
+        # test kneighbors on normal query dataframe
         (item_df_withid, query_df_withid, knn_df) = gpu_model.kneighbors(query_df)
         item_df_withid.show()
         query_df_withid.show()
@@ -271,11 +277,6 @@ def func_test_example_no_id(
         (_, _, knn_df_v2) = gpu_model_v2.kneighbors(query_df)
         assert knn_df_v2.collect() == knn_df.collect()
 
-        # test kneighbors on empty dataframe
-        df_empty = spark.createDataFrame([], schema="features array<float>")
-        (_, _, knn_df_empty) = gpu_model.kneighbors(df_empty)
-        knn_df_empty.show()
-
         knn_df.unpersist()
         knnjoin_df.unpersist()
 
@@ -325,6 +326,13 @@ def func_test_example_with_id(
         gpu_knn = gpu_knn.setK(topk)
 
         gpu_model = gpu_knn.fit(data_df)
+
+        # test kneighbors on empty query dataframe with id column
+        df_empty = spark.createDataFrame([], schema="id long, features array<float>")
+        (_, _, knn_df_empty) = gpu_model.kneighbors(df_empty)
+        knn_df_empty.show()
+
+        # test kneighbors on normal query dataframe
         item_df_withid, query_df_withid, knn_df = gpu_model.kneighbors(query_df)
         item_df_withid.show()
         query_df_withid.show()
@@ -376,11 +384,6 @@ def func_test_example_with_id(
         assert_indices_equal(reconstructed_knn_indices)
         reconstructed_query_ids = [r.query_id for r in reconstructed_rows]
         assert reconstructed_query_ids == [201, 202, 203, 204, 205]
-
-        # test kneighbors on empty dataframe without id column
-        df_empty = spark.createDataFrame([], schema="features array<float>")
-        (_, _, knn_df_empty) = gpu_model.kneighbors(df_empty)
-        knn_df_empty.show()
 
         knn_df.unpersist()
         knnjoin_df.unpersist()


### PR DESCRIPTION
For both ANN and KNN:
(1) Support query_df is an empty dataframe

For ANN:
(1) Support item_df is an empty dataframe (root cause of triggering "no object to concat" error from pd.concat)

For KNN: 
(1) Select relevant columns (id, features) before calling union on query_df and item_df to avoid schema mismatch error 