### PR TITLE
address python workers not exiting properly after failures

### DIFF
--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -775,6 +775,14 @@ class _CumlCaller(_CumlParams, _CumlCommon):
 
                 logger.info("Invoking cuml fit")
 
+                # pyspark uses sighup to kill python workers gracefully, and for some reason
+                # the signal handler for sighup needs to be explicitly reset at this point
+                # to avoid having SIGHUP be swallowed during a usleep call in the nccl library.
+                # this helps avoid zombie surviving python workers when some workers fail.
+                import signal
+
+                signal.signal(signal.SIGHUP, signal.SIG_DFL)
+
                 # call the cuml fit function
                 # *note*: cuml_fit_func may delete components of inputs to free
                 # memory.  do not rely on inputs after this call.


### PR DESCRIPTION
This eliminates zombie workers on my workstation when I try to run the benchmark script on my two gpu cards, only one of which supports the app.   The bad gpu worker fails and exits, while, before this change, the good gpu python worker would hang forever.   With this change, the good worker also exists.

Would be good to test other scenarios.