### PR TITLE
Construct cpu model in JVM side for connect plugin

### DIFF
--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -30,7 +30,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>2.13.14</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
-        <spark.version>4.0.1-SNAPSHOT</spark.version>
+        <spark.version>4.0.0</spark.version>
         <!-- Extra JVM arguments for tests (required for Java 17 module system) -->
         <extraJavaTestArgs>
             -XX:+IgnoreUnrecognizedVMOptions
@@ -127,17 +127,4 @@
         </plugins>
     </build>
 
-    <!-- Additional repositories (temporary until Spark 4.1 is released) -->
-    <repositories>
-        <repository>
-            <id>apache-snapshots</id>
-            <url>https://repository.apache.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled> <!-- Enable snapshot versions -->
-            </snapshots>
-            <releases>
-                <enabled>false</enabled> <!-- Do not fetch release versions from here -->
-            </releases>
-        </repository>
-    </repositories>
 </project>

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsKMeans.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsKMeans.scala
@@ -17,7 +17,8 @@
 package com.nvidia.rapids.ml
 
 import org.apache.spark.ml.clustering.rapids.RapidsKMeansModel
-import org.apache.spark.ml.clustering.{KMeans, KMeansModel}
+import org.apache.spark.ml.clustering.KMeans
+import org.apache.spark.ml.rapids.ModelHelper
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
@@ -37,8 +38,8 @@ class RapidsKMeans(override val uid: String) extends KMeans with DefaultParamsWr
 
   override def fit(dataset: Dataset[_]): RapidsKMeansModel = {
     val trainedModel = trainOnPython(dataset)
-    val cpuModel = copyValues(trainedModel.model.asInstanceOf[KMeansModel])
-    copyValues(new RapidsKMeansModel(uid, cpuModel, trainedModel.modelAttributes))
+    val parentModel = ModelHelper.createKMeansModel(trainedModel.modelAttributes)
+    copyValues(new RapidsKMeansModel(uid, parentModel, trainedModel.modelAttributes))
   }
 
   // Override this function to allow feature to be array

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsLinearRegression.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsLinearRegression.scala
@@ -16,8 +16,8 @@
 
 package com.nvidia.rapids.ml
 
-import org.apache.spark.ml.rapids.RapidsLinearRegressionModel
-import org.apache.spark.ml.regression.{LinearRegression, LinearRegressionModel}
+import org.apache.spark.ml.rapids.{ModelHelper, RapidsLinearRegressionModel}
+import org.apache.spark.ml.regression.LinearRegression
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
@@ -37,8 +37,9 @@ class RapidsLinearRegression(override val uid: String) extends LinearRegression
 
   override def train(dataset: Dataset[_]): RapidsLinearRegressionModel = {
     val trainedModel = trainOnPython(dataset)
-    val cpuModel = copyValues(trainedModel.model.asInstanceOf[LinearRegressionModel])
-    copyValues(new RapidsLinearRegressionModel(uid, cpuModel, trainedModel.modelAttributes))
+    val (coef, intercept, scale) = ModelHelper.createLinearRegressionModel(trainedModel.modelAttributes)
+    copyValues(new RapidsLinearRegressionModel(uid, coef, intercept, scale,
+      trainedModel.modelAttributes))
   }
 
   // Override this function to allow feature to be array

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsLogisticRegression.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsLogisticRegression.scala
@@ -17,8 +17,8 @@
 package com.nvidia.rapids.ml
 
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
-import org.apache.spark.ml.classification.{LogisticRegression, LogisticRegressionModel}
-import org.apache.spark.ml.rapids.RapidsLogisticRegressionModel
+import org.apache.spark.ml.classification.LogisticRegression
+import org.apache.spark.ml.rapids.{ModelHelper, RapidsLogisticRegressionModel}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
 
@@ -37,9 +37,9 @@ class RapidsLogisticRegression(override val uid: String) extends LogisticRegress
 
   override def train(dataset: Dataset[_]): RapidsLogisticRegressionModel = {
     val trainedModel = trainOnPython(dataset)
-    val cpuModel = copyValues(trainedModel.model.asInstanceOf[LogisticRegressionModel])
-    val isMultinomial = cpuModel.numClasses != 2
-    copyValues(new RapidsLogisticRegressionModel(uid, cpuModel, trainedModel.modelAttributes, isMultinomial))
+    val (coef, intercept, numClasses) =
+      ModelHelper.createLogisticRegressionModel(trainedModel.modelAttributes)
+    copyValues(new RapidsLogisticRegressionModel(uid, coef, intercept, numClasses, trainedModel.modelAttributes))
   }
 
   // Override this function to allow feature to be array

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsPCA.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsPCA.scala
@@ -16,8 +16,8 @@
 
 package com.nvidia.rapids.ml
 
-import org.apache.spark.ml.feature.{PCA, PCAModel}
-import org.apache.spark.ml.rapids.RapidsPCAModel
+import org.apache.spark.ml.feature.PCA
+import org.apache.spark.ml.rapids.{ModelHelper, RapidsPCAModel}
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
@@ -37,8 +37,8 @@ class RapidsPCA(override val uid: String) extends PCA with DefaultParamsWritable
 
   override def fit(dataset: Dataset[_]): RapidsPCAModel = {
     val trainedModel = trainOnPython(dataset)
-    val cpuModel = copyValues(trainedModel.model.asInstanceOf[PCAModel])
-    copyValues(new RapidsPCAModel(uid, cpuModel, trainedModel.modelAttributes))
+    val (pc, explainedVariance) = ModelHelper.createPCAModel(trainedModel.modelAttributes)
+    copyValues(new RapidsPCAModel(uid, pc, explainedVariance, trainedModel.modelAttributes))
   }
 
   // Override this function to allow feature to be array

--- a/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsRandomForestRegressor.scala
+++ b/jvm/src/main/scala/com/nvidia/rapids/ml/RapidsRandomForestRegressor.scala
@@ -16,8 +16,8 @@
 
 package com.nvidia.rapids.ml
 
-import org.apache.spark.ml.rapids.RapidsRandomForestRegressionModel
-import org.apache.spark.ml.regression.{RandomForestRegressionModel, RandomForestRegressor}
+import org.apache.spark.ml.rapids.{RapidsRandomForestRegressionModel, ModelHelper}
+import org.apache.spark.ml.regression.RandomForestRegressor
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
@@ -37,8 +37,9 @@ class RapidsRandomForestRegressor(override val uid: String) extends RandomForest
 
   override def train(dataset: Dataset[_]): RapidsRandomForestRegressionModel = {
     val trainedModel = trainOnPython(dataset)
-    val cpuModel = copyValues(trainedModel.model.asInstanceOf[RandomForestRegressionModel])
-    copyValues(new RapidsRandomForestRegressionModel(uid, cpuModel, trainedModel.modelAttributes))
+    val (trees, numFeatures) = ModelHelper.createRandomForestRegressionModel(
+      trainedModel.modelAttributes, getImpurity, uid)
+    copyValues(new RapidsRandomForestRegressionModel(uid, trees, numFeatures, trainedModel.modelAttributes))
   }
 
   // Override this function to allow feature to be array

--- a/jvm/src/main/scala/org/apache/spark/ml/rapids/ModelHelper.scala
+++ b/jvm/src/main/scala/org/apache/spark/ml/rapids/ModelHelper.scala
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.rapids
+
+import org.apache.spark.ml.classification.DecisionTreeClassificationModel
+import org.apache.spark.mllib.clustering.{KMeansModel => MLlibKMeansModel}
+import org.apache.spark.ml.linalg.{DenseMatrix, DenseVector, Matrices, Matrix, Vector, Vectors}
+import org.apache.spark.ml.regression.DecisionTreeRegressionModel
+import org.apache.spark.ml.tree.{ContinuousSplit, InternalNode, LeafNode, Node}
+import org.apache.spark.mllib.tree.impurity.{EntropyCalculator, GiniCalculator, ImpurityCalculator, VarianceCalculator}
+import org.json4s.{DefaultFormats, Formats}
+import org.json4s.JsonAST.{JArray, _}
+import org.json4s.jackson.JsonMethods.parse
+
+object ModelHelper {
+
+  implicit val formats: Formats = DefaultFormats
+
+  private def createCalcAndPred(impurity: String,
+                                instanceCount: Int,
+                                stats: Array[Double] = Array.empty): (ImpurityCalculator, Double) = {
+    impurity match {
+      case "gini" => (new GiniCalculator(stats, instanceCount), Vectors.dense(stats).argmax)
+      case "entropy" => (new EntropyCalculator(stats, instanceCount), Vectors.dense(stats).argmax)
+      case "variance" => (new VarianceCalculator(Array.fill(3)(0), instanceCount), stats(0))
+      case _ => throw new RuntimeException(s"Unsupported impurity: $impurity")
+    }
+  }
+
+  private def getNodes(json: JValue, impurity: String): List[Node] = {
+    json match {
+      case JArray(arr) => arr.map(e => parseTreeNode(e, impurity))
+      case _ => throw new IllegalArgumentException(s"Expected JArray of TreeNodes, found $json")
+    }
+  }
+
+
+  private def parseTreeNode(json: JValue, impurity: String): Node = json match {
+    case JObject(fields) =>
+      val fieldMap = fields.toMap
+      if (fields.exists(_._1 == "split_feature")) {
+        val left_child_id = fieldMap("yes").extract[Int]
+        val right_child_id = fieldMap("no").extract[Int]
+
+        var left_child: Option[JValue] = None
+        var right_child: Option[JValue] = None
+
+        fieldMap("children") match {
+          case JArray(arr) =>
+            arr.foreach { child =>
+              child \ "nodeid" match {
+                case JInt(nodeId) if nodeId.toInt == left_child_id => left_child = Some(child)
+                case JInt(nodeId) if nodeId.toInt == right_child_id => right_child = Some(child)
+                case JInt(_) => throw new IllegalArgumentException("Unexpected node id")
+                case _ => throw new IllegalArgumentException("nodeid is not an integer")
+              }
+            }
+        }
+        val gain = fieldMap("gain").extract[Double]
+        val split = new ContinuousSplit(
+          featureIndex = fieldMap("split_feature").extract[Int],
+          threshold = fieldMap("split_threshold").extract[Double])
+
+        val instanceCount = fieldMap("instance_count").extract[Int]
+        val leafValue = Array.fill(instanceCount)(0.0)
+        val (calc, _) = createCalcAndPred(impurity, instanceCount, leafValue)
+        new InternalNode(
+          0.0, // prediction value is no-use for internal node, just fake it
+          0.0, // impurity value is no-use for internal node. just fake it
+          gain,
+          parseTreeNode(left_child.get, impurity),
+          parseTreeNode(right_child.get, impurity),
+          split,
+          calc)
+      } else if (fields.exists(_._1 == "leaf_value")) {
+        val leafValue = fieldMap("leaf_value").extract[List[Double]].toArray
+        val (calc, pred) = createCalcAndPred(impurity,
+          fieldMap("instance_count").extract[Int],
+          leafValue)
+        // TODO calculate the impurity according to leaf value
+        new LeafNode(pred, 0.0, calc)
+      } else {
+        throw new RuntimeException("Wrong tree json format")
+      }
+    case _ => throw new RuntimeException(s"Failed to parse json $json")
+  }
+
+
+  def createRandomForestRegressionModel(modelAttributes: String,
+                                        impurity: String,
+                                        uid: String): (Array[DecisionTreeRegressionModel], Int) = {
+    val parsedJson = parse(modelAttributes)
+    implicit val format = DefaultFormats
+    val (treeModelJson, numFeatures) = parsedJson match {
+      case JArray(arr) =>
+        (arr.last.extract[List[String]], arr.head.extract[Int])
+      case _ => throw new IllegalArgumentException(s"Failed to parse $parsedJson")
+    }
+    val nodes = getNodes(parse(treeModelJson.head), impurity)
+    val trees = nodes.map(n => new DecisionTreeRegressionModel(uid, n, numFeatures)).toArray
+    (trees, numFeatures)
+  }
+
+  def createRandomForestClassificationModel(modelAttributes: String,
+                                            impurity: String,
+                                            uid: String): (Array[DecisionTreeClassificationModel], Int, Int) = {
+    val parsedJson = parse(modelAttributes)
+    implicit val format = DefaultFormats
+    val (treeModelJson, numFeatures, numClasses) = parsedJson match {
+      case JArray(arr) =>
+        (arr.dropRight(1).last.extract[List[String]], arr.head.extract[Int], arr.last.extract[Int])
+      case _ => throw new IllegalArgumentException(s"Failed to parse $parsedJson")
+    }
+    val nodes = getNodes(parse(treeModelJson.head), impurity)
+    val trees = nodes.map(n => new DecisionTreeClassificationModel(uid, n, numFeatures, numClasses)).toArray
+    (trees, numFeatures, numClasses)
+  }
+
+  def createLinearRegressionModel(modelAttributes: String): (Vector, Double, Double) = {
+    val parsedJson = parse(modelAttributes)
+    implicit val format = DefaultFormats
+    parsedJson match {
+      case JArray(arr) =>
+        val coef = arr.head.extract[List[Double]].toArray
+        val intercept = arr(1).extract[Double]
+        (Vectors.dense(coef), intercept, 1.0)
+      case _ => throw new IllegalArgumentException(s"Failed to parse $parsedJson")
+    }
+  }
+
+  def createLogisticRegressionModel(modelAttributes: String): (Matrix, Vector, Int) = {
+    val parsedJson = parse(modelAttributes)
+    implicit val format = DefaultFormats
+    parsedJson match {
+      case JArray(arr) =>
+        val coef = arr.head.extract[List[List[Double]]]
+        val rows = coef.length
+        val cols = coef.head.length
+        val coefMatrix = new DenseMatrix(rows, cols, coef.flatten.toArray, true)
+        val intercept = arr(1).extract[List[Double]].toArray
+        val numClasses = arr(2).extract[List[Double]].length
+        (coefMatrix, Vectors.dense(intercept), numClasses)
+      case _ => throw new IllegalArgumentException(s"Failed to parse $parsedJson")
+    }
+  }
+
+  def createPCAModel(modelAttributes: String): (DenseMatrix, DenseVector) = {
+    val parsedJson = parse(modelAttributes)
+    implicit val format = DefaultFormats
+    parsedJson match {
+      case JArray(arr) =>
+        val pc = arr(1).extract[List[List[Double]]]
+        val rows = pc.length
+        val cols = arr(4).extract[Int]
+        // DenseMatrix is column major, so flip rows/cols
+        val pcMatrix = Matrices.dense(cols, rows, pc.flatten.toArray).asInstanceOf[DenseMatrix]
+        val explainedVariance = arr(2).extract[List[Double]].toArray
+        (pcMatrix, Vectors.dense(explainedVariance).asInstanceOf[DenseVector])
+      case _ => throw new IllegalArgumentException(s"Failed to parse $parsedJson")
+    }
+  }
+
+  def createKMeansModel(modelAttributes: String): MLlibKMeansModel = {
+    val parsedJson = parse(modelAttributes)
+    implicit val format = DefaultFormats
+    parsedJson match {
+      case JArray(arr) =>
+        val clusterCenters = arr.head.extract[List[List[Double]]]
+        val clusterCentersVectors = clusterCenters.map(v =>
+          org.apache.spark.mllib.linalg.Vectors.dense(v.toArray)).toArray
+        new MLlibKMeansModel(clusterCentersVectors)
+      case _ => throw new IllegalArgumentException(s"Failed to parse $parsedJson")
+    }
+  }
+}

--- a/jvm/src/main/scala/org/apache/spark/ml/rapids/PythonEstimatorRunner.scala
+++ b/jvm/src/main/scala/org/apache/spark/ml/rapids/PythonEstimatorRunner.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.python.PythonPlannerRunner
 
 case class Fit(name: String, params: String)
 
-case class TrainedModel(model: Object, modelAttributes: String)
+case class TrainedModel(modelAttributes: String)
 
 /**
  * PythonEstimatorRunner is a bridge to launch and manage Python process. It sends the
@@ -56,12 +56,8 @@ class PythonEstimatorRunner(fit: Fit,
   }
 
   override protected def receiveFromPython(dataIn: DataInputStream): TrainedModel = {
-    // Read the model target id in py4j server
-    val modelTargetId = PythonWorkerUtils.readUTF(dataIn)
-    val m = PythonRunnerUtils.getObjectAndDeref(modelTargetId)
-
     val modelAttributes = PythonWorkerUtils.readUTF(dataIn)
-    TrainedModel(m, modelAttributes)
+    TrainedModel(modelAttributes)
   }
 
   override def close(): Unit = {

--- a/jvm/src/main/scala/org/apache/spark/ml/rapids/RapidsLogisticRegressionModel.scala
+++ b/jvm/src/main/scala/org/apache/spark/ml/rapids/RapidsLogisticRegressionModel.scala
@@ -17,10 +17,10 @@
 package org.apache.spark.ml.rapids
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.internal.Logging
 import org.apache.spark.ml.classification.LogisticRegressionModel
+import org.apache.spark.ml.linalg.{Matrix, Vector}
 import org.apache.spark.ml.param.ParamMap
-import org.apache.spark.ml.util.{MLReadable, MLReader, MLWritable, MLWriter}
+import org.apache.spark.ml.util.{MLReadable, MLReader, MLWritable}
 import org.apache.spark.sql.{DataFrame, Dataset}
 
 /**
@@ -30,16 +30,17 @@ import org.apache.spark.sql.{DataFrame, Dataset}
  * the model attributes trained by spark-rapids-ml python in string format.
  */
 class RapidsLogisticRegressionModel(override val uid: String,
-                                    protected[ml] override val cpuModel: LogisticRegressionModel,
-                                    override val modelAttributes: String,
-                                    private val isMultinomial: Boolean)
-  extends LogisticRegressionModel(uid, cpuModel.coefficientMatrix, cpuModel.interceptVector,
-    cpuModel.numClasses, isMultinomial) with MLWritable with RapidsModel {
+                                    override val coefficientMatrix: Matrix,
+                                    override val interceptVector: Vector,
+                                    override val numClasses: Int,
+                                    override val modelAttributes: String)
+  extends LogisticRegressionModel(uid, coefficientMatrix, interceptVector,
+    numClasses, numClasses != 2) with MLWritable with RapidsModel {
 
-  private[ml] def this() = this("", null, "", false)
+  private[ml] def this() = this("", null, null, 2, null)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-    transformOnPython(dataset)
+    transformOnPython(dataset, super.transform)
   }
 
   /**
@@ -49,13 +50,16 @@ class RapidsLogisticRegressionModel(override val uid: String,
 
   override def copy(extra: ParamMap): RapidsLogisticRegressionModel = {
     val newModel = copyValues(
-      new RapidsLogisticRegressionModel(uid, cpuModel, modelAttributes, isMultinomial), extra)
+      new RapidsLogisticRegressionModel(uid, coefficientMatrix, interceptVector,
+        numClasses, modelAttributes), extra)
     newModel.setSummary(trainingSummary).setParent(parent)
     newModel
   }
 
-  override def write: MLWriter =
-    new RapidsLogisticRegressionModel.RapidsLogisticRegressionModelWriter(this)
+  override def cpu: LogisticRegressionModel = {
+    copyValues(
+      new LogisticRegressionModel(uid, coefficientMatrix, interceptVector, numClasses, numClasses != 2))
+  }
 }
 
 object RapidsLogisticRegressionModel extends MLReadable[RapidsLogisticRegressionModel] {
@@ -64,24 +68,6 @@ object RapidsLogisticRegressionModel extends MLReadable[RapidsLogisticRegression
 
   override def load(path: String): RapidsLogisticRegressionModel = super.load(path)
 
-  private class RapidsLogisticRegressionModelWriter(instance: RapidsLogisticRegressionModel)
-    extends MLWriter with Logging {
-
-    override protected def saveImpl(path: String): Unit = {
-      val writer = instance.cpuModel.write
-      if (shouldOverwrite) {
-        writer.overwrite()
-      }
-      optionMap.foreach { case (k, v) => writer.option(k, v) }
-      writer.save(path)
-
-      val attributesPath = new Path(path, "attributes").toString
-      sparkSession.createDataFrame(
-          Seq(Tuple3(instance.uid, instance.isMultinomial, instance.modelAttributes))
-        ).write.parquet(attributesPath)
-    }
-  }
-
   private class RapidsLogisticRegressionModelReader extends MLReader[RapidsLogisticRegressionModel] {
 
     override def load(path: String): RapidsLogisticRegressionModel = {
@@ -89,7 +75,7 @@ object RapidsLogisticRegressionModel extends MLReadable[RapidsLogisticRegression
       val attributesPath = new Path(path, "attributes").toString
       val row = sparkSession.read.parquet(attributesPath).first()
       val model = new RapidsLogisticRegressionModel(row.getString(0),
-        cpuModel, row.getString(2), row.getBoolean(1))
+        cpuModel.coefficientMatrix, cpuModel.interceptVector, cpuModel.numClasses, row.getString(1))
       cpuModel.paramMap.toSeq.foreach(p => model.set(p.param.name, p.value))
       model
     }

--- a/jvm/src/main/scala/org/apache/spark/ml/rapids/Utils.scala
+++ b/jvm/src/main/scala/org/apache/spark/ml/rapids/Utils.scala
@@ -19,15 +19,16 @@ package org.apache.spark.ml.rapids
 import java.security.SecureRandom
 import java.util.Base64
 import java.io.File
-
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.sys.process.Process
-
 import py4j.GatewayServer.GatewayServerBuilder
 import org.apache.spark.api.python.SimplePythonFunction
+import org.apache.spark.ml.linalg
+import org.apache.spark.ml.linalg.{DenseVector, Vectors}
 import org.apache.spark.ml.param.{ParamPair, Params}
 import org.apache.spark.util.Utils
+import org.json4s.{DefaultFormats, JArray}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods.{compact, parse, render}
 


### PR DESCRIPTION
It's super slow when constructing the corresponding CPU Model in python especially for RandomForest cases which have many trees. This PR moves the cpu model construction from python side to jvm side.