### PR TITLE
Enable UMAP to properly handle sparse data

### DIFF
--- a/python/benchmark/benchmark/bench_kmeans.py
+++ b/python/benchmark/benchmark/bench_kmeans.py
@@ -192,17 +192,6 @@ class BenchmarkKMeans(BenchmarkBase):
 
             cluster_centers = gpu_model.cluster_centers_
 
-            # temporary patch for DB with spark-rapids plugin
-            # this part is not timed so overhead is not critical, but should be reverted
-            # once https://github.com/NVIDIA/spark-rapids/issues/10770 is fixed
-            db_version = os.environ.get("DATABRICKS_RUNTIME_VERSION")
-            if db_version:
-                dim = len(cluster_centers[0])
-                # inject unsupported expr (slice) that is essentially a noop
-                df_for_scoring = df_for_scoring.select(
-                    F.slice(feature_col, 1, dim).alias(feature_col), output_col
-                )
-
         if num_cpus > 0:
             from pyspark.ml.clustering import KMeans as SparkKMeans
 

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -751,7 +751,8 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                 concated_nnz = sum(triplet[0].nnz for triplet in inputs)  # type: ignore
                 if concated_nnz > np.iinfo(np.int32).max:
                     logger.warn(
-                        "the number of non-zero values of a partition is larger than the int32 index dtype of cupyx csr_matrix"
+                        f"The number of non-zero values of a partition exceeds the int32 index dtype of cupyx csr_matrix. \
+                        cupyx currently does not promote the dtype to int64 when concatenated; keeping as scipy to avoid overflow."
                     )
                 else:
                     inputs = [

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -751,8 +751,9 @@ class _CumlCaller(_CumlParams, _CumlCommon):
                 concated_nnz = sum(triplet[0].nnz for triplet in inputs)  # type: ignore
                 if concated_nnz > np.iinfo(np.int32).max:
                     logger.warn(
-                        f"The number of non-zero values of a partition exceeds the int32 index dtype of cupyx csr_matrix. \
-                        cupyx currently does not promote the dtype to int64 when concatenated; keeping as scipy to avoid overflow."
+                        f"The number of non-zero values of a partition exceeds the int32 index dtype. \
+                        cupyx csr_matrix currently does not promote the dtype to int64 when concatenated; \
+                        keeping as scipy csr_matrix to avoid overflow."
                     )
                 else:
                     inputs = [

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -1340,7 +1340,7 @@ class UMAPModel(_CumlModelWithColumns, UMAPClass, _UMAPCumlParams):
                 "data": _chunk_and_broadcast(
                     spark.sparkContext, self.raw_data_.data, self.BROADCAST_LIMIT
                 ),
-            }
+            }  # NOTE: CSR chunks are not independently meaningful; do not use until recombined.
         else:
             broadcast_raw_data = _chunk_and_broadcast(
                 spark.sparkContext, self.raw_data_, self.BROADCAST_LIMIT

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -1599,7 +1599,7 @@ class _CumlModelReaderNumpy(_CumlModelReader):
             if isinstance(value, str) and value.endswith(".npz"):
                 npz_data = np.load(value)
                 if value.endswith("csr_.npz"):
-
+                    # Handle sparse raw data - npz file contains separate arrays for CSR attributes
                     def _get_sorted_data_keys(
                         npz_data: np.lib.npyio.NpzFile, csr_key: str
                     ) -> List[str]:
@@ -1613,7 +1613,6 @@ class _CumlModelReaderNumpy(_CumlModelReader):
                     indices_keys = _get_sorted_data_keys(npz_data, "indices")
                     indptr_keys = _get_sorted_data_keys(npz_data, "indptr")
                     data_keys = _get_sorted_data_keys(npz_data, "data")
-
                     raw_data_dict = {
                         "indices": [
                             spark.sparkContext.broadcast(npz_data[key])
@@ -1628,7 +1627,6 @@ class _CumlModelReaderNumpy(_CumlModelReader):
                             for key in data_keys
                         ],
                     }
-
                     model_attr_dict[key] = raw_data_dict
                 else:
                     chunks = [npz_data[f"{key}_{i}"] for i in range(len(npz_data))]

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -912,7 +912,7 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
         num_workers: Optional[int] = None,
         enable_sparse_data_optim: Optional[
             bool
-        ] = None,  # TODO: reuses 'vector -> sparse csr' conversion code, but will enable sparse data if first row is sparse. maybe have logic specific to UMAP?
+        ] = None,  # TBD: reuses 'vector -> sparse csr' conversion code, but will enable sparse data if first row is sparse for any metric. maybe set False by default, and None for 'jaccard'?
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -1369,7 +1369,7 @@ class UMAPModel(_CumlModel, UMAPClass, _UMAPCumlParams):
                 # scipy csr matrix to dense numpy array
                 df = df.toarray()  # type: ignore
                 """
-                TODO: or, we can convert this back to pyspark SparseVector so it matches the user input? e.g.,
+                TBD: we may want to convert this back to pyspark SparseVector so it matches the user input, e.g.,
                 vector_udt_rows = [
                     SparseVector(df.shape[1], row.indices, row.data) for row in df
                 ]

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -1153,8 +1153,9 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
                 concated_nnz = sum(triplet[0].nnz for triplet in inputs)  # type: ignore
                 if concated_nnz > np.iinfo(np.int32).max:
                     logger.warn(
-                        f"The number of non-zero values of a partition exceeds the int32 index dtype of cupyx csr_matrix. \
-                        cupyx currently does not promote the dtype to int64 when concatenated; keeping as scipy to avoid overflow."
+                        f"The number of non-zero values of a partition exceeds the int32 index dtype. \
+                        cupyx csr_matrix currently does not promote the dtype to int64 when concatenated; \
+                        keeping as scipy csr_matrix to avoid overflow."
                     )
                 else:
                     inputs = [

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -1049,7 +1049,7 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
                         )
                         for i in range(num_chunks)
                     ],
-                }  # NOTE: CSR chunks are not inherently meaningful; do not use until recombined
+                }  # NOTE: CSR chunks are not independently meaningful; do not use until recombined
 
             else:
                 # should never get here
@@ -1063,8 +1063,9 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
             spark.sparkContext, raw_data, self.BROADCAST_LIMIT
         )
 
+        assert isinstance(broadcast_embeddings, list)
         model = UMAPModel(
-            embedding_=broadcast_embeddings,  # type: ignore
+            embedding_=broadcast_embeddings,
             raw_data_=broadcast_raw_data,
             sparse_fit=self._sparse_fit,
             n_cols=self._n_cols,

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -1329,7 +1329,7 @@ class UMAPModel(_CumlModelWithColumns, UMAPClass, _UMAPCumlParams):
             spark.sparkContext, self.embedding_, self.BROADCAST_LIMIT
         )
 
-        if sparse_fit:
+        if isinstance(self.raw_data_, scipy.sparse.csr_matrix):
             broadcast_raw_data = {
                 "indices": _chunk_and_broadcast(
                     spark.sparkContext, self.raw_data_.indices, self.BROADCAST_LIMIT
@@ -1344,7 +1344,7 @@ class UMAPModel(_CumlModelWithColumns, UMAPClass, _UMAPCumlParams):
         else:
             broadcast_raw_data = _chunk_and_broadcast(
                 spark.sparkContext, self.raw_data_, self.BROADCAST_LIMIT
-            )
+            )  # type: ignore
 
         def _construct_umap() -> CumlT:
             import cupy as cp

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -501,7 +501,17 @@ def test_umap_build_algo(gpu_number: int) -> None:
 def test_umap_sparse_vector(
     n_rows: int, n_cols: int, nnz: int, gpu_number: int
 ) -> None:
+    import pyspark
+    from packaging import version
     from pyspark.ml.linalg import SparseVector
+
+    if version.parse(pyspark.__version__) < version.parse("3.4.0"):
+        import logging
+
+        err_msg = "pyspark < 3.4 is detected. Cannot import pyspark `unwrap_udt` function for SparseVector. "
+        "The test case will be skipped. Please install pyspark>=3.4."
+        logging.info(err_msg)
+        return
 
     with CleanSparkSession() as spark:
         data = []

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -495,9 +495,9 @@ def test_umap_build_algo(gpu_number: int) -> None:
         assert trust_diff <= 0.15
 
 
-@pytest.mark.parametrize("n_rows", [1000])
-@pytest.mark.parametrize("n_cols", [8, 64])
-@pytest.mark.parametrize("nnz", [3, 5])
+@pytest.mark.parametrize("n_rows", [3000])
+@pytest.mark.parametrize("n_cols", [64, 128])
+@pytest.mark.parametrize("nnz", [7, 12])
 def test_umap_sparse_vector(
     n_rows: int, n_cols: int, nnz: int, gpu_number: int, tmp_path: str
 ) -> None:


### PR DESCRIPTION
Addressing [bug](https://nvbugspro.nvidia.com/bug/4937596) found by QA, where UMAP did not properly handle sparse inputs for 'jaccard' metric. 

### Changes:
#### Handling sparse data:
- Convert UMAP input data to CSR matrix in case of SparseVectors by inheriting enable_sparse_data_optim code.
- Return and store "raw_data" attribute in dict of lists containing the CSR attributes after fit. 
- Chunk and broadcast each CSR attribute independently, store result within dict.
- Fixed bug where UMAP was inheriting from the wrong CumlModel and was returning a new dataframe, rather than adding columns to the input dataframe. 
#### Reading/writing:
- Added logic to save/load CSR array components.
- Refactored to save model attributes as single compressed .npz file for all chunks (rather than separate .npy files) - requires compression time but less disk space. 
#### Testing:
- Added test for sparse inputs.
- Added test for model persistence in sparse case, including when data is saved/loaded in chunks. 

### Todos:
These features can be targeted for 24.12:
- Extend SparseDataGen to generate binary sparse dataset for testing jaccard metric (can be reused for exact/approx KNN)
- Refactor UMAP model persistence to enable saving/loading arrays to cloud storage (e.g., put arrays into a spark dataframe and use Spark dataframe writer)
- Chunking by bytes/row currently rests on the assumption of relatively uniform memory distribution - add better handling of skewed data.