### PR TITLE
Add unit test for connect ml plugin (#883) [skip ci]

### DIFF
--- a/jvm/README.md
+++ b/jvm/README.md
@@ -6,17 +6,6 @@ acceleration for machine learning workloads without requiring changes to the use
 
 ## Environment Setup
 
-- Compile the Spark Rapids ML Connect Plugin
-
-  To compile the plugin, run the following command:
-
-    ``` shell
-    mvn clean package
-    ```
-
-  After compilation, the latest JAR file, `com.nvidia.rapids.ml-<LATEST_VERSION>.jar`, will be
-  available in the `target` directory.
-
 - Install spark-rapids-ml
 
   Follow
@@ -29,6 +18,24 @@ acceleration for machine learning workloads without requiring changes to the use
   from [this site](https://urm.nvidia.com/artifactory/sw-spark-maven-local/org/apache/spark/4.1.0-SNAPSHOT/)
 
   Extract the archive and set the `SPARK_HOME` environment variable to point to the Spark directory.
+
+- Compile the Spark Rapids ML Connect Plugin
+
+  To compile the plugin, run the following command:
+
+    ``` shell
+    mvn clean package -DskipTests
+    ```
+
+  if you would like to compile the plugin and run the unit tests, run the following command:
+
+    ``` shell
+    export PYSPARK_PYTHON=YOUR_PYTHON_PATH_WITH_SPARK_RAPIDS_ML
+    mvn clean package
+    ```
+
+  After compilation, the latest JAR file, `com.nvidia.rapids.ml-<LATEST_VERSION>.jar`, will be
+  available in the `target` directory.
 
 - Install PySpark Connect Client
 

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -3,7 +3,7 @@
   Copyright (c) 2025, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
+  You may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
      http://www.apache.org/licenses/LICENSE-2.0
@@ -30,7 +30,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>2.13.14</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
-        <spark.version>4.0.0-SNAPSHOT</spark.version>
+        <spark.version>4.1.0-SNAPSHOT</spark.version>
+        <!-- Extra JVM arguments for tests (required for Java 17 module system) -->
+        <extraJavaTestArgs>
+            -XX:+IgnoreUnrecognizedVMOptions
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens=java.base/java.io=ALL-UNNAMED
+            --add-opens=java.base/java.net=ALL-UNNAMED
+            --add-opens=java.base/java.nio=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+            --add-opens=java.base/sun.security.action=ALL-UNNAMED
+            --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+        </extraJavaTestArgs>
     </properties>
 
     <dependencies>
@@ -42,13 +57,13 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-connect_2.13</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <artifactId>spark-connect_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
 
@@ -58,62 +73,70 @@
             <version>${scala.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- ScalaTest for unit testing -->
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>3.2.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <!-- Final name of the built JAR -->
         <finalName>${groupId}.${artifactId}-${version}</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
 
+        <plugins>
+
+            <!-- Scala Maven Plugin (adds Scala sources before compile phase) -->
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
                         <goals>
-                            <goal>compile</goal>
+                            <goal>add-source</goal>  <!-- Add Scala source directories -->
+                            <goal>compile</goal>     <!-- Compile Scala sources -->
                             <goal>testCompile</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
 
+            <!-- ScalaTest Maven Plugin (to run Scala tests) -->
             <plugin>
-                <groupId>net.alchim31.maven</groupId>
-                <artifactId>scala-maven-plugin</artifactId>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
                 <configuration>
-                    <javacArgs combine.children="append">
-                        <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
-                        <javacArg>-XDignore.symbol.file</javacArg>
-                    </javacArgs>
-                    <fork>true</fork>
+                    <!-- JVM arguments passed to test process -->
+                    <argLine>-ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>scala-compile-first</id>
-                        <phase>process-resources</phase>
+                        <id>test</id>
+                        <phase>test</phase> <!-- Bind to Maven's test phase -->
                         <goals>
-                            <goal>add-source</goal>
-                            <goal>compile</goal>
+                            <goal>test</goal> <!-- Goal to run ScalaTest tests -->
                         </goals>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
-    <!-- TODO Remove below repositories after spark has released spark 4.0 officially -->
+
+    <!-- Additional repositories (temporary until Spark 4.1 is released) -->
     <repositories>
         <repository>
             <id>apache-snapshots</id>
             <url>https://repository.apache.org/content/repositories/snapshots/</url>
             <snapshots>
-                <enabled>true</enabled>
+                <enabled>true</enabled> <!-- Enable snapshot versions -->
             </snapshots>
             <releases>
-                <enabled>false</enabled>
+                <enabled>false</enabled> <!-- Do not fetch release versions from here -->
             </releases>
         </repository>
     </repositories>

--- a/jvm/src/test/scala/com/nvidia/rapids/ml/SparkRapidsMLSuite.scala
+++ b/jvm/src/test/scala/com/nvidia/rapids/ml/SparkRapidsMLSuite.scala
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.rapids.ml
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.SparkSession
+
+class SparkRapidsMLSuite extends AnyFunSuite with BeforeAndAfterEach {
+  @transient var ss: SparkSession = _
+
+  override def beforeEach(): Unit = {
+    try {
+      ss = SparkSession.builder()
+        .master("local[1]")
+        // TODO add spark-rapids after spark-rapids has supported 4.0
+//        .config("spark.sql.adaptive.enabled", "false")
+//        .config("spark.stage.maxConsecutiveAttempts", "1")
+//        .config("spark.plugins", "com.nvidia.spark.SQLPlugin")
+//        .config("spark.rapids.memory.gpu.pool", "none") // Disable RMM for unit tests.
+        .appName("SparkRapidsML-connect-plugin")
+        .getOrCreate()
+    } finally {
+      super.beforeEach()
+    }
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      if (ss != null) {
+        ss.stop()
+        ss = null
+      }
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  test("RapidsLogisticRegression") {
+    val df = ss.createDataFrame(
+      Seq(
+        (Vectors.dense(1.0, 2.0), 1.0f),
+        (Vectors.dense(1.0, 3.0), 1.0f),
+        (Vectors.dense(2.0, 1.0), 0.0f),
+        (Vectors.dense(3.0, 1.0), 0.0f))
+    ).toDF("test_feature", "class")
+
+    val lr = new RapidsLogisticRegression()
+      .setFeaturesCol("test_feature")
+      .setLabelCol("class")
+      .setMaxIter(23)
+      .setTol(0.03)
+    // .setThreshold(0.51)  // this is going to fail due to spark-rapids-ml has mapped threshold to None
+
+    val model = lr.fit(df)
+
+    assert(model.getFeaturesCol == "test_feature")
+    assert(model.getTol == 0.03)
+    assert(model.getLabelCol == "class")
+    assert(model.getMaxIter == 23)
+  }
+}


### PR DESCRIPTION
The added unit tests are not testing the end-to-end case for the 'connect'. Instead, the tests simply ensure that the functionality of the spark rapids ml JVM estimator/model could work even without 'connect' , behaving like a normal ML operator.

---------