### PR TITLE
Quick fix: CUDA 12 classifier [skip ci]

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,12 +23,12 @@ classifiers = [
     "Environment :: GPU :: NVIDIA CUDA :: 11.7",
     "Environment :: GPU :: NVIDIA CUDA :: 11.8",
     "Environment :: GPU :: NVIDIA CUDA :: 12",
-    "Environment :: GPU :: NVIDIA CUDA :: 12.0",
-    "Environment :: GPU :: NVIDIA CUDA :: 12.1",
-    "Environment :: GPU :: NVIDIA CUDA :: 12.2",
-    "Environment :: GPU :: NVIDIA CUDA :: 12.3",
-    "Environment :: GPU :: NVIDIA CUDA :: 12.4",
-    "Environment :: GPU :: NVIDIA CUDA :: 12.5",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.0",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.1",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.2",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.3",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.4",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.5",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Update CUDA 12 classifiers in `pyproject.toml` to fix error of uploading python package to Test.PyPI.