### PR TITLE
Require spark.sql.execution.arrow.pyspark.enabled=true [skip ci]

### DIFF
--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -10,3 +10,4 @@ The following configurations can be supplied as Spark properties.
 | :-------------- | :------ | :------- |
 | spark.rapids.ml.uvm.enabled | false | if set to true, enables [CUDA unified virtual memory](https://developer.nvidia.com/blog/unified-memory-cuda-beginners/) (aka managed memory) during estimator.fit() operations to allow processing of larger datasets than would fit in GPU memory|
 
+Since the algorithms rely heavily on Pandas UDFs, we also require `spark.sql.execution.arrow.pyspark.enabled=true` to ensure efficient data transfer between the JVM and Python processes. 


### PR DESCRIPTION
Make this conf suggestion explicit, since UMAP relies on it to write attributes. See [this thread](https://github.com/NVIDIA/spark-rapids-ml/pull/823#discussion_r1914157957). 