### PR TITLE
Revert "Update pooling confs to use spark.rapids.memory.gpu.pool"

### DIFF
--- a/notebooks/aws-emr/init-configurations.json
+++ b/notebooks/aws-emr/init-configurations.json
@@ -57,7 +57,7 @@
             "spark.sql.adaptive.enabled":"false",
             "spark.python.worker.reuse":"true",
             "spark.rapids.memory.gpu.minAllocFraction":"0.0001",
-            "spark.rapids.memory.gpu.pool":"NONE",
+            "spark.rapids.memory.gpu.pooling.enabled":"false",
             "spark.rapids.sql.explain":"ALL",
             "spark.rapids.memory.gpu.reserve":"20",
             "spark.rapids.sql.python.gpu.enabled":"true",

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -33,7 +33,7 @@ If you already have a Databricks account, you can run the example notebooks on a
       spark.plugins com.nvidia.spark.SQLPlugin
       spark.locality.wait 0s
       spark.sql.cache.serializer com.nvidia.spark.ParquetCachedBatchSerializer
-      spark.rapids.memory.gpu.pool NONE
+      spark.rapids.memory.gpu.pooling.enabled false
       spark.rapids.sql.explain ALL
       spark.rapids.memory.gpu.reserve 20
       spark.sql.execution.sortBeforeRepartition false

--- a/notebooks/dataproc/README.md
+++ b/notebooks/dataproc/README.md
@@ -57,7 +57,7 @@ If you already have a Dataproc account, you can run the example notebooks on a D
   spark:spark.locality.wait=0,\
   spark:spark.sql.execution.arrow.pyspark.enabled=true,\
   spark:spark.sql.execution.arrow.maxRecordsPerBatch=100000,\
-  spark:spark.rapids.memory.gpu.pool=NONE \
+  spark:spark.rapids.memory.gpu.pooling.enabled=false \
   --bucket ${GCS_BUCKET} \
   --enable-component-gateway \
   --subnet=default \

--- a/python/benchmark/databricks/gpu_etl_cluster_spec.sh
+++ b/python/benchmark/databricks/gpu_etl_cluster_spec.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/benchmark/databricks/gpu_etl_cluster_spec.sh
+++ b/python/benchmark/databricks/gpu_etl_cluster_spec.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ cat <<EOF
         "spark.plugins": "com.nvidia.spark.SQLPlugin",
         "spark.locality.wait": "0s",
         "spark.sql.cache.serializer": "com.nvidia.spark.ParquetCachedBatchSerializer",
-        "spark.rapids.memory.gpu.pool": "NONE",
+        "spark.rapids.memory.gpu.pooling.enabled": "false",
         "spark.rapids.sql.explain": "ALL",
         "spark.sql.execution.sortBeforeRepartition": "false",
         "spark.rapids.sql.python.gpu.enabled": "true",

--- a/python/benchmark/databricks/run_benchmark.sh
+++ b/python/benchmark/databricks/run_benchmark.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/benchmark/databricks/run_benchmark.sh
+++ b/python/benchmark/databricks/run_benchmark.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/benchmark/dataproc/run_benchmark.sh
+++ b/python/benchmark/dataproc/run_benchmark.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/benchmark/dataproc/run_benchmark.sh
+++ b/python/benchmark/dataproc/run_benchmark.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ gpu_args=$(cat <<EOF
 --num_gpus=2 \
 --spark_confs spark.executor.resource.gpu.amount=1 \
 --spark_confs spark.task.resource.gpu.amount=1 \
---spark_confs spark.rapids.memory.gpu.pool=NONE
+--spark_confs spark.rapids.memory.gpu.pooling.enabled=false
 EOF
 )
 

--- a/python/run_benchmark.sh
+++ b/python/run_benchmark.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ cat <<EOF
 --spark_confs spark.plugins=com.nvidia.spark.SQLPlugin \
 --spark_confs spark.locality.wait=0s \
 --spark_confs spark.sql.cache.serializer=com.nvidia.spark.ParquetCachedBatchSerializer \
---spark_confs spark.rapids.memory.gpu.pool=NONE \
+--spark_confs spark.rapids.memory.gpu.pooling.enabled=false \
 --spark_confs spark.rapids.sql.explain=ALL \
 --spark_confs spark.sql.execution.sortBeforeRepartition=false \
 --spark_confs spark.rapids.sql.format.parquet.reader.type=MULTITHREADED \

--- a/python/run_benchmark.sh
+++ b/python/run_benchmark.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Reverts https://github.com/NVIDIA/spark-rapids-ml/pull/842. rapids.daemon python workers do not respect the new pooling configs when `spark.rapids.sql.python.gpu.enabled=true` (see [this issue](https://github.com/NVIDIA/spark-rapids/issues/12228)); need to use old config to disable pooling.