### PR TITLE
Fix conda build CondaToSNonInteractiveError issue [skip ci]

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -41,6 +41,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     && mkdir /root/.conda \
     && bash Miniconda3-latest-Linux-x86_64.sh -b \
     && rm -f Miniconda3-latest-Linux-x86_64.sh \
+    && conda tos accept --override-channels -c conda-forge -c defaults \
     && conda init && conda update -n base conda \
     && conda install -n base conda-libmamba-solver \
     && conda config --set solver libmamba

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,6 +91,7 @@ RUN wget --quiet \
     && mkdir /root/.conda \
     && bash Miniconda3-py38_4.10.3-Linux-x86_64.sh -b \
     && rm -f Miniconda3-py38_4.10.3-Linux-x86_64.sh \
+    && conda tos accept --override-channels -c conda-forge -c defaults \
     && conda init
 
 # install cuDF dependency, Fall back to use cudf 22.04 due to issue:

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -42,6 +42,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linu
     && mkdir /root/.conda \
     && bash Miniconda3-py38_4.10.3-Linux-x86_64.sh -b \
     && rm -f Miniconda3-py38_4.10.3-Linux-x86_64.sh \
+    && conda tos accept --override-channels -c conda-forge -c defaults \
     && conda init
 
 # install cuML


### PR DESCRIPTION
conda now requires accepting the default channel to proceed. Otherwise it would fail
```
[2025-07-15T19:41:39.043Z] CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:
[2025-07-15T19:41:39.043Z]     • https://repo.anaconda.com/pkgs/main
[2025-07-15T19:41:39.043Z]     • https://repo.anaconda.com/pkgs/r
```

explicitly accept terms to avoid failing `CondaToSNonInteractiveError`. This has been verified in both local dev and internal CI