### PR TITLE
Use int64 instead of int32 index dtype for sparse logistic regression on large dataset to avoid array index overflow

### DIFF
--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -1002,6 +1002,7 @@ class LogisticRegression(
             pdesc = PartitionDescriptor.build(
                 [concated.shape[0]],
                 params[param_alias.num_cols],
+                concated.nnz if is_sparse else None,
             )
 
             # Use cupy to standardize dataset as a workaround to gain better numeric stability
@@ -1081,7 +1082,7 @@ class LogisticRegression(
                 logistic_regression.lbfgs_memory = 10
                 logistic_regression.linesearch_max_iter = 20
 
-                if is_sparse and concated.nnz > nnz_limit_for_int32:
+                if is_sparse and pdesc.partition_max_nnz > nnz_limit_for_int32:  # type: ignore
                     logistic_regression._convert_index = np.int64
 
                 logistic_regression.fit(

--- a/python/tests_large/test_large_logistic_regression.py
+++ b/python/tests_large/test_large_logistic_regression.py
@@ -75,6 +75,7 @@ def test_sparse_large(
     n_rows: int = int(1e7),
     n_cols: int = 2200,
     density: float = 0.1,
+    tolerance: float = 0.001,
 ) -> None:
     """
     This test requires minimum 128G CPU memory, 32 GB GPU memory
@@ -90,7 +91,6 @@ def test_sparse_large(
         1.0 if data_shape[0] <= 100000 else 100000 / data_shape[0]
     )
     n_classes = 8
-    tolerance = 0.001
     est_params: Dict[str, Any] = {
         "regParam": 0.02,
         "maxIter": 10,
@@ -174,7 +174,7 @@ def test_sparse_large(
 
 
 def test_sparse_int64_mg() -> None:
-    test_sparse_large(multi_gpus=True)
+    test_sparse_large(multi_gpus=True, tolerance=0.005)
 
 
 @pytest.mark.parametrize("float32_inputs", [True, False])
@@ -216,4 +216,5 @@ def test_sparse_large_int32(float32_inputs: bool, beyond_limit: bool) -> None:
         n_rows=n_rows,
         n_cols=n_cols,
         density=density,
+        tolerance=0.005,
     )


### PR DESCRIPTION
int32 theoretically supports up to 2.1 billion nnz. But some cuda kernel (e.g. map_kernel) calculates array index which can be overflow if int32 is used.

Let int32 support up to 1 billion nnz and switch to int64 if nnz is larger than 1 billion.  