### PR TITLE
Compatibility fixes for cuml 25.02.1 patch

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -1451,7 +1451,7 @@ class LogisticRegressionModel(
 
                 data = {}
 
-                scores = lr.decision_function(pdf).T
+                scores = lr.decision_function(pdf)
                 assert isinstance(scores, cp.ndarray)
                 _num_classes = max(scores.shape[1] if len(scores.shape) == 2 else 2, 2)
 

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -115,7 +115,7 @@ class KMeansClass(_CumlClass):
             "verbose": False,
             "random_state": 1,
             "init": "scalable-k-means++",
-            "n_init": 1,
+            "n_init": "warn",  # See https://github.com/rapidsai/cuml/pull/6142 - this needs to be updated to "auto" for cuml 25.04
             "oversampling_factor": 2.0,
             "max_samples_per_batch": 32768,
         }


### PR DESCRIPTION
Relevant PRs: [cuml 6235](https://github.com/rapidsai/cuml/pull/6235), [cuml 6142](https://github.com/rapidsai/cuml/pull/6142), for sklearn compatibility.
- n_init defaults to "warn" as a future warning for the user (still ends up defaulting to 1), since the default will change to "auto" in 25.04 to match sklearn. 
- LR output shape changed from (n_classes, n_rows) to (n_rows, n_classes) to match sklearn. 

Resolves #860 