### PR TITLE
Provide schemas to createDataFrame for backwards compatibility

### DIFF
--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Numpy support for createDataFrame was [introduced in PySpark 3.4.0](https://github.com/apache/spark/pull/36793); previous versions require PDF with schema. 
This resolves #815 . Tested against PySpark 3.2.1. 