### PR TITLE
fix hang in pyspark-rapids shell

### DIFF
--- a/python/src/spark_rapids_ml/pyspark_rapids.py
+++ b/python/src/spark_rapids_ml/pyspark_rapids.py
@@ -33,6 +33,10 @@ def main_cli() -> None:
             output_str = output_str.replace("pyspark", "pyspark-rapids")
             print(output_str, file=sys.stderr)
             exit(0)
+        elif sys.argv[i] in ["--verbose", "-v", "--supervise"]:
+            i += 1
+        else:
+            i += 2
 
     command_line = "pyspark " + " ".join(sys.argv[1:])
     env = dict(os.environ)


### PR DESCRIPTION
broke while copy pasting.

Not clear how to test this script in ci.

cat script.py | pyspark doesn't work as expected and as a result neither does cat script.py | pyspark-rapids.