### PR TITLE
Update databricks 17.3 [skip ci]

### DIFF
--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -26,7 +26,7 @@ If you already have a Databricks account, you can run the example notebooks on a
       spark.task.resource.gpu.amount 0.125
       spark.databricks.delta.preview.enabled true
       spark.python.worker.reuse true
-      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.13-25.12.0.jar:/databricks/spark/python
+      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.13-26.4.2.jar:/databricks/spark/python
       spark.sql.execution.arrow.maxRecordsPerBatch 100000
       spark.plugins com.nvidia.spark.SQLPlugin
       spark.locality.wait 0s

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -26,7 +26,7 @@ If you already have a Databricks account, you can run the example notebooks on a
       spark.task.resource.gpu.amount 0.125
       spark.databricks.delta.preview.enabled true
       spark.python.worker.reuse true
-      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.13-26.04.2.jar:/databricks/spark/python
+      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.13-25.12.0.jar:/databricks/spark/python
       spark.sql.execution.arrow.maxRecordsPerBatch 100000
       spark.plugins com.nvidia.spark.SQLPlugin
       spark.locality.wait 0s

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -14,7 +14,6 @@ If you already have a Databricks account, you can run the example notebooks on a
   databricks workspace import --format AUTO --file init-pip-cuda-12.sh ${WS_SAVE_DIR}/init-pip-cuda-12.sh --profile ${PROFILE}
   ```
   **Note**: the init script does the following on each Spark node:
-  - updates the CUDA runtime (required for Spark Rapids ML dependencies).
   - downloads and installs the [Spark-Rapids](https://github.com/NVIDIA/spark-rapids) plugin for accelerating data loading and Spark SQL.
   - installs various `cuXX` dependencies via pip.
   - if the cluster environment variable `SPARK_RAPIDS_ML_NO_IMPORT_ENABLED=1` is define (see below), the init script also modifies a Databricks notebook kernel startup script to enable no-import change UX for the cluster.  See [no-import-change](../README.md#no-import-change).

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -18,7 +18,7 @@ If you already have a Databricks account, you can run the example notebooks on a
   - downloads and installs the [Spark-Rapids](https://github.com/NVIDIA/spark-rapids) plugin for accelerating data loading and Spark SQL.
   - installs various `cuXX` dependencies via pip.
   - if the cluster environment variable `SPARK_RAPIDS_ML_NO_IMPORT_ENABLED=1` is define (see below), the init script also modifies a Databricks notebook kernel startup script to enable no-import change UX for the cluster.  See [no-import-change](../README.md#no-import-change).
-- Create a cluster using **Databricks 13.3 LTS ML GPU Runtime** using at least two single-gpu workers and add the following configurations to the **Advanced options**.
+- Create a cluster using **Databricks 17.3 LTS ML GPU Runtime** using at least two single-gpu workers and add the following configurations to the **Advanced options**.
   - **Init Scripts**
     - add the workspace path to the uploaded init script `${WS_SAVE_DIR}/init-pip-cuda-12.sh` as set above (but substitute variables manually in the form).
   - **Spark**
@@ -27,7 +27,7 @@ If you already have a Databricks account, you can run the example notebooks on a
       spark.task.resource.gpu.amount 0.125
       spark.databricks.delta.preview.enabled true
       spark.python.worker.reuse true
-      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-25.12.0.jar:/databricks/spark/python
+      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.13-26.04.2.jar:/databricks/spark/python
       spark.sql.execution.arrow.maxRecordsPerBatch 100000
       spark.plugins com.nvidia.spark.SQLPlugin
       spark.locality.wait 0s

--- a/notebooks/databricks/README.md
+++ b/notebooks/databricks/README.md
@@ -26,7 +26,7 @@ If you already have a Databricks account, you can run the example notebooks on a
       spark.task.resource.gpu.amount 0.125
       spark.databricks.delta.preview.enabled true
       spark.python.worker.reuse true
-      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.13-26.4.2.jar:/databricks/spark/python
+      spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.13-26.04.2.jar:/databricks/spark/python
       spark.sql.execution.arrow.maxRecordsPerBatch 100000
       spark.plugins com.nvidia.spark.SQLPlugin
       spark.locality.wait 0s

--- a/notebooks/databricks/init-pip-cuda-12.sh
+++ b/notebooks/databricks/init-pip-cuda-12.sh
@@ -21,8 +21,8 @@ set -ex
 # 
 # Note also that sometimes the jar and python packages will have different patch versions published and available at any time,
 # so the versions may not perfectly align. This is expected and should not cause issues.
-RAPIDS_VERSION=25.12.0
-SPARK_RAPIDS_VERSION=25.12.0
+RAPIDS_VERSION=26.4.0
+SPARK_RAPIDS_VERSION=26.04.2
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}-cuda12.jar -o /databricks/jars/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}.jar
 

--- a/notebooks/databricks/init-pip-cuda-12.sh
+++ b/notebooks/databricks/init-pip-cuda-12.sh
@@ -19,9 +19,10 @@ set -ex
 # also in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 26.4.0 and not 26.04.0)
 # while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 26.04.2 and not 26.4.2)
 # 
-# Note also that sometimes the jar and python packages will have different patch versions published and available at any time,
-# so the versions may not perfectly align. This is expected and should not cause issues.
-RAPIDS_VERSION=26.4.0
+# Note that the SPARK_RAPIDS_VERSION will not necessarily match the RAPIDS_VERSION. Check https://nvidia.github.io/spark-rapids/docs/download.html for the latest compatible version of 
+# spark-rapids version that verifies compatibility with your Databricks Runtime. (In this case, Databricks 17.3 ML LTS.) The available versions for RAPIDS_VERSION can be
+# found by executing "pip index versions spark-rapids-ml".   
+RAPIDS_VERSION=25.12.0
 SPARK_RAPIDS_VERSION=26.04.2
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}-cuda12.jar -o /databricks/jars/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}.jar

--- a/notebooks/databricks/init-pip-cuda-12.sh
+++ b/notebooks/databricks/init-pip-cuda-12.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ set -ex
 # 
 # Note also that sometimes the jar and python packages will have different patch versions published and available at any time,
 # so the versions may not perfectly align. This is expected and should not cause issues.
-RAPIDS_VERSION=26.4.0
-SPARK_RAPIDS_VERSION=26.04.2
+RAPIDS_VERSION=25.12.0
+SPARK_RAPIDS_VERSION=25.12.0
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}-cuda12.jar -o /databricks/jars/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}.jar
 

--- a/notebooks/databricks/init-pip-cuda-12.sh
+++ b/notebooks/databricks/init-pip-cuda-12.sh
@@ -15,13 +15,16 @@
 
 set -ex
 
-# IMPORTANT: specify RAPIDS_VERSION fully 23.10.0 and not 23.10
-# also in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 23.8.0 and not 23.08.0)
-# while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 23.08.2 and not 23.8.2)
-RAPIDS_VERSION=25.12.0
-SPARK_RAPIDS_VERSION=25.12.0
+# IMPORTANT: specify RAPIDS_VERSION fully 26.4.0 and not 26.4
+# also in general, RAPIDS_VERSION (python) fields should omit any leading 0 in month/minor field (i.e. 26.4.0 and not 26.04.0)
+# while SPARK_RAPIDS_VERSION (jar) should have leading 0 in month/minor (e.g. 26.04.2 and not 26.4.2)
+# 
+# Note also that sometimes the jar and python packages will have different patch versions published and available at any time,
+# so the versions may not perfectly align. This is expected and should not cause issues.
+RAPIDS_VERSION=26.4.0
+SPARK_RAPIDS_VERSION=26.04.2
 
-curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}-cuda12.jar -o /databricks/jars/rapids-4-spark_2.12-${SPARK_RAPIDS_VERSION}.jar
+curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}-cuda12.jar -o /databricks/jars/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}.jar
 
 # install cudatoolkit 12.2 via runfile approach
 wget https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run

--- a/notebooks/databricks/init-pip-cuda-12.sh
+++ b/notebooks/databricks/init-pip-cuda-12.sh
@@ -26,14 +26,6 @@ SPARK_RAPIDS_VERSION=26.04.2
 
 curl -L https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.13/${SPARK_RAPIDS_VERSION}/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}-cuda12.jar -o /databricks/jars/rapids-4-spark_2.13-${SPARK_RAPIDS_VERSION}.jar
 
-# install cudatoolkit 12.2 via runfile approach
-wget https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
-sh cuda_12.2.2_535.104.05_linux.run --silent --toolkit
-
-# reset symlink and update library loading paths
-rm /usr/local/cuda
-ln -s /usr/local/cuda-12.2 /usr/local/cuda
-
 # upgrade pip
 /databricks/python/bin/pip install --upgrade pip
 


### PR DESCRIPTION
Databricks just sent an automated email this morning warning me that my cluster that uses Spark Rapids ML was using a Databricks LTS runtime (13.3 LTS ML) that would go end-of-life this August. That means, in a few months, new users will not be able to follow these instructions.

Rectifying this was relatively straightforward in terms of getting the new Spark 4 and Scala 2.13 dependencies sussed out and updating to the newest 26.04.2 build.

Also note that the manual CUDA installation is no longer necessary and would in fact create a regression. For simplicity, that was removed.