### PR TITLE
Support User Default Log Level Globally

### DIFF
--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -434,6 +434,16 @@ class _CumlCaller(_CumlParams, _CumlCommon):
         super().__init__()
         self._initialize_cuml_params()
 
+        import os
+
+        log_level = os.environ.get("SPARK_RAPIDS_ML_LOG_LEVEL")
+        if log_level is not None:
+            if isinstance(log_level, str) and log_level.isdigit():
+                verbose_value = int(log_level)
+                self._set_params(**{"verbose": int(log_level)})
+            else:
+                self._set_params(**{"verbose": log_level})
+
     @abstractmethod
     def _out_schema(self) -> Union[StructType, str]:
         """

--- a/python/tests/test_logistic_regression.py
+++ b/python/tests/test_logistic_regression.py
@@ -330,6 +330,14 @@ def test_params(tmp_path: str, caplog: LogCaptureFixture) -> None:
     _test_input_setter_getter(LogisticRegression)
 
 
+def test_spark_rapids_ml_log_level() -> None:
+    import os
+
+    os.environ["SPARK_RAPIDS_ML_LOG_LEVEL"] = "2"
+    lr = LogisticRegression()
+    assert lr.cuml_params["verbose"] == 2
+
+
 def test_lr_copy() -> None:
     from .test_common_estimator import _test_est_copy
 


### PR DESCRIPTION
verbosity level defaults to False. 
This PR supports changing the default value by setting an environment variable SPARK_RAPIDS_ML_LOG_LEVEL.  