### PR TITLE
fix rmm managed memory resource initialization to resolve some intermittent …

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ First, install RAPIDS cuML per [these instructions](https://rapids.ai/start.html
 ```bash
 conda create -n rapids-24.10 \
     -c rapidsai -c conda-forge -c nvidia \
-    cuml=24.10 cuvs=24.10 python=3.10 cuda-version=11.8
+    cuml=24.10 cuvs=24.10 python=3.10 cuda-version=11.8 numpy~=1.0
 ```
 
 **Note**: while testing, we recommend using conda or docker to simplify installation and isolate your environment while experimenting.  Once you have a working environment, you can then try installing directly, if necessary.

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -75,6 +75,7 @@ from .metrics import EvalMetricInfo
 from .params import _CumlParams
 from .utils import (
     _ArrayOrder,
+    _configure_memory_resource,
     _get_gpu_id,
     _get_spark_session,
     _is_local,
@@ -707,18 +708,8 @@ class _CumlCaller(_CumlParams, _CumlCommon):
             # set gpu device
             _CumlCommon._set_gpu_device(context, is_local)
 
-            if cuda_managed_mem_enabled:
-                import rmm
-                from rmm.allocators.cupy import rmm_cupy_allocator
-
-                # avoid initializing these twice to avoid downstream segfaults and other cuda memory errors
-                if not type(rmm.mr.get_current_device_resource()) == type(
-                    rmm.mr.ManagedMemoryResource()
-                ):
-                    rmm.mr.set_current_device_resource(rmm.mr.ManagedMemoryResource())
-
-                if not cp.cuda.get_allocator().__name__ == rmm_cupy_allocator.__name__:
-                    cp.cuda.set_allocator(rmm_cupy_allocator)
+            # must do after setting gpu device
+            _configure_memory_resource(cuda_managed_mem_enabled)
 
             _CumlCommon._initialize_cuml_logging(cuml_verbose)
 
@@ -1384,19 +1375,8 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
 
             _CumlCommon._set_gpu_device(context, is_local, True)
 
-            if cuda_managed_mem_enabled:
-                import cupy as cp
-                import rmm
-                from rmm.allocators.cupy import rmm_cupy_allocator
-
-                # avoid initializing these twice to avoid downstream segfaults and other cuda memory errors
-                if not type(rmm.mr.get_current_device_resource()) == type(
-                    rmm.mr.ManagedMemoryResource()
-                ):
-                    rmm.mr.set_current_device_resource(rmm.mr.ManagedMemoryResource())
-
-                if not cp.cuda.get_allocator().__name__ == rmm_cupy_allocator.__name__:
-                    cp.cuda.set_allocator(rmm_cupy_allocator)
+            # must do after setting gpu device
+            _configure_memory_resource(cuda_managed_mem_enabled)
 
             # Construct the cuml counterpart object
             cuml_instance = construct_cuml_object_func()
@@ -1564,12 +1544,21 @@ class _CumlModelWithColumns(_CumlModel):
 
         output_schema = self._out_schema(dataset.schema)
 
+        cuda_managed_mem_enabled = (
+            _get_spark_session().conf.get("spark.rapids.ml.uvm.enabled", "false")
+            == "true"
+        )
+        if cuda_managed_mem_enabled:
+            get_logger(self.__class__).info("CUDA managed memory enabled.")
+
         @pandas_udf(output_schema)  # type: ignore
         def predict_udf(iterator: Iterator[pd.DataFrame]) -> Iterator[pd.Series]:
             from pyspark import TaskContext
 
             context = TaskContext.get()
             _CumlCommon._set_gpu_device(context, is_local, True)
+            # must do after setting gpu device
+            _configure_memory_resource(cuda_managed_mem_enabled)
             cuml_objects = construct_cuml_object_func()
             cuml_object = (
                 cuml_objects[0] if isinstance(cuml_objects, list) else cuml_objects

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -1114,8 +1114,14 @@ class UMAP(UMAPClass, _CumlEstimatorSupervised, _UMAPCumlParams):
                 import rmm
                 from rmm.allocators.cupy import rmm_cupy_allocator
 
-                rmm.reinitialize(managed_memory=True)
-                cp.cuda.set_allocator(rmm_cupy_allocator)
+                # avoid initializing these twice to avoid downstream segfaults and other cuda memory errors
+                if not type(rmm.mr.get_current_device_resource()) == type(
+                    rmm.mr.ManagedMemoryResource()
+                ):
+                    rmm.mr.set_current_device_resource(rmm.mr.ManagedMemoryResource())
+
+                if not cp.cuda.get_allocator().__name__ == rmm_cupy_allocator.__name__:
+                    cp.cuda.set_allocator(rmm_cupy_allocator)
 
             _CumlCommon._initialize_cuml_logging(cuml_verbose)
 

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -144,6 +144,21 @@ def _get_gpu_id(task_context: TaskContext) -> int:
     return gpu_id
 
 
+def _configure_memory_resource(uvm_enabled: bool = False) -> None:
+    import cupy as cp
+    import rmm
+    from rmm.allocators.cupy import rmm_cupy_allocator
+
+    if uvm_enabled:
+        if not type(rmm.mr.get_current_device_resource()) == type(
+            rmm.mr.ManagedMemoryResource()
+        ):
+            rmm.mr.set_current_device_resource(rmm.mr.ManagedMemoryResource())
+
+        if not cp.cuda.get_allocator().__name__ == rmm_cupy_allocator.__name__:
+            cp.cuda.set_allocator(rmm_cupy_allocator)
+
+
 def _get_default_params_from_func(
     func: Callable, unsupported_set: List[str] = []
 ) -> Dict[str, Any]:


### PR DESCRIPTION
…memory issues

Looks like rmm.reinitialize destroys memory resources assigned to all other devices besides the current device.  This way of initializing as in this PR and doing only once per process avoids this.  I think the intermittent cuda errors were due to hit or miss uses of destroyed resources on the c++ api rmm operations.   So this should address the issue.

Also, in umap, current device was set before the memory resource was initialized.  Needs to be the other way around.

also pin numpy < 1 in readme