### PR TITLE
Support array input for connect plugin

### DIFF
--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsKMeans.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsKMeans.scala
@@ -20,6 +20,7 @@ import org.apache.spark.ml.clustering.rapids.RapidsKMeansModel
 import org.apache.spark.ml.clustering.{KMeans, KMeansModel}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.types.StructType
 
 /**
  * RapidsKMeans is a JVM wrapper of KMeans in spark-rapids-ml python package.
@@ -39,6 +40,9 @@ class RapidsKMeans(override val uid: String) extends KMeans with DefaultParamsWr
     val cpuModel = copyValues(trainedModel.model.asInstanceOf[KMeansModel])
     copyValues(new RapidsKMeansModel(uid, cpuModel, trainedModel.modelAttributes))
   }
+
+  // Override this function to allow feature to be array
+  override def transformSchema(schema: StructType): StructType = schema
 
   /**
    * The estimator name

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsLinearRegression.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsLinearRegression.scala
@@ -20,6 +20,7 @@ import org.apache.spark.ml.rapids.RapidsLinearRegressionModel
 import org.apache.spark.ml.regression.{LinearRegression, LinearRegressionModel}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.types.StructType
 
 /**
  * RapidsLinearRegression is a JVM wrapper of LinearRegression in spark-rapids-ml python package.
@@ -39,6 +40,9 @@ class RapidsLinearRegression(override val uid: String) extends LinearRegression
     val cpuModel = copyValues(trainedModel.model.asInstanceOf[LinearRegressionModel])
     copyValues(new RapidsLinearRegressionModel(uid, cpuModel, trainedModel.modelAttributes))
   }
+
+  // Override this function to allow feature to be array
+  override def transformSchema(schema: StructType): StructType = schema
 
   /**
    * The estimator name

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsLogisticRegression.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsLogisticRegression.scala
@@ -20,6 +20,7 @@ import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, I
 import org.apache.spark.ml.classification.{LogisticRegression, LogisticRegressionModel}
 import org.apache.spark.ml.rapids.RapidsLogisticRegressionModel
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.types.StructType
 
 /**
  * RapidsLogisticRegression is a JVM wrapper of LogisticRegression in spark-rapids-ml python package.
@@ -40,6 +41,9 @@ class RapidsLogisticRegression(override val uid: String) extends LogisticRegress
     val isMultinomial = cpuModel.numClasses != 2
     copyValues(new RapidsLogisticRegressionModel(uid, cpuModel, trainedModel.modelAttributes, isMultinomial))
   }
+
+  // Override this function to allow feature to be array
+  override def transformSchema(schema: StructType): StructType = schema
 
   /**
    * The estimator name

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsPCA.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsPCA.scala
@@ -20,6 +20,7 @@ import org.apache.spark.ml.feature.{PCA, PCAModel}
 import org.apache.spark.ml.rapids.RapidsPCAModel
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.types.StructType
 
 /**
  * RapidsPCA is a JVM wrapper of PCA in spark-rapids-ml python package.
@@ -39,6 +40,9 @@ class RapidsPCA(override val uid: String) extends PCA with DefaultParamsWritable
     val cpuModel = copyValues(trainedModel.model.asInstanceOf[PCAModel])
     copyValues(new RapidsPCAModel(uid, cpuModel, trainedModel.modelAttributes))
   }
+
+  // Override this function to allow feature to be array
+  override def transformSchema(schema: StructType): StructType = schema
 
   /**
    * The estimator name

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsRandomForestClassifier.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsRandomForestClassifier.scala
@@ -20,6 +20,7 @@ import org.apache.spark.ml.classification.{RandomForestClassificationModel, Rand
 import org.apache.spark.ml.rapids.RapidsRandomForestClassificationModel
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.types.StructType
 
 /**
  * RapidsRandomForestClassifier is a JVM wrapper of RandomForestClassifier in spark-rapids-ml python package.
@@ -39,6 +40,9 @@ class RapidsRandomForestClassifier(override val uid: String) extends RandomFores
     val cpuModel = copyValues(trainedModel.model.asInstanceOf[RandomForestClassificationModel])
     copyValues(new RapidsRandomForestClassificationModel(uid, cpuModel, trainedModel.modelAttributes))
   }
+
+  // Override this function to allow feature to be array
+  override def transformSchema(schema: StructType): StructType = schema
 
   /**
    * The estimator name

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsRandomForestRegressor.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsRandomForestRegressor.scala
@@ -20,6 +20,7 @@ import org.apache.spark.ml.rapids.RapidsRandomForestRegressionModel
 import org.apache.spark.ml.regression.{RandomForestRegressionModel, RandomForestRegressor}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.types.StructType
 
 /**
  * RapidsRandomForestRegressor is a JVM wrapper of RandomForestRegressor in spark-rapids-ml python package.
@@ -39,6 +40,9 @@ class RapidsRandomForestRegressor(override val uid: String) extends RandomForest
     val cpuModel = copyValues(trainedModel.model.asInstanceOf[RandomForestRegressionModel])
     copyValues(new RapidsRandomForestRegressionModel(uid, cpuModel, trainedModel.modelAttributes))
   }
+
+  // Override this function to allow feature to be array
+  override def transformSchema(schema: StructType): StructType = schema
 
   /**
    * The estimator name

--- a/jvm/src/main/scala/org/apache/spark/ml/rapids/RapidsPCAModel.scala
+++ b/jvm/src/main/scala/org/apache/spark/ml/rapids/RapidsPCAModel.scala
@@ -50,6 +50,8 @@ class RapidsPCAModel(override val uid: String,
     newModel
   }
 
+  override def featureName: String = getInputCol
+
 }
 
 


### PR DESCRIPTION
This PR tries to override `transformSchema` function in estimator which is going to check if the feature is Vector input, if not, this function is going to throw exception. Given that, spark-rapids-ml supports vector/array/multicolumns, we need to eliminate this checking to make it support array input.