### PR TITLE
cpu fallback for unsupported params

### DIFF
--- a/docs/site/compatibility.md
+++ b/docs/site/compatibility.md
@@ -8,18 +8,18 @@ nav_order: 3
 
 The following table shows the currently supported algorithms.  The goal is to expand this over time with support from the underlying RAPIDS cuML libraries.  If you would like support for a specific algorithm, please file a [git issue](https://github.com/NVIDIA/spark-rapids-ml/issues) to help us prioritize.
 
-| Supported Algorithms   | Python | Scala (Deprecated) |
-| :--------------------- | :----: | :---: |
-| CrossValidator         |   √    |       |
-| DBSCAN (*)             |   √    |       |
-| KMeans                 |   √    |       |
-| approx/exact k-NN (*)  |   √    |       |
-| LinearRegression       |   √    |       |
-| LogisticRegression     |   √    |       | 
-| PCA                    |   √    |   √   |
-| RandomForestClassifier |   √    |       |
-| RandomForestRegressor  |   √    |       |
-| UMAP (*)               |   √    |       |
+| Supported Algorithms   | Python |
+| :--------------------- | :----: |
+| CrossValidator         |   √    |
+| DBSCAN (*)             |   √    |
+| KMeans                 |   √    |
+| approx/exact k-NN (*)  |   √    |
+| LinearRegression       |   √    |
+| LogisticRegression     |   √    |
+| PCA                    |   √    |
+| RandomForestClassifier |   √    |
+| RandomForestRegressor  |   √    |
+| UMAP (*)               |   √    |
 
 (*) Notes: 
 - As an alternative to KMeans, we also provide a Spark API for GPU accelerated Density-Based Spatial Clustering of Applications with Noise (DBSCAN), a density based clustering algorithm in the RAPIDS cuML library.

--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -9,6 +9,6 @@ The following configurations can be supplied as Spark properties.
 | Property name   | Default | Meaning  |
 | :-------------- | :------ | :------- |
 | spark.rapids.ml.uvm.enabled | false | if set to true, enables [CUDA unified virtual memory](https://developer.nvidia.com/blog/unified-memory-cuda-beginners/) (aka managed memory) during estimator.fit() operations to allow processing of larger datasets than would fit in GPU memory |
-| spark.rapids.ml.cpu.fallback.enabled | false | if set to true and spark-rapids-ml estimator.fit() is invoked with unsupported parameters or parameter values, the pyspark.ml cpu based estimator.fit() and model.transform() will be run, otherwise an exception is raised (default) |
+| spark.rapids.ml.cpu.fallback.enabled | false | if set to true and spark-rapids-ml estimator.fit() is invoked with unsupported parameters or parameter values, the pyspark.ml cpu based estimator.fit() and model.transform() will be run; if set to false, an exception is raised in this case (default) |
 
 Since the algorithms rely heavily on Pandas UDFs, we also require `spark.sql.execution.arrow.pyspark.enabled=true` to ensure efficient data transfer between the JVM and Python processes. 

--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -8,6 +8,7 @@ The following configurations can be supplied as Spark properties.
 
 | Property name   | Default | Meaning  |
 | :-------------- | :------ | :------- |
-| spark.rapids.ml.uvm.enabled | false | if set to true, enables [CUDA unified virtual memory](https://developer.nvidia.com/blog/unified-memory-cuda-beginners/) (aka managed memory) during estimator.fit() operations to allow processing of larger datasets than would fit in GPU memory|
+| spark.rapids.ml.uvm.enabled | false | if set to true, enables [CUDA unified virtual memory](https://developer.nvidia.com/blog/unified-memory-cuda-beginners/) (aka managed memory) during estimator.fit() operations to allow processing of larger datasets than would fit in GPU memory |
+| spark.rapids.ml.cpu.fallback.enabled | false | if set to true and spark-rapids-ml estimator.fit() is invoked with unsupported parameters or parameter values, the pyspark.ml cpu based estimator.fit() and model.transform() will be run, otherwise an exception is raised (default) |
 
 Since the algorithms rely heavily on Pandas UDFs, we also require `spark.sql.execution.arrow.pyspark.enabled=true` to ensure efficient data transfer between the JVM and Python processes. 

--- a/python/README.md
+++ b/python/README.md
@@ -157,6 +157,7 @@ While the Spark Rapids ML API attempts to mirror the PySpark ML API to minimize 
 - **Unsupported ML Params** - some PySpark ML algorithms have ML Params which do not map directly to their respective cuML implementations.  For these cases, the ML Param default values will be ignored, and if explicitly set by end-user code:
     - a warning will be printed (for non-critical cases that should have minimal impact, e.g. `initSteps`).
     - an exception will be raised (for critical cases that can greatly affect results, e.g. `weightCol`).
+        - this behavior can be changed by setting the Spark config `spark.rapids.ml.cpu.fallback.enabled` (default=`false`) to `true` to cause the corresponding `fit` or `transform` operations to fallback to using baseline CPU Spark MLlib. 
 - **Unsupported methods** - some PySpark ML methods may not map to the underlying cuML implementations, or may not be meaningful for GPUs.  In these cases, an error will be raised if the method is invoked.
 - **cuML parameters** - there may be additional cuML-specific parameters which might be useful for optimizing GPU performance.  These can be supplied to the various class constructors, but they are _not_ exposed via getters and setters to avoid any confusion with the PySpark ML Params.  If needed, they can be observed via the `cuml_params` attribute.
 - **Algorithmic Results** - again, since the GPU implementations are entirely different from their PySpark ML CPU counterparts, there may be slight differences in the produced results.  This can be due to various reasons, including different optimizations, randomized initializations, or algorithm design.  While these differences should be relatively minor, they should still be reviewed in the context of your specific use case to see if they are within acceptable limits.
@@ -211,7 +212,7 @@ A similar `spark_rapids_ml` enabling CLI is included for `pyspark` shell:
 pyspark-rapids --master <master> <other pyspark options>
 ```
 
-For the time being, any methods or attributes not supported by the corresponding accelerated `spark_rapids_ml` objects will result in errors.
+For the time being, any methods or attributes not supported by the corresponding accelerated `spark_rapids_ml` objects will result in errors, or, in the case of unsupported parameters, if `spark.rapids.ml.cpu.fallback.enabled` is set to `true`, will fallback to baseline Spark MLlib running on CPU.
 
 Nearly similar functionality can be enabled in [notebooks](../notebooks/README.md#no-import-change).
 

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -680,13 +680,13 @@ class LogisticRegressionClass(_CumlClass):
             "thresholds": None,
             "standardization": "standardization",
             "weightCol": None,
-            "aggregationDepth": None,
+            "aggregationDepth": "",
             "family": "",  # family can be 'auto', 'binomial' or 'multinomial', cuml automatically detects num_classes
             "lowerBoundsOnCoefficients": None,
             "upperBoundsOnCoefficients": None,
             "lowerBoundsOnIntercepts": None,
             "upperBoundsOnIntercepts": None,
-            "maxBlockSizeInMB": None,
+            "maxBlockSizeInMB": "",
         }
 
     @classmethod

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -1059,7 +1059,6 @@ class DBSCANModel(
         rdd = self._call_cuml_fit_func(
             dataset=dataset,
             partially_collect=False,
-            paramMaps=None,
         )
         rdd = rdd.repartition(default_num_partitions)
 

--- a/python/src/spark_rapids_ml/connect_plugin.py
+++ b/python/src/spark_rapids_ml/connect_plugin.py
@@ -123,7 +123,10 @@ def main(infile: IO, outfile: IO) -> None:
 
             lr = LogisticRegression(**params)
             model: LogisticRegressionModel = lr.fit(df)
-            model_cpu = model.cpu()
+            # if cpu fallback was enabled a pyspark.ml model is returned in which case no need to call cpu()
+            model_cpu = (
+                model.cpu() if isinstance(model, LogisticRegressionModel) else model
+            )
             assert model_cpu._java_obj is not None
             model_targe_id = model_cpu._java_obj._get_object_id().encode("utf-8")
             write_with_length(model_targe_id, outfile)

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -91,6 +91,8 @@ if TYPE_CHECKING:
 
 CumlT = Any
 
+_CumlParamMap = Dict[str, Any]
+
 _SinglePdDataFrameBatchType = Tuple[
     pd.DataFrame, Optional[pd.DataFrame], Optional[pd.DataFrame]
 ]
@@ -416,16 +418,6 @@ class _CumlCommon(MLWritable, MLReadable):
                 raise ValueError(f"invalid value for verbose parameter: {verbose}")
 
             cuml_logger.set_level(log_level)
-
-    def _pyspark_class(self) -> Optional[ABCMeta]:
-        """
-        Subclass should override to return corresponding pyspark.ml class
-        Ex. logistic regression should return pyspark.ml.classification.LogisticRegression
-        Return None if no corresponding class in pyspark, e.g. knn
-        """
-        raise NotImplementedError(
-            "pyspark.ml class corresponding to estimator not specified."
-        )
 
 
 class _CumlCaller(_CumlParams, _CumlCommon):
@@ -904,7 +896,15 @@ class _CumlEstimator(Estimator, _CumlCaller):
             using `paramMaps[index]`. `index` values may not be sequential.
         """
 
+        if self._cpu_fallback():
+            return super().fitMultiple(dataset, paramMaps)
+
         if self._enable_fit_multiple_in_single_pass():
+            for paramMap in paramMaps:
+                if self._cpu_fallback(paramMap):
+                    return super().fitMultiple(dataset, paramMaps)
+
+            # reach here if no cpu fallback
             estimator = self.copy()
 
             def fitMultipleModels() -> List["_CumlModel"]:
@@ -1057,9 +1057,17 @@ class _CumlEstimator(Estimator, _CumlCaller):
 
         return models
 
-    def _fit(self, dataset: DataFrame) -> "_CumlModel":
+    def _fit(self, dataset: DataFrame) -> "Model":
         """fit only 1 model"""
-        return self._fit_internal(dataset, None)[0]
+        if self._pyspark_class() and self._fallback_enabled and self._cpu_fallback():
+            logger = get_logger(self.__class__)
+            logger.warning("Invoking cpu estimator fit().")
+            cpu_class = self._pyspark_class()
+            cpu_est = cpu_class(**{p.name: v for p, v in self.extractParamMap().items() if self.isSet(p) and hasattr(cpu_class, p.name)})  # type: ignore
+            model = cpu_est.fit(dataset)
+            return model
+        else:
+            return self._fit_internal(dataset, None)[0]
 
     def write(self) -> MLWriter:
         return _CumlEstimatorWriter(self)
@@ -1440,9 +1448,14 @@ class _CumlModel(Model, _CumlParams, _CumlCommon):
         :py:class:`pyspark.sql.DataFrame`
             transformed dataset
         """
-        return self._transform_evaluate_internal(
-            dataset, schema=self._out_schema(dataset.schema)
-        )
+
+        # this will catch use of unsupported model setters like setThreshold in logistic regression.
+        if self._fallback_enabled and self._cpu_fallback():
+            return self.cpu().transform(dataset)
+        else:
+            return self._transform_evaluate_internal(
+                dataset, schema=self._out_schema(dataset.schema)
+            )
 
     def write(self) -> MLWriter:
         return _CumlModelWriter(self)

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -687,7 +687,7 @@ class _CumlParams(_CumlClass, HasVerboseParam, Params):
         value_map = self._get_cuml_mapping_value(k, v)
         self._cuml_params[k] = value_map
 
-    def _cpu_fallback(self, params: Optional[Dict[Param, Any]] = None) -> bool:
+    def _use_cpu_fallback(self, params: Optional[Dict[Param, Any]] = None) -> bool:
         param_mapping = self._param_mapping()
         param_value_mapping = self._param_value_mapping()
         fallback = False

--- a/python/src/spark_rapids_ml/params.py
+++ b/python/src/spark_rapids_ml/params.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -28,6 +28,7 @@ from typing import (
 )
 
 from pyspark import SparkContext
+from pyspark.ml import Estimator, Model
 from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark.sql import SparkSession
 from pyspark.sql.dataframe import DataFrame
@@ -244,6 +245,17 @@ class _CumlClass(object):
         run on the driver side without rapids dependencies"""
         raise NotImplementedError()
 
+    @abstractmethod
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        """
+        Subclass should override to return corresponding pyspark.ml class
+        Ex. logistic regression should return pyspark.ml.classification.LogisticRegression
+        Return None if no corresponding class in pyspark, e.g. knn
+        """
+        raise NotImplementedError(
+            "pyspark.ml class corresponding to estimator not specified."
+        )
+
 
 class _CumlParams(_CumlClass, HasVerboseParam, Params):
     """
@@ -254,6 +266,66 @@ class _CumlParams(_CumlClass, HasVerboseParam, Params):
     _cuml_params: Dict[str, Any] = {}
     _num_workers: Optional[int] = None
     _float32_inputs: bool = True
+    _fallback_enabled: bool = False
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.logger = get_logger(self.__class__)
+
+        spark = _get_spark_session()
+        fallback_enabled = spark.conf.get(
+            "spark.rapids.ml.cpu.fallback.enabled", "false"
+        )
+        if fallback_enabled == "false":
+            self._fallback_enabled = False
+        elif fallback_enabled == "true":
+            self._fallback_enabled = True
+        else:
+            raise ValueError(
+                f"unknown value {fallback_enabled} for spark.rapids.ml.cpu.fallback.enabled"
+            )
+        # automatically add/override setters for unsupported params currently left undefined
+        pyspark_class = self._pyspark_class()
+        if pyspark_class:
+            unsupported = [p for p, v in self._param_mapping().items() if v is None]
+            for param in unsupported:
+                setter_name = f"set{param[0].upper()}{param[1:]}"
+
+                # for models, unsupported setters are already defined in our code by including pyspark ml mixins
+                # so only modify those and do not add all unsupported estimator param setters
+                if isinstance(self, Estimator) or (
+                    isinstance(self, Model) and hasattr(self, setter_name)
+                ):
+                    # wrapping setter def in function avoids late closure binding issues with param
+                    def create_gpu_setter(
+                        _param: str,
+                    ) -> Callable[[_CumlParams, Any], _CumlParams]:
+                        def gpu_setter(self: _CumlParams, value: Any) -> _CumlParams:
+                            self._set_params(**{_param: value})
+                            return self
+
+                        return gpu_setter
+
+                    gpu_setter = create_gpu_setter(param)
+                    setattr(self, setter_name, gpu_setter.__get__(self))
+
+                    ## below code adds documentation for 'unsupported' setter and param.
+                    cpu_setter = getattr(pyspark_class, setter_name)
+                    gpu_setter.__annotations__["value"] = cpu_setter.__annotations__[
+                        "value"
+                    ]
+                    gpu_setter.__doc__ = f"""
+                    Sets the value of :py:attr:`{param}`.
+                    This parameter is not supported for GPU acceleration.
+                    If this method is invoked with cpu fallback enabled, fit() and transform() will fallback to cpu,
+                    otherwise, an exception will be raised.
+                    """
+
+                    spark_param = self.getParam(param)
+                    spark_param.doc = (
+                        spark_param.doc
+                        + " This parameter is not supported for GPU acceleration, with fall back to cpu fit() and transform() if set."
+                    )
 
     @property
     def cuml_params(self) -> Dict[str, Any]:
@@ -387,7 +459,7 @@ class _CumlParams(_CumlClass, HasVerboseParam, Params):
             elif self.hasParam(k):
                 # Param is declared as a Spark ML Param
                 self._set(**{str(k): v})  # type: ignore
-                self._set_cuml_param(k, v, silent=False)
+                self._set_cuml_param(k, v, silent=self._fallback_enabled)
             elif k in self.cuml_params:
                 # cuml param
                 self._cuml_params[k] = v
@@ -568,13 +640,16 @@ class _CumlParams(_CumlClass, HasVerboseParam, Params):
             try:
                 self._set_cuml_value(cuml_param, spark_value)
             except ValueError:
-                # create more informative message
-                param_ref_str = (
-                    cuml_param + " or " + spark_param
-                    if cuml_param != spark_param
-                    else spark_param
-                )
-                raise ValueError(f"{param_ref_str} given invalid value {spark_value}")
+                if not self._fallback_enabled:
+                    # create more informative message
+                    param_ref_str = (
+                        cuml_param + " or " + spark_param
+                        if cuml_param != spark_param
+                        else spark_param
+                    )
+                    raise ValueError(
+                        f"{param_ref_str} given an invalid or unsupported value {spark_value}"
+                    )
 
     def _get_cuml_mapping_value(self, k: str, v: Any) -> Any:
         value_map = self._param_value_mapping()
@@ -611,6 +686,25 @@ class _CumlParams(_CumlClass, HasVerboseParam, Params):
         """
         value_map = self._get_cuml_mapping_value(k, v)
         self._cuml_params[k] = value_map
+
+    def _cpu_fallback(self, params: Optional[Dict[Param, Any]] = None) -> bool:
+        param_mapping = self._param_mapping()
+        param_value_mapping = self._param_value_mapping()
+        fallback = False
+        for param, value in (params if params else self.extractParamMap()).items():
+            if param.name in param_mapping:
+                mapped_param = param_mapping[param.name]
+                if (not mapped_param and (self.isSet(param) or params)) or (
+                    mapped_param
+                    and mapped_param in param_value_mapping
+                    and param_value_mapping[mapped_param](value) is None
+                ):
+                    msg = f"Setting Spark Param '{param.name}' to '{value}' is not supported on GPU.  Will fall back to CPU."
+                    logger = get_logger(self.__class__)
+                    logger.warning(msg)
+                    fallback = True
+
+        return fallback
 
 
 class DictTypeConverters(TypeConverters):

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -470,6 +470,18 @@ class LinearRegression(
         """
         return self._set_params(tol=value)
 
+    def setFitIntercept(self, value: bool) -> "LinearRegression":
+        """
+        Sets the value of :py:attr:`fitIntercept`.
+        """
+        return self._set_params(fitIntercept=value)
+
+    def setSolver(self, value: str) -> "LinearRegression":
+        """
+        Sets the value of :py:attr:`solver`.
+        """
+        return self._set_params(solver=value)
+
     def _pre_process_data(
         self, dataset: DataFrame
     ) -> Tuple[

--- a/python/src/spark_rapids_ml/tuning.py
+++ b/python/src/spark_rapids_ml/tuning.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/src/spark_rapids_ml/tuning.py
+++ b/python/src/spark_rapids_ml/tuning.py
@@ -26,6 +26,7 @@ from pyspark.ml.util import DefaultParamsReader
 from pyspark.sql import DataFrame
 
 from .core import _CumlEstimator, _CumlModel
+from .utils import get_logger
 
 
 def _gen_avg_and_std_metrics_(
@@ -102,7 +103,9 @@ class CrossValidator(SparkCrossValidator):
         # fallback if any params are not gpu supported
         for param_map in epm:
             est_tmp = est.copy(param_map)
-            if est_tmp._fallback_enabled and est_tmp._cpu_fallback():
+            if est_tmp._fallback_enabled and est_tmp._use_cpu_fallback():
+                logger = get_logger(self.__class__)
+                logger.warning("Falling back to CPU CrossValidator fit().")
                 return super()._fit(dataset)
 
         numModels = len(epm)

--- a/python/src/spark_rapids_ml/tuning.py
+++ b/python/src/spark_rapids_ml/tuning.py
@@ -99,6 +99,12 @@ class CrossValidator(SparkCrossValidator):
             return super()._fit(dataset)
 
         epm = self.getOrDefault(self.estimatorParamMaps)
+        # fallback if any params are not gpu supported
+        for param_map in epm:
+            est_tmp = est.copy(param_map)
+            if est_tmp._fallback_enabled and est_tmp._cpu_fallback():
+                return super()._fit(dataset)
+
         numModels = len(epm)
         nFolds = self.getOrDefault(self.numFolds)
         metrics_all = [[0.0] * numModels for i in range(nFolds)]
@@ -120,13 +126,13 @@ class CrossValidator(SparkCrossValidator):
             metrics = model._transformEvaluate(datasets[fold][1], eva)
             return fold, metrics, models if collectSubModelsParam else None
 
-        for fold, metrics, subModels in pool.imap_unordered(
+        for fold, metrics, _subModels in pool.imap_unordered(
             inheritable_thread_target(singePassTask), range(nFolds)
         ):
             metrics_all[fold] = metrics
             if collectSubModelsParam:
                 assert subModels is not None
-                subModels[fold] = subModels
+                subModels[fold] = _subModels
 
         metrics, std_metrics = _gen_avg_and_std_metrics_(metrics_all)
 

--- a/python/tests/test_common_estimator.py
+++ b/python/tests/test_common_estimator.py
@@ -112,6 +112,9 @@ class _SparkRapidsMLDummyParams(_CumlParams):
             k=4,
         )
 
+    def _pyspark_class(self) -> Optional[ABCMeta]:
+        return None
+
 
 class SparkRapidsMLDummy(
     SparkRapidsMLDummyClass,
@@ -237,9 +240,6 @@ class SparkRapidsMLDummy(
         assert result.model_attribute_a == 1024
         assert result.model_attribute_b == "hello dummy"
         return SparkRapidsMLDummyModel._from_row(result)
-
-    def _pyspark_class(self) -> Optional[ABCMeta]:
-        return None
 
 
 class SparkRapidsMLDummyModel(

--- a/python/tests/test_kmeans.py
+++ b/python/tests/test_kmeans.py
@@ -517,3 +517,44 @@ def test_parameters_validation() -> None:
             IllegalArgumentException, match="maxIter given invalid value -1"
         ):
             KMeans().setMaxIter(-1).fit(df)
+
+
+@pytest.mark.parametrize("setting_method", ["constructor", "setter"])
+def test_kmeans_cpu_fallback(setting_method: str) -> None:
+    with CleanSparkSession({"spark.rapids.ml.cpu.fallback.enabled": "true"}) as spark:
+        from pyspark.ml import Model
+        from pyspark.ml.linalg import Vectors
+
+        from spark_rapids_ml.core import _CumlModel
+
+        unsupported = [k for k, v in KMeans._param_mapping().items() if v is None]
+        vals_to_try = {
+            "distanceMeasure": "euclidean",
+            "weightCol": "weightscol",
+        }
+
+        assert set(unsupported) == set(vals_to_try.keys())
+        # Add weights column to dataframe
+        data = spark.createDataFrame(
+            [
+                (Vectors.dense(1.0, 0.0), 1.0),
+                (Vectors.dense(1.0, 1.0), 1.0),
+                (Vectors.dense(0.0, 0.0), 1.0),
+                (Vectors.dense(0.0, 1.0), 1.0),
+            ],
+            ["features", "weightscol"],
+        )
+
+        # Test constructor params
+        for param in unsupported:
+            val = vals_to_try[param]
+            if setting_method == "constructor":
+                gpu_kmeans = KMeans(**{param: val})  # type: ignore
+            else:
+                gpu_kmeans = KMeans()
+                setter_name = "set" + param[0].upper() + param[1:]
+                getattr(gpu_kmeans, setter_name)(val)  # type: ignore
+            model = gpu_kmeans.fit(data)
+            getter_name = "get" + param[0].upper() + param[1:]
+            assert getattr(model, getter_name)() == val
+            assert not isinstance(model, _CumlModel) and isinstance(model, Model)


### PR DESCRIPTION
Notes:

- also fixes an existing bug in CrossValidator for subModels return.
- adds new config `spark.rapids.ml.cpu.fallback.enabled` to control cpu  fallback behavior.  default is `false` which induces current behavior of raising exceptions when unsupported params are set.
- Fallback is triggered when an unsupported Param or Param value is set in constructor or via setter.
- Previously omitted setters for unsupported params are added dynamically based on unsupported param ground truth.
- If cpu fallback happens for unsupported fit(), returned model is a baseline pyspark.ml model (not spark_rapids_ml).
- Model attributes for gpu fitted models that are impossible to reproduce without fit on cpu (e.g. summary) will continue to trigger errors.
- for CrossValidator, if base estimator or any param sweeps are unsupported, fully falls back to cpu for all sweeps.

