### PR TITLE
Avoid hitting BufferHolder limit when kmeans model is larger than int_max

### DIFF
--- a/python/benchmark/test_gen_data.py
+++ b/python/benchmark/test_gen_data.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2007-2025 The scikit-learn developers. All rights reserved.
-# Modifications copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Modifications copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/benchmark/test_gen_data.py
+++ b/python/benchmark/test_gen_data.py
@@ -396,7 +396,7 @@ def _func_test_make_sparse_regression(
 
             for i in range(len(chunk_boundary)):
                 start = 0 if i == 0 else chunk_boundary[i - 1]
-                dense_count = int(np.count_nonzero(X_np[:, start : chunk_boundary[i]]))
+                dense_count = np.count_nonzero(X_np[:, start : chunk_boundary[i]])
 
                 col_density = density_values[i]
                 chunk_size = col_per_chunk[i]

--- a/python/benchmark/test_gen_data.py
+++ b/python/benchmark/test_gen_data.py
@@ -396,7 +396,7 @@ def _func_test_make_sparse_regression(
 
             for i in range(len(chunk_boundary)):
                 start = 0 if i == 0 else chunk_boundary[i - 1]
-                dense_count = np.count_nonzero(X_np[:, start : chunk_boundary[i]])
+                dense_count = int(np.count_nonzero(X_np[:, start : chunk_boundary[i]]))
 
                 col_density = density_values[i]
                 chunk_size = col_per_chunk[i]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -16,3 +16,4 @@ numpy_allocator
 psutil
 pyspark>=3.2.1,<3.5
 scikit-learn>=1.2.1
+cryptography==46.0.6

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -494,6 +494,8 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
             if len(rows) == 0:
                 raise ValueError("Expected at least one fit result row but got none")
             return [_one_model_row(rows)]
+
+        # fitMultiple case: chunking not supported, just remove chunk_id from each row.
         assert len(rows) == len(
             paramMaps
         ), f"Expected {len(paramMaps)} rows (one per param map) but got {len(rows)}"

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -405,10 +405,25 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 f"iterations: {kmeans_object.n_iter_}, inertia: {kmeans_object.inertia_}"
             )
 
+            all_centers = kmeans_object.cluster_centers_.get().tolist()
+            n_cols = params[param_alias.num_cols]
+            dtype_str = str(kmeans_object.cluster_centers_.dtype.name)
+
+            # Chunk centers so each row stays under Spark BufferHolder limit (~2^31 bytes).
+            # Use 8 bytes per element (double); overestimate for float32 is safe (smaller chunks).
+            max_bytes_per_chunk = 1024**3  # 1GB
+            bytes_per_center = n_cols * 8
+            max_centers_per_chunk = max(1, max_bytes_per_chunk // bytes_per_center)
+
+            chunk_centers = []
+            for start in range(0, len(all_centers), max_centers_per_chunk):
+                end = min(start + max_centers_per_chunk, len(all_centers))
+                chunk_centers.append(all_centers[start:end])
+
             return {
-                "cluster_centers_": [kmeans_object.cluster_centers_.get().tolist()],
-                "n_cols": params[param_alias.num_cols],
-                "dtype": str(kmeans_object.cluster_centers_.dtype.name),
+                "cluster_centers_": chunk_centers,
+                "n_cols": [n_cols] * len(chunk_centers),
+                "dtype": [dtype_str] * len(chunk_centers),
             }
 
         return _cuml_fit
@@ -426,6 +441,19 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
 
     def _create_pyspark_model(self, result: Row) -> "KMeansModel":
         return KMeansModel._from_row(result)
+
+    def _merge_model_chunks(self, rows: List[Row]) -> Row:
+        """Merge chunked fit result rows into one Row (avoids BufferHolder 2GB limit)."""
+        merged_centers: List[List[float]] = []
+        for row in rows:
+            merged_centers.extend(row["cluster_centers_"])
+        n_cols = rows[0]["n_cols"]
+        dtype = rows[0]["dtype"]
+        return Row(
+            cluster_centers_=merged_centers,
+            n_cols=n_cols,
+            dtype=dtype,
+        )
 
 
 class KMeansModel(KMeansClass, _CumlModelWithPredictionCol, _KMeansCumlParams):

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -453,7 +453,9 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
         )
 
     def _create_pyspark_model(self, result: Row) -> "KMeansModel":
-        return KMeansModel._from_row(result)
+        attr_dict = result.asDict()
+        attr_dict.pop("chunk_id", None)
+        return KMeansModel(**attr_dict)
 
     def _merge_model_chunks(self, rows: List[Row]) -> Row:
         """Merge chunked fit result rows into one Row (avoids BufferHolder 2GB limit)."""

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -453,6 +453,9 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
         )
 
     def _create_pyspark_model(self, result: Row) -> "KMeansModel":
+        """One collected row per model (``fit`` or ``fitMultiple``). Drop ``chunk_id`` when
+        present (e.g. ``fitMultiple`` does not go through ``_merge_model_chunks``).
+        """
         attr_dict = result.asDict()
         attr_dict.pop("chunk_id", None)
         return KMeansModel(**attr_dict)

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -409,6 +409,15 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
             n_cols = params[param_alias.num_cols]
             dtype_str = str(kmeans_object.cluster_centers_.dtype.name)
 
+            # fitMultiple (paramMap): do not chunk; return one row. Single model: chunk below.
+            # TODO: support chunking for fitMultiple in the future
+            if params.get(param_alias.fit_multiple_params):
+                return {
+                    "cluster_centers_": [all_centers],
+                    "n_cols": [n_cols],
+                    "dtype": [dtype_str],
+                }
+
             # Chunk centers so each row stays under Spark BufferHolder limit (~2^31 bytes).
             # Use 8 bytes per element (double); overestimate for float32 is safe (smaller chunks).
             max_bytes_per_chunk = 1024**3  # 1GB

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -15,7 +15,22 @@
 #
 
 from abc import ABCMeta
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+if TYPE_CHECKING:
+    from pyspark.ml._typing import ParamMap
 
 import numpy as np
 import pandas as pd
@@ -453,26 +468,36 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
         )
 
     def _create_pyspark_model(self, result: Row) -> "KMeansModel":
-        """One collected row per model (``fit`` or ``fitMultiple``). Drop ``chunk_id`` when
-        present (e.g. ``fitMultiple`` does not go through ``_merge_model_chunks``).
-        """
-        attr_dict = result.asDict()
-        attr_dict.pop("chunk_id", None)
-        return KMeansModel(**attr_dict)
+        return KMeansModel(**result.asDict())
 
-    def _merge_model_chunks(self, rows: List[Row]) -> Row:
-        """Merge chunked fit result rows into one Row (avoids BufferHolder 2GB limit)."""
-        sorted_rows = sorted(rows, key=lambda r: r["chunk_id"])
-        merged_centers: List[List[float]] = []
-        for row in sorted_rows:
-            merged_centers.extend(row["cluster_centers_"])
-        n_cols = sorted_rows[0]["n_cols"]
-        dtype = sorted_rows[0]["dtype"]
-        return Row(
-            cluster_centers_=merged_centers,
-            n_cols=n_cols,
-            dtype=dtype,
-        )
+    def _merge_model_chunks(
+        self,
+        rows: List[Row],
+        paramMaps: Optional[Sequence["ParamMap"]] = None,
+    ) -> List[Row]:
+        """Override ``_CumlEstimator._merge_model_chunks`` for KMeans (center chunks, drops ``chunk_id``)."""
+
+        def _one_model_row(chunk_rows: List[Row]) -> Row:
+            sorted_rows = sorted(chunk_rows, key=lambda r: r["chunk_id"])
+            merged_centers: List[List[float]] = []
+            for row in sorted_rows:
+                merged_centers.extend(row["cluster_centers_"])
+            n_cols = sorted_rows[0]["n_cols"]
+            dtype = sorted_rows[0]["dtype"]
+            return Row(
+                cluster_centers_=merged_centers,
+                n_cols=n_cols,
+                dtype=dtype,
+            )
+
+        if paramMaps is None:
+            if len(rows) == 0:
+                raise ValueError("Expected at least one fit result row but got none")
+            return [_one_model_row(rows)]
+        assert len(rows) == len(
+            paramMaps
+        ), f"Expected {len(paramMaps)} rows (one per param map) but got {len(rows)}"
+        return [_one_model_row([r]) for r in rows]
 
 
 class KMeansModel(KMeansClass, _CumlModelWithPredictionCol, _KMeansCumlParams):

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -413,6 +413,7 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
             # TODO: support chunking for fitMultiple in the future
             if params.get(param_alias.fit_multiple_params):
                 return {
+                    "chunk_id": [0],
                     "cluster_centers_": [all_centers],
                     "n_cols": [n_cols],
                     "dtype": [dtype_str],
@@ -429,10 +430,12 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
                 end = min(start + max_centers_per_chunk, len(all_centers))
                 chunk_centers.append(all_centers[start:end])
 
+            n_chunks = len(chunk_centers)
             return {
+                "chunk_id": list(range(n_chunks)),
                 "cluster_centers_": chunk_centers,
-                "n_cols": [n_cols] * len(chunk_centers),
-                "dtype": [dtype_str] * len(chunk_centers),
+                "n_cols": [n_cols] * n_chunks,
+                "dtype": [dtype_str] * n_chunks,
             }
 
         return _cuml_fit
@@ -440,6 +443,7 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
     def _out_schema(self) -> Union[StructType, str]:
         return StructType(
             [
+                StructField("chunk_id", IntegerType(), False),
                 StructField(
                     "cluster_centers_", ArrayType(ArrayType(DoubleType()), False), False
                 ),
@@ -453,11 +457,12 @@ class KMeans(KMeansClass, _CumlEstimator, _KMeansCumlParams):
 
     def _merge_model_chunks(self, rows: List[Row]) -> Row:
         """Merge chunked fit result rows into one Row (avoids BufferHolder 2GB limit)."""
+        sorted_rows = sorted(rows, key=lambda r: r["chunk_id"])
         merged_centers: List[List[float]] = []
-        for row in rows:
+        for row in sorted_rows:
             merged_centers.extend(row["cluster_centers_"])
-        n_cols = rows[0]["n_cols"]
-        dtype = rows[0]["dtype"]
+        n_cols = sorted_rows[0]["n_cols"]
+        dtype = sorted_rows[0]["dtype"]
         return Row(
             cluster_centers_=merged_centers,
             n_cols=n_cols,

--- a/python/src/spark_rapids_ml/clustering.py
+++ b/python/src/spark_rapids_ml/clustering.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1088,25 +1088,38 @@ class _CumlEstimator(Estimator, _CumlCaller):
         """
         raise NotImplementedError()
 
-    def _merge_model_chunks(self, rows: List[Row]) -> Row:
-        """Merge chunk rows after a single-model ``fit`` (not used for ``fitMultiple``).
+    def _merge_model_chunks(
+        self,
+        rows: List[Row],
+        paramMaps: Optional[Sequence["ParamMap"]] = None,
+    ) -> List[Row]:
+        """Normalize collected fit rows before building models.
 
-        Spark limits serialized row payload size (roughly the ~2GB BufferHolder cap). If a
-        trained model would exceed that, an estimator must shard it so each chunk is
-        collected as its own Row, then override this method to stitch those Rows back
-        into one logical model Row.
+        Single ``fit`` (``paramMaps is None``): default returns one collected Row unchanged,
+        or raises ``NotImplementedError`` if multiple Rows are present—there is no base
+        implementation for merging sharded model chunks across Rows.
 
-        If there is only one Row, it is returned unchanged. If there are several and this
-        method is not overridden, ``NotImplementedError`` is raised.
+        ``fitMultiple`` (``paramMaps`` set): one Row per param map; default returns them
+        unchanged;
+
+        Very large models can exceed Spark's per-row serialization limit (~2GB BufferHolder)
+        even as ``one Row per model``; estimators that shard a fit result across multiple
+        Rows must override this method to merge chunks. The same limit applies in principle
+        to each ``fitMultiple`` model Row.
         """
-        n = len(rows)
-        if n == 0:
-            raise ValueError("Expected at least one fit result row but got none")
-        if n == 1:
-            return rows[0]
-        raise NotImplementedError(
-            "Merging multiple fit result rows is not implemented for this estimator"
-        )
+        if paramMaps is None:
+            n = len(rows)
+            if n == 0:
+                raise ValueError("Expected at least one fit result row but got none")
+            if n == 1:
+                return [rows[0]]
+            raise NotImplementedError(
+                "Merging multiple fit result rows is not implemented for this estimator"
+            )
+        assert len(rows) == len(
+            paramMaps
+        ), f"Expected {len(paramMaps)} rows (one per param map) but got {len(rows)}"
+        return list(rows)
 
     def _handle_param_spark_confs(self) -> None:
         """
@@ -1245,14 +1258,7 @@ class _CumlEstimator(Estimator, _CumlCaller):
 
         self.logger.info("Finished training")
 
-        if paramMaps is None:
-            # single model
-            rows = [self._merge_model_chunks(rows)]
-        else:
-            # multiple models
-            assert len(rows) == len(
-                paramMaps
-            ), f"Expected {len(paramMaps)} rows (one per param map) but got {len(rows)}"
+        rows = self._merge_model_chunks(rows, paramMaps)
 
         models: List["_CumlModel"] = [None]  # type: ignore
         if paramMaps is not None:

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1225,6 +1225,10 @@ class _CumlEstimator(Estimator, _CumlCaller):
 
         self.logger.info("Finished training")
 
+        # Merge chunked fit result rows (e.g. KMeans large model) into one row per model
+        if paramMaps is None and len(rows) > 1 and hasattr(self, "_merge_model_chunks"):
+            rows = [self._merge_model_chunks(rows)]
+
         models: List["_CumlModel"] = [None]  # type: ignore
         if paramMaps is not None:
             models = [None] * len(paramMaps)  # type: ignore

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1231,6 +1231,10 @@ class _CumlEstimator(Estimator, _CumlCaller):
                 rows = [self._merge_model_chunks(rows)]
         elif paramMaps is None:
             assert len(rows) <= 1, f"Expected at most 1 row but got {len(rows)}"
+        else:
+            assert len(rows) == len(
+                paramMaps
+            ), f"Expected {len(paramMaps)} rows (one per param map) but got {len(rows)}"
 
         models: List["_CumlModel"] = [None]  # type: ignore
         if paramMaps is not None:

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1225,9 +1225,12 @@ class _CumlEstimator(Estimator, _CumlCaller):
 
         self.logger.info("Finished training")
 
-        # Merge chunked fit result rows (e.g. KMeans large model) into one row per model
-        if paramMaps is None and len(rows) > 1 and hasattr(self, "_merge_model_chunks"):
-            rows = [self._merge_model_chunks(rows)]
+        # Merge chunked fit result rows (e.g. KMeans large model) into one row per model.
+        if paramMaps is None and hasattr(self, "_merge_model_chunks"):
+            if len(rows) > 1:
+                rows = [self._merge_model_chunks(rows)]
+        elif paramMaps is None:
+            assert len(rows) <= 1, f"Expected at most 1 row but got {len(rows)}"
 
         models: List["_CumlModel"] = [None]  # type: ignore
         if paramMaps is not None:

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1088,6 +1088,26 @@ class _CumlEstimator(Estimator, _CumlCaller):
         """
         raise NotImplementedError()
 
+    def _merge_model_chunks(self, rows: List[Row]) -> Row:
+        """Merge chunk rows after a single-model ``fit`` (not used for ``fitMultiple``).
+
+        Spark limits serialized row payload size (roughly the ~2GB BufferHolder cap). If a
+        trained model would exceed that, an estimator must shard it so each chunk is
+        collected as its own Row, then override this method to stitch those Rows back
+        into one logical model Row.
+
+        If there is only one Row, it is returned unchanged. If there are several and this
+        method is not overridden, ``NotImplementedError`` is raised.
+        """
+        n = len(rows)
+        if n == 0:
+            raise ValueError("Expected at least one fit result row but got none")
+        if n == 1:
+            return rows[0]
+        raise NotImplementedError(
+            "Merging multiple fit result rows is not implemented for this estimator"
+        )
+
     def _handle_param_spark_confs(self) -> None:
         """
         Some parameters can be set globally in spark confs if they are not set in the constructor.
@@ -1225,13 +1245,11 @@ class _CumlEstimator(Estimator, _CumlCaller):
 
         self.logger.info("Finished training")
 
-        # Merge chunked fit result rows (e.g. KMeans large model) into one row per model.
-        if paramMaps is None and hasattr(self, "_merge_model_chunks"):
-            if len(rows) > 1:
-                rows = [self._merge_model_chunks(rows)]
-        elif paramMaps is None:
-            assert len(rows) <= 1, f"Expected at most 1 row but got {len(rows)}"
+        if paramMaps is None:
+            # single model
+            rows = [self._merge_model_chunks(rows)]
         else:
+            # multiple models
             assert len(rows) == len(
                 paramMaps
             ), f"Expected {len(paramMaps)} rows (one per param map) but got {len(rows)}"

--- a/python/src/spark_rapids_ml/core.py
+++ b/python/src/spark_rapids_ml/core.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -214,16 +214,16 @@ def _configure_memory_resource(
         ):
             _old_memory_resources.append(rmm.mr.get_current_device_resource())
             _last_sam_headroom_size = None
-            sys_mr = rmm.mr.SystemMemoryResource()
-            rmm.mr.set_current_device_resource(sys_mr)
+            mr = rmm.mr.SystemMemoryResource()
+            rmm.mr.set_current_device_resource(mr)
     elif sam_enabled and sam_headroom is not None:
         if sam_headroom != _last_sam_headroom_size or not type(
             rmm.mr.get_current_device_resource()
         ) == type(rmm.mr.SamHeadroomMemoryResource(headroom=sam_headroom)):
             _old_memory_resources.append(rmm.mr.get_current_device_resource())
             _last_sam_headroom_size = sam_headroom
-            sam_mr = rmm.mr.SamHeadroomMemoryResource(headroom=sam_headroom)
-            rmm.mr.set_current_device_resource(sam_mr)
+            mr = rmm.mr.SamHeadroomMemoryResource(headroom=sam_headroom)
+            rmm.mr.set_current_device_resource(mr)
 
     if uvm_enabled:
         if not type(rmm.mr.get_current_device_resource()) == type(

--- a/python/src/spark_rapids_ml/utils.py
+++ b/python/src/spark_rapids_ml/utils.py
@@ -214,16 +214,16 @@ def _configure_memory_resource(
         ):
             _old_memory_resources.append(rmm.mr.get_current_device_resource())
             _last_sam_headroom_size = None
-            mr = rmm.mr.SystemMemoryResource()
-            rmm.mr.set_current_device_resource(mr)
+            sys_mr = rmm.mr.SystemMemoryResource()
+            rmm.mr.set_current_device_resource(sys_mr)
     elif sam_enabled and sam_headroom is not None:
         if sam_headroom != _last_sam_headroom_size or not type(
             rmm.mr.get_current_device_resource()
         ) == type(rmm.mr.SamHeadroomMemoryResource(headroom=sam_headroom)):
             _old_memory_resources.append(rmm.mr.get_current_device_resource())
             _last_sam_headroom_size = sam_headroom
-            mr = rmm.mr.SamHeadroomMemoryResource(headroom=sam_headroom)
-            rmm.mr.set_current_device_resource(mr)
+            sam_mr = rmm.mr.SamHeadroomMemoryResource(headroom=sam_headroom)
+            rmm.mr.set_current_device_resource(sam_mr)
 
     if uvm_enabled:
         if not type(rmm.mr.get_current_device_resource()) == type(

--- a/python/tests_large/conftest.py
+++ b/python/tests_large/conftest.py
@@ -26,6 +26,7 @@ _default_conf = {
     "spark.driver.host": "127.0.0.1",
     "spark.task.maxFailures": "1",
     "spark.driver.memory": "128g",
+    "spark.driver.maxResultSize": "0",  # allow large model collect (e.g. KMeans 100k centers)
     "spark.sql.execution.pyspark.udf.simplifiedTraceback.enabled": "false",
     "spark.sql.pyspark.jvmStacktrace.enabled": "true",
     "spark.sql.execution.arrow.pyspark.enabled": "true",

--- a/python/tests_large/conftest.py
+++ b/python/tests_large/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/tests_large/test_large_kmeans.py
+++ b/python/tests_large/test_large_kmeans.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import pytest
 from gen_data_distributed import BlobsDataGen
 
 from spark_rapids_ml.clustering import KMeans

--- a/python/tests_large/test_large_kmeans.py
+++ b/python/tests_large/test_large_kmeans.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/tests_large/test_large_kmeans.py
+++ b/python/tests_large/test_large_kmeans.py
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from gen_data_distributed import BlobsDataGen
+
+from spark_rapids_ml.clustering import KMeans
+
+from .conftest import _spark
+
+
+def test_kmeans_large_model_exceeds_int32_max() -> None:
+    """
+    Test KMeans with 100,000 centers and 4,000 dimensions per center.
+    The resulting model size = 100,000 * 4,000 * 8 bytes (DoubleType) = 3.2GB,
+    which exceeds Spark's default driver maxResultSize (2GB), as well as the BufferHolder
+    size limit of 2,147,483,632 bytes. To collect this large model to the driver,
+    spark.driver.maxResultSize must be set to 0 (unlimited), and Spark payload buffer sizes
+    must be sufficient to handle the large model.
+    """
+    gpu_number = 1
+    n_centers = 100_000
+    n_dimensions = 4_000
+    n_samples = 120_000  # need more samples than centers for k-means
+    output_num_files = 12  # partitions for distributed data gen
+
+    data_gen_args = [
+        "--num_rows",
+        str(n_samples),
+        "--num_cols",
+        str(n_dimensions),
+        "--centers",
+        "10",
+        "--output_num_files",
+        str(output_num_files),
+        "--dtype",
+        "float32",
+        "--output_dir",
+        "./temp",
+        "--random_state",
+        "42",
+    ]
+    data_gen = BlobsDataGen(data_gen_args)
+    df, feature_cols, _ = data_gen.gen_dataframe_and_meta(_spark)
+
+    kmeans = KMeans(
+        num_workers=gpu_number,
+        k=n_centers,
+        max_iter=2,
+        initMode="random",
+        seed=42,
+    ).setFeaturesCols(feature_cols)
+
+    kmeans_model = kmeans.fit(df)
+
+    # Verify model shape: 100k centers, each 4k dimensions
+    assert len(kmeans_model.cluster_centers_) == n_centers
+    assert len(kmeans_model.cluster_centers_[0]) == n_dimensions
+    assert kmeans_model.n_cols == n_dimensions
+
+    # Model size in bytes (DoubleType on driver)
+    model_size_bytes = n_centers * n_dimensions * 8  # 3.2GB for 100k * 4k
+    assert model_size_bytes > 2 * (1024**3)  # exceeds 2GB

--- a/python/tests_large/test_large_kmeans.py
+++ b/python/tests_large/test_large_kmeans.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+import cudf
+import numpy as np
+from cuml.cluster import KMeans as CumlKMeans
 from gen_data_distributed import BlobsDataGen
 
 from spark_rapids_ml.clustering import KMeans
@@ -54,6 +57,7 @@ def test_kmeans_large_model_exceeds_int32_max() -> None:
     ]
     data_gen = BlobsDataGen(data_gen_args)
     df, feature_cols, _ = data_gen.gen_dataframe_and_meta(_spark)
+    df = df.cache()
 
     kmeans = KMeans(
         num_workers=gpu_number,
@@ -65,11 +69,14 @@ def test_kmeans_large_model_exceeds_int32_max() -> None:
 
     kmeans_model = kmeans.fit(df)
 
-    # Verify model shape: 100k centers, each 4k dimensions
+    # Verify model shape
     assert len(kmeans_model.cluster_centers_) == n_centers
     assert len(kmeans_model.cluster_centers_[0]) == n_dimensions
     assert kmeans_model.n_cols == n_dimensions
 
-    # Model size in bytes (DoubleType on driver)
-    model_size_bytes = n_centers * n_dimensions * 8  # 3.2GB for 100k * 4k
-    assert model_size_bytes > 2 * (1024**3)  # exceeds 2GB
+    # Transform
+    pred_col = kmeans_model.getPredictionCol()
+    predictions = kmeans_model.transform(df)
+    assert predictions.count() == n_samples
+    pred_max = predictions.agg({pred_col: "max"}).head()[0]
+    assert pred_max < n_centers


### PR DESCRIPTION
error message when kmeans model > 2G:

java.lang.IllegalArgumentException: Cannot grow BufferHolder by size 33288 because the size after growing exceeds size limitation 2147483632 
