### PR TITLE
updates for RAPIDS 25.10 compatibility

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -47,6 +47,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     && conda config --set solver libmamba
 
 # install cuML
-ARG CUML_VER=25.08
-RUN conda install -y -c rapidsai -c conda-forge -c nvidia cuml=$CUML_VER cuvs=$CUML_VER python=3.10 cuda-version=12.0 numpy~=1.0 \
+ARG CUML_VER=25.10
+RUN conda install -y -c rapidsai-nightly -c conda-forge -c nvidia cuml=$CUML_VER cuvs=$CUML_VER python=3.10 cuda-version=12.0 numpy~=1.0 \
     && conda clean --all -f -y

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@
 project = 'spark-rapids-ml'
 copyright = '2025, NVIDIA'
 author = 'NVIDIA'
-release = '25.08.0'
+release = '25.10.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.nvidia.rapids</groupId>
     <artifactId>ml</artifactId>
-    <version>25.08.0</version>
+    <version>25.10.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/jvm/src/main/scala/org/apache/spark/ml/rapids/ModelHelper.scala
+++ b/jvm/src/main/scala/org/apache/spark/ml/rapids/ModelHelper.scala
@@ -44,61 +44,85 @@ object ModelHelper {
   private def getNodes(json: JValue, impurity: String): List[Node] = {
     json match {
       case JArray(arr) => arr.map(e => parseTreeNode(e, impurity))
-      case _ => throw new IllegalArgumentException(s"Expected JArray of TreeNodes, found $json")
+      case _ => throw new IllegalArgumentException(s"Expected JArray of TreeLite trees, found $json")
     }
   }
 
-
-  private def parseTreeNode(json: JValue, impurity: String): Node = json match {
-    case JObject(fields) =>
-      val fieldMap = fields.toMap
-      if (fields.exists(_._1 == "split_feature")) {
-        val left_child_id = fieldMap("yes").extract[Int]
-        val right_child_id = fieldMap("no").extract[Int]
-
-        var left_child: Option[JValue] = None
-        var right_child: Option[JValue] = None
-
-        fieldMap("children") match {
-          case JArray(arr) =>
-            arr.foreach { child =>
-              child \ "nodeid" match {
-                case JInt(nodeId) if nodeId.toInt == left_child_id => left_child = Some(child)
-                case JInt(nodeId) if nodeId.toInt == right_child_id => right_child = Some(child)
-                case JInt(_) => throw new IllegalArgumentException("Unexpected node id")
-                case _ => throw new IllegalArgumentException("nodeid is not an integer")
-              }
-            }
+  private def parseTreeNode(treeliteJson: JValue, impurity: String): Node = {
+    // Extract the nodes array from treelite JSON
+    val nodes = treeliteJson \ "nodes" match {
+      case JArray(arr) => arr
+      case _ => throw new RuntimeException("Expected 'nodes' array in treelite JSON")
+    }
+    
+    // Create a map from node_id to node data for efficient lookup
+    val nodeMap = nodes.map { node =>
+      val nodeId = (node \ "node_id").extract[Int]
+      nodeId -> node
+    }.toMap
+    
+    // Parse starting from root node (node_id = 0)
+    parseTreeNodeRecursive(nodeMap, 0, impurity)
+  }
+  
+  private def parseTreeNodeRecursive(nodeMap: Map[Int, JValue], nodeId: Int, impurity: String): Node = {
+    val node = nodeMap(nodeId)
+    
+    node match {
+      case JObject(fields) =>
+        val fieldMap = fields.toMap
+        
+        // Check if this is an internal node (has split_feature_id)
+        if (fieldMap.contains("split_feature_id")) {
+          val leftChildId = fieldMap("left_child").extract[Int]
+          val rightChildId = fieldMap("right_child").extract[Int]
+          val gain = fieldMap.get("gain").map(_.extract[Double]).getOrElse(0.0)
+          
+          val split = new ContinuousSplit(
+            featureIndex = fieldMap("split_feature_id").extract[Int],
+            threshold = fieldMap("threshold").extract[Double])
+          
+          val instanceCount = fieldMap.get("instance_count").map(_.extract[Int]).getOrElse(1)
+          val leafValue = Array.fill(instanceCount)(0.0)
+          val (calc, _) = createCalcAndPred(impurity, instanceCount, leafValue)
+          
+          new InternalNode(
+            0.0, // prediction value is no-use for internal node, just fake it
+            0.0, // impurity value is no-use for internal node. just fake it
+            gain,
+            parseTreeNodeRecursive(nodeMap, leftChildId, impurity),
+            parseTreeNodeRecursive(nodeMap, rightChildId, impurity),
+            split,
+            calc)
+        } 
+        // Check if this is a leaf node (has leaf_value)
+        else if (fieldMap.contains("leaf_value")) {
+          val leafValue = fieldMap("leaf_value") match {
+            case JDouble(value) => Array(value)
+            case JArray(arr) => arr.map(_.extract[Double]).toArray
+            case _ => throw new RuntimeException(s"Unexpected leaf_value format: ${fieldMap("leaf_value")}")
+          }
+          
+          val instanceCount = fieldMap.get("instance_count").map(_.extract[Int]).getOrElse(1)
+          val (calc, pred) = createCalcAndPred(impurity, instanceCount, leafValue)
+          
+          new LeafNode(pred, 0.0, calc)
+        } else {
+          throw new RuntimeException(s"Unknown node type in treelite JSON: $node")
         }
-        val gain = fieldMap("gain").extract[Double]
-        val split = new ContinuousSplit(
-          featureIndex = fieldMap("split_feature").extract[Int],
-          threshold = fieldMap("split_threshold").extract[Double])
-
-        val instanceCount = fieldMap("instance_count").extract[Int]
-        val leafValue = Array.fill(instanceCount)(0.0)
-        val (calc, _) = createCalcAndPred(impurity, instanceCount, leafValue)
-        new InternalNode(
-          0.0, // prediction value is no-use for internal node, just fake it
-          0.0, // impurity value is no-use for internal node. just fake it
-          gain,
-          parseTreeNode(left_child.get, impurity),
-          parseTreeNode(right_child.get, impurity),
-          split,
-          calc)
-      } else if (fields.exists(_._1 == "leaf_value")) {
-        val leafValue = fieldMap("leaf_value").extract[List[Double]].toArray
-        val (calc, pred) = createCalcAndPred(impurity,
-          fieldMap("instance_count").extract[Int],
-          leafValue)
-        // TODO calculate the impurity according to leaf value
-        new LeafNode(pred, 0.0, calc)
-      } else {
-        throw new RuntimeException("Wrong tree json format")
-      }
-    case _ => throw new RuntimeException(s"Failed to parse json $json")
+      case _ => throw new RuntimeException(s"Failed to parse treelite node: $node")
+    }
   }
 
+  private def parseTreeLiteTrees(treeLiteModelJson: String): JValue = {
+    parse(treeLiteModelJson) match {
+        case JObject(fields) => {
+            val fieldMap = fields.toMap
+            fieldMap("trees")
+        }
+        case _ => throw new RuntimeException(s"Failed to find trees in treelite model json")
+    }
+  }
 
   def createRandomForestRegressionModel(modelAttributes: String,
                                         impurity: String,
@@ -106,11 +130,11 @@ object ModelHelper {
     val parsedJson = parse(modelAttributes)
     implicit val format = DefaultFormats
     val (treeModelJson, numFeatures) = parsedJson match {
-      case JArray(arr) =>
-        (arr.last.extract[List[String]], arr.head.extract[Int])
+      case JArray(arr) => (arr.last.extract[String], arr.head.extract[Int])
       case _ => throw new IllegalArgumentException(s"Failed to parse $parsedJson")
     }
-    val nodes = getNodes(parse(treeModelJson.head), impurity)
+    val treeLiteTrees = parseTreeLiteTrees(treeModelJson)
+    val nodes = getNodes(treeLiteTrees, impurity)
     val trees = nodes.map(n => new DecisionTreeRegressionModel(uid, n, numFeatures)).toArray
     (trees, numFeatures)
   }
@@ -122,10 +146,11 @@ object ModelHelper {
     implicit val format = DefaultFormats
     val (treeModelJson, numFeatures, numClasses) = parsedJson match {
       case JArray(arr) =>
-        (arr.dropRight(1).last.extract[List[String]], arr.head.extract[Int], arr.last.extract[Int])
+        (arr.dropRight(1).last.extract[String], arr.head.extract[Int], arr.last.extract[Int])
       case _ => throw new IllegalArgumentException(s"Failed to parse $parsedJson")
     }
-    val nodes = getNodes(parse(treeModelJson.head), impurity)
+    val treeLiteTrees = parseTreeLiteTrees(treeModelJson)
+    val nodes = getNodes(treeLiteTrees, impurity)
     val trees = nodes.map(n => new DecisionTreeClassificationModel(uid, n, numFeatures, numClasses)).toArray
     (trees, numFeatures, numClasses)
   }

--- a/python/benchmark/benchmark/utils.py
+++ b/python/benchmark/benchmark/utils.py
@@ -69,6 +69,7 @@ def inspect_default_params_from_func(
             filtered_params_dict[parameter.name] = parameter.default
     return filtered_params_dict
 
+
 def is_remote() -> bool:
     try:
         # pyspark.sql.utils.is_remote is not available in older versions of pyspark in which case remote is not supported

--- a/python/benchmark/benchmark/utils.py
+++ b/python/benchmark/benchmark/utils.py
@@ -71,9 +71,10 @@ def inspect_default_params_from_func(
 
 
 def to_bool(literal: str) -> bool:
-    if literal in ["true", "yes", "y", "on", "1"]:
+    _literal = literal.lower()
+    if _literal in ["true", "yes", "y", "on", "1"]:
         return True
-    elif literal in ["false", "no", "n", "off", "0"]:
+    elif _literal in ["false", "no", "n", "off", "0"]:
         return False
     else:
         raise ValueError(f"Invalid boolean literal: {literal}")

--- a/python/benchmark/benchmark/utils.py
+++ b/python/benchmark/benchmark/utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import inspect
-from distutils.util import strtobool
 from time import time
 from typing import Any, Callable, Dict, List
 
@@ -69,11 +68,6 @@ def inspect_default_params_from_func(
         ):
             filtered_params_dict[parameter.name] = parameter.default
     return filtered_params_dict
-
-
-def to_bool(literal: str) -> bool:
-    return bool(strtobool(literal))
-
 
 def is_remote() -> bool:
     try:

--- a/python/benchmark/benchmark/utils.py
+++ b/python/benchmark/benchmark/utils.py
@@ -70,6 +70,15 @@ def inspect_default_params_from_func(
     return filtered_params_dict
 
 
+def to_bool(literal: str) -> bool:
+    if literal in ["true", "yes", "y", "on", "1"]:
+        return True
+    elif literal in ["false", "no", "n", "off", "0"]:
+        return False
+    else:
+        raise ValueError(f"Invalid boolean literal: {literal}")
+
+
 def is_remote() -> bool:
     try:
         # pyspark.sql.utils.is_remote is not available in older versions of pyspark in which case remote is not supported

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "spark-rapids-ml"
-version = "25.08.0"
+version = "25.10.0"
 authors = [
   { name="Jinfeng Li", email="jinfeng@nvidia.com" },
   { name="Bobby Wang", email="bobwang@nvidia.com" },

--- a/python/run_plugin_test.sh
+++ b/python/run_plugin_test.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pip install pyspark~=4.0
+pip install pyspark==4.0.0
 pushd ../jvm
 mvn clean test
 popd

--- a/python/src/spark_rapids_ml/__init__.py
+++ b/python/src/spark_rapids_ml/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "25.08.0"
+__version__ = "25.10.0"
 
 import pandas as pd
 import pyspark

--- a/python/src/spark_rapids_ml/classification.py
+++ b/python/src/spark_rapids_ml/classification.py
@@ -539,7 +539,7 @@ class RandomForestClassificationModel(
         n_cols: int,
         dtype: str,
         treelite_model: Union[str, List[str]],
-        model_json: Union[List[str], List[List[str]]],
+        model_json: Union[str, List[str]],
         num_classes: int,
     ):
         super().__init__(

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -361,11 +361,11 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
             params: Dict[str, Any],
         ) -> Dict[str, Any]:
             import cupy as cp
-            from cuml.cluster.kmeans_mg import KMeansMG as CumlKMeansMG
+            from cuml.cluster.kmeans import KMeans as CumlKMeans
 
-            kmeans_object = CumlKMeansMG(
+            kmeans_object = CumlKMeans(
                 handle=params[param_alias.handle],
-                output_type="cudf",
+                output_type="cupy",
                 **params[param_alias.cuml_init],
             )
             df_list = [x for (x, _, _) in dfs]
@@ -375,9 +375,10 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 # features are either cp or np arrays here
                 concated = _concat_and_free(df_list, order=array_order)
 
-            kmeans_object.fit(
+            kmeans_object._fit(
                 concated,
                 sample_weight=None,
+                multigpu=True,
             )
 
             logger = get_logger(cls)
@@ -387,11 +388,9 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
             )
 
             return {
-                "cluster_centers_": [
-                    kmeans_object.cluster_centers_.to_numpy().tolist()
-                ],
+                "cluster_centers_": [kmeans_object.cluster_centers_.get().tolist()],
                 "n_cols": params[param_alias.num_cols],
-                "dtype": str(kmeans_object.dtype.name),
+                "dtype": str(kmeans_object.cluster_centers_.dtype.name),
             }
 
         return _cuml_fit
@@ -489,11 +488,9 @@ class KMeansModel(KMeansClass, _CumlModelWithPredictionCol, _KMeansCumlParams):
         array_order = self._transform_array_order()
 
         def _construct_kmeans() -> CumlT:
-            from cuml.cluster.kmeans_mg import KMeansMG as CumlKMeansMG
+            from cuml.cluster.kmeans import KMeans as CumlKMeans
 
-            kmeans = CumlKMeansMG(output_type="cudf", **cuml_alg_params)
-            # need this to revert a change in cuML targeting sklearn compat.
-            kmeans.n_features_in_ = None
+            kmeans = CumlKMeans(output_type="cudf", **cuml_alg_params)
             from spark_rapids_ml.utils import cudf_to_cuml_array
 
             kmeans.n_features_in_ = n_cols

--- a/python/src/spark_rapids_ml/common/cuml_context.py
+++ b/python/src/spark_rapids_ml/common/cuml_context.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/src/spark_rapids_ml/regression.py
+++ b/python/src/spark_rapids_ml/regression.py
@@ -1022,7 +1022,7 @@ class RandomForestRegressionModel(
         n_cols: int,
         dtype: str,
         treelite_model: Union[str, List[str]],
-        model_json: Union[List[str], List[List[str]]] = [],  # type: ignore
+        model_json: Union[str, List[str]] = [],  # type: ignore
     ):
         super().__init__(
             dtype=dtype,

--- a/python/src/spark_rapids_ml/tree.py
+++ b/python/src/spark_rapids_ml/tree.py
@@ -404,8 +404,7 @@ class _RandomForestEstimator(
                 serialized_model = rf._treelite_model_bytes
                 pickled_model = pickle.dumps(serialized_model)
                 msg = base64.b64encode(pickled_model).decode("utf-8")
-                # trees = rf.as_treelite().dump_as_json()
-                data = {"model_bytes": msg}  # , "model_json": trees}
+                data = {"model_bytes": msg}
                 messages = context.allGather(json.dumps(data))
 
                 # concatenate the random forest in the worker0

--- a/python/src/spark_rapids_ml/umap.py
+++ b/python/src/spark_rapids_ml/umap.py
@@ -1417,8 +1417,7 @@ class UMAPModel(_CumlModelWithColumns, UMAPClass, _UMAPCumlParams):
                 )
 
             internal_model = CumlUMAP(**cuml_alg_params)
-            # need this to revert a change in cuML targeting sklearn compat.
-            internal_model.n_features_in_ = None
+            internal_model.n_features_in_ = raw_data_cuml.shape[1]
             internal_model.embedding_ = cp.array(embedding).data
             internal_model._raw_data = raw_data_cuml
             internal_model.sparse_fit = sparse_fit

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -582,68 +582,122 @@ def _create_leaf_node(sc: SparkContext, impurity: str, model: Dict[str, Any]):  
     return java_leaf_node
 
 
-def translate_trees(sc: SparkContext, impurity: str, model: Dict[str, Any]):  # type: ignore
-    """Translate Cuml RandomForest trees to PySpark trees
+def translate_tree(sc: SparkContext, impurity: str, model: Dict[str, Any]):  # type: ignore
+    """Translate Treelite JSON representation to PySpark trees
 
-    Cuml trees
-    [
-      {
-        "nodeid": 0,
-        "split_feature": 3,
-        "split_threshold": 0.827687974732221,
-        "gain": 0.41999999999999998,
-        "instance_count": 10,
-        "yes": 1,
-        "no": 2,
-        "children": [
-          {
-            "nodeid": 1,
-            "leaf_value": [
-              1,
-              0
-            ],
-            "instance_count": 7
-          },
-          {
-            "nodeid": 2,
-            "leaf_value": [
-              0,
-              1
-            ],
-            "instance_count": 3
-          }
-        ]
-      }
-    ]
+    Converts Treelite JSON format to Spark MLlib tree format.
+    
+    Args:
+        sc: SparkContext
+        impurity: Impurity type ("gini", "entropy", or "variance")
+        model: Treelite JSON model portion representing a single tree
+        
+    Returns:
+        Spark tree 
+        
+ (see https://treelite.readthedocs.io/en/latest/tutorials/builder.html#example-regressor)
+    Example TreeliteJson Tree:
+    {
+        "num_nodes": 5,
+        "has_categorical_split": false,
+        "nodes": [{
+                "node_id": 0,
+                "split_feature_id": 0,
+                "default_left": true,
+                "node_type": "numerical_test_node",
+                "comparison_op": "<",
+                "threshold": 5.0,
+                "left_child": 1,
+                "right_child": 2
+            }, {
+                "node_id": 1,
+                "split_feature_id": 2,
+                "default_left": false,
+                "node_type": "numerical_test_node",
+                "comparison_op": "<",
+                "threshold": -3.0,
+                "left_child": 3,
+                "right_child": 4
+            }, {
+                "node_id": 2,
+                "leaf_value": 0.6000000238418579
+            }, {
+                "node_id": 3,
+                "leaf_value": -0.4000000059604645
+            }, {
+                "node_id": 4,
+                "leaf_value": 1.2000000476837159
+            }]
+    }
 
-    Spark trees,
+    Spark tree,
              InternalNode {split{featureIndex=3, threshold=0.827687974732221}, gain = 0.41999999999999998}
              /         \
            left        right
            /             \
     LeafNode           LeafNode
     """
-    if "split_feature" in model:
-        left_child_id = model["yes"]
-        right_child_id = model["no"]
+    tree = model
 
-        for child in model["children"]:
-            if child["nodeid"] == left_child_id:
-                left_child = child
-            elif child["nodeid"] == right_child_id:
-                right_child = child
-            else:
-                raise ValueError("Unexpected node id")
+    root_id = 0
+    nodes = tree["nodes"]
 
-        return _create_internal_node(
-            sc,
-            impurity,
-            model,
-            translate_trees(sc, impurity, left_child),
-            translate_trees(sc, impurity, right_child),
-        )
-    elif "leaf_value" in model:
-        return _create_leaf_node(sc, impurity, model)
+    # Create a mapping from node_id to node data
+    node_map = {node["node_id"]: node for node in nodes}
+
+    # Convert the tree starting from root
+    spark_tree = _convert_treelite_node(sc, impurity, node_map, root_id)
+    # spark_trees.append(spark_tree)
+
+    return spark_tree
+
+
+def _convert_treelite_node(sc: SparkContext, impurity: str, node_map: Dict[int, Dict[str, Any]], node_id: int):  # type: ignore
+    """Convert a single Treelite node to Spark MLlib node
+
+    Args:
+        sc: SparkContext
+        impurity: Impurity type
+        node_map: Dictionary mapping node_id to node data
+        node_id: ID of the node to convert
+
+    Returns:
+        Spark MLlib node (InternalNode or LeafNode)
+    """
+    node = node_map[node_id]
+
+    # Check if this is a leaf node
+    if "leaf_value" in node:
+        # Convert leaf node
+        leaf_model = {
+            "leaf_value": (
+                node["leaf_value"]
+                if isinstance(node["leaf_value"], list)
+                else [node["leaf_value"]]
+            ),
+            "instance_count": node.get("instance_count", 1),
+        }
+        return _create_leaf_node(sc, impurity, leaf_model)
+
+    # This is an internal node
+    left_child_id = node["left_child"]
+    right_child_id = node["right_child"]
+
+    # Convert children recursively
+    left_child = _convert_treelite_node(sc, impurity, node_map, left_child_id)
+    right_child = _convert_treelite_node(sc, impurity, node_map, right_child_id)
+
+    # Create internal node model in the format expected by _create_internal_node
+    internal_model = {
+        "split_feature": node["split_feature_id"],
+        "split_threshold": node["threshold"],
+        "gain": node.get("gain", 0.0),  # Treelite doesn't always provide gain
+        "instance_count": node.get("instance_count", 1),
+        "yes": left_child_id,
+        "no": right_child_id,
+    }
+
+    return _create_internal_node(sc, impurity, internal_model, left_child, right_child)
 
 
 # to the XGBOOST _get_unwrap_udt_fn in https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/spark/core.py

--- a/python/tests/test_random_forest.py
+++ b/python/tests/test_random_forest.py
@@ -904,10 +904,8 @@ def test_fit_multiple_in_single_pass(
         def get_num_trees(
             model: Union[RandomForestClassificationModel, RandomForestRegressionModel],
         ) -> int:
-            model_jsons = cast(List[str], model._model_json)
-            trees = [
-                None for trees_json in model_jsons for trees in json.loads(trees_json)
-            ]
+            model_json = cast(str, model._model_json)
+            trees = [None for tree in json.loads(model_json)["trees"]]
             return len(trees)
 
         for i, param_map in enumerate(param_maps):

--- a/python/tests/test_umap.py
+++ b/python/tests/test_umap.py
@@ -687,8 +687,6 @@ def test_umap_build_algo(gpu_number: int, metric: str) -> None:
             metric=metric,
         ).setFeaturesCol("features")
 
-        # TODO: cuml nn_descent currently relies on the RAFT implementation (only supports L2/euclidean);
-        # once they move to cuvs, it should also support cosine
         if metric not in ["l2", "euclidean", "cosine"]:
             try:
                 umap.fit(df)


### PR DESCRIPTION
- keeps up with on-going refactoring of cuml internal apis we invoke
- conversion of random forest models to spark mllib is now via treelite json format as cuml json format was removed
- ucx-py -> ucxx required some changes (currently knn and dbscan which rely on ucxx will yield incorrect results until https://github.com/rapidsai/raft/pull/2829 is merged and pulled in through cuml).